### PR TITLE
Added  vetoable event to all available tools

### DIFF
--- a/.claude/hooks/fetch-issue-context.sh
+++ b/.claude/hooks/fetch-issue-context.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Claude Code hook: user-prompt-submit
+# Detects #NNN patterns in user prompt, fetches GitHub issue context via gh CLI.
+# Outputs structured issue context to stdout (injected into conversation).
+
+set -euo pipefail
+
+# Read prompt from stdin JSON (Claude Code hook contract)
+PROMPT=$(jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
+
+# Extract all #NNN references (deduplicated)
+ISSUES=$(echo "$PROMPT" | grep -oE '#[0-9]+' | sort -u | sed 's/#//') || true
+
+if [ -z "$ISSUES" ]; then
+  exit 0
+fi
+
+# Auto-detect repo
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+  echo "⚠ Could not detect GitHub repo. Ensure gh CLI is authenticated." >&2
+  exit 0
+}
+
+for ISSUE_NUM in $ISSUES; do
+  # Fetch issue details
+  ISSUE_JSON=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json \
+    number,title,state,body,labels,milestone,assignees,comments,projectItems,closedAt,createdAt,updatedAt \
+    2>/dev/null) || {
+    echo "⚠ Could not fetch issue #${ISSUE_NUM}" >&2
+    continue
+  }
+
+  # Fetch linked PRs
+  LINKED_PRS=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/timeline" \
+    --jq '[.[] | select(.event == "cross-referenced" and .source.issue.pull_request != null) | {number: .source.issue.number, title: .source.issue.title, state: .source.issue.state, url: .source.issue.html_url}] | unique_by(.number)' \
+    2>/dev/null) || LINKED_PRS="[]"
+
+  # Format output
+  TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+  STATE=$(echo "$ISSUE_JSON" | jq -r '.state')
+  BODY=$(echo "$ISSUE_JSON" | jq -r '.body // "No description"')
+  LABELS=$(echo "$ISSUE_JSON" | jq -r '[.labels[].name] | join(", ") // "none"')
+  MILESTONE=$(echo "$ISSUE_JSON" | jq -r '.milestone.title // "none"')
+  ASSIGNEES=$(echo "$ISSUE_JSON" | jq -r '[.assignees[].login] | join(", ") // "unassigned"')
+  CREATED=$(echo "$ISSUE_JSON" | jq -r '.createdAt')
+  UPDATED=$(echo "$ISSUE_JSON" | jq -r '.updatedAt')
+  PROJECT_STATUS=$(echo "$ISSUE_JSON" | jq -r '[.projectItems[]? | "\(.project.title): \(.status.name // "no status")"] | join(", ") // "none"')
+
+  cat <<EOF
+--- GitHub Issue #${ISSUE_NUM} ---
+Title: ${TITLE}
+State: ${STATE}
+Labels: ${LABELS}
+Milestone: ${MILESTONE}
+Assignees: ${ASSIGNEES}
+Project: ${PROJECT_STATUS}
+Created: ${CREATED}
+Updated: ${UPDATED}
+
+## Description
+${BODY}
+
+EOF
+
+  # Comments
+  COMMENT_COUNT=$(echo "$ISSUE_JSON" | jq '.comments | length')
+  if [ "$COMMENT_COUNT" -gt 0 ]; then
+    echo "## Comments (${COMMENT_COUNT})"
+    echo "$ISSUE_JSON" | jq -r '.comments[] | "### \(.author.login) (\(.createdAt))\n\(.body)\n"'
+  fi
+
+  # Linked PRs
+  PR_COUNT=$(echo "$LINKED_PRS" | jq 'length')
+  if [ "$PR_COUNT" -gt 0 ]; then
+    echo "## Linked PRs"
+    echo "$LINKED_PRS" | jq -r '.[] | "- #\(.number) \(.title) [\(.state)] \(.url)"'
+    echo ""
+  fi
+
+  echo "--- End Issue #${ISSUE_NUM} ---"
+  echo ""
+done

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/fetch-issue-context.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Quality, safety, and operational gates. Standard plugins subscribing to `before:
 
 Gates use `EmitVetoable()` which wraps payloads in `VetoablePayload{Original, Veto}`. Handlers inspect `Original` (e.g. `*events.LLMRequest`), set `Veto` to block. Priority ordering: gates at 10, agents at 50 — gates always evaluate first.
 
-Hook points: `before:llm.request` (input-side), `before:io.output` (output-side), `before:tool.invoke`, `before:skill.activate`.
+Hook points: `before:llm.request` (input-side), `before:io.output` (output-side), `before:tool.invoke`, `before:tool.result`, `before:skill.activate`.
 
 Resume mechanism: Gates that veto `before:llm.request` temporarily (rate limiter, context window) emit `gate.llm.retry` when the condition clears. All agent plugins (react, planexec, orchestrator) subscribe to this event and re-invoke `sendLLMRequest()` if they have an active turn — no user re-submission needed.
 

--- a/docs/src/architecture/overview.md
+++ b/docs/src/architecture/overview.md
@@ -71,7 +71,8 @@ User types message
         → Agent emits "before:tool.invoke" (vetoable)
         → Agent emits "tool.invoke"
         → nexus.tool.shell receives "tool.invoke"
-        → Tool executes, emits "tool.result"
+        → Tool executes, emits "before:tool.result" (vetoable)
+        → Tool emits "tool.result"
         → Agent receives result, loops back to LLM
     → If no tool calls:
         → Agent emits "io.output"

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -212,6 +212,7 @@ Complete reference for all event types in Nexus, organized by domain.
 | `tool.register` | `ToolDef` | Tool available for use |
 | `before:tool.invoke` | `ToolCall` | Before tool execution (vetoable) |
 | `tool.invoke` | `ToolCall` | Tool invocation |
+| `before:tool.result` | `ToolResult` | Before tool result propagation (vetoable) |
 | `tool.result` | `ToolResult` | Tool execution result |
 
 ### Payloads

--- a/docs/src/plugins/agents/orchestrator.md
+++ b/docs/src/plugins/agents/orchestrator.md
@@ -46,6 +46,7 @@ The orchestrator implements a manager-worker pattern. It uses an LLM to decompos
 |-------|------|
 | `llm.request` | Decomposition and synthesis LLM calls |
 | `before:tool.invoke` / `tool.invoke` | Tool invocation |
+| `before:tool.result` | Before tool result propagation (vetoable) |
 | `thinking.step` | Decomposition and synthesis reasoning |
 | `io.status` | Phase transitions |
 | `agent.turn.start` / `agent.turn.end` | Turn boundaries |

--- a/docs/src/plugins/agents/planexec.md
+++ b/docs/src/plugins/agents/planexec.md
@@ -69,6 +69,7 @@ to `never`.
 | `plan.approval.request` | When planexec's own `approval: always` is set |
 | `llm.request` | Step execution and final synthesis |
 | `before:tool.invoke` / `tool.invoke` | Tool invocation |
+| `before:tool.result` | Before tool result propagation (vetoable) |
 | `agent.plan` | After each step status change |
 | `io.status` | Phase transitions |
 | `thinking.step` | Reasoning steps |

--- a/docs/src/plugins/agents/react.md
+++ b/docs/src/plugins/agents/react.md
@@ -44,6 +44,7 @@ The ReAct (Reason + Act) agent is the default and most commonly used agent strat
 | `llm.request` | Sending a message to the LLM |
 | `before:tool.invoke` | Before executing a tool (vetoable — enables approval) |
 | `tool.invoke` | Invoking a tool |
+| `before:tool.result` | Before tool result propagation (vetoable) |
 | `tool.result` | Synthetic tool results (e.g., for vetoed tools) |
 | `before:io.output` | Before sending output (vetoable) |
 | `io.output` | Final agent response to the user |
@@ -61,6 +62,7 @@ The ReAct (Reason + Act) agent is the default and most commonly used agent strat
 4. If tool calls exist:
    - Agent emits `before:tool.invoke` (can be vetoed for approval)
    - Agent emits `tool.invoke` for each tool call
+   - Tool plugin emits `before:tool.result` (vetoable — gates can inspect/block)
    - Waits for `tool.result` events
    - Loops back to step 2 with tool results appended
 5. If no tool calls, the LLM's response is the final answer → `io.output`

--- a/docs/src/plugins/tools/index.md
+++ b/docs/src/plugins/tools/index.md
@@ -18,8 +18,9 @@ Tool plugins give the agent capabilities to interact with the outside world. Eac
 2. The agent collects registered tools and includes them in `llm.request`
 3. When the LLM responds with a tool call, the agent emits `before:tool.invoke` (vetoable for approval)
 4. If not vetoed, the agent emits `tool.invoke`
-5. The tool plugin handles the invocation and emits `tool.result`
-6. The agent feeds the result back to the LLM
+5. The tool plugin handles the invocation and emits `before:tool.result` (vetoable — gates can inspect/block results)
+6. If not vetoed, the tool plugin emits `tool.result`
+7. The agent feeds the result back to the LLM
 
 ## Tool Registration Event
 

--- a/plugins/agents/planexec/plugin.go
+++ b/plugins/agents/planexec/plugin.go
@@ -204,6 +204,7 @@ func (p *Plugin) Emissions() []string {
 		"before:llm.request",
 		"before:tool.invoke",
 		"tool.invoke",
+		"before:tool.result",
 		"tool.result",
 		"before:io.output",
 		"io.output",
@@ -696,12 +697,17 @@ func (p *Plugin) handleExecutorResponse(resp events.LLMResponse) {
 
 			if veto, err := p.bus.EmitVetoable("before:tool.invoke", &toolCall); err == nil && veto.Vetoed {
 				p.logger.Info("tool.invoke vetoed", "tool", tc.Name, "reason", veto.Reason)
-				_ = p.bus.Emit("tool.result", events.ToolResult{
+				syntheticResult := events.ToolResult{
 					ID:     tc.ID,
 					Name:   tc.Name,
 					Error:  fmt.Sprintf("Tool call vetoed: %s", veto.Reason),
 					TurnID: turnID,
-				})
+				}
+				if rv, rvErr := p.bus.EmitVetoable("before:tool.result", &syntheticResult); rvErr == nil && rv.Vetoed {
+					p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", rv.Reason)
+					continue
+				}
+				_ = p.bus.Emit("tool.result", syntheticResult)
 				continue
 			}
 

--- a/plugins/agents/react/plugin.go
+++ b/plugins/agents/react/plugin.go
@@ -141,6 +141,7 @@ func (p *Plugin) Emissions() []string {
 		"before:llm.request",
 		"before:tool.invoke",
 		"tool.invoke",
+		"before:tool.result",
 		"tool.result",
 		"before:io.output",
 		"io.output",
@@ -477,12 +478,17 @@ func (p *Plugin) handleLLMResponse(resp events.LLMResponse) {
 			if veto, err := p.bus.EmitVetoable("before:tool.invoke", &toolCall); err == nil && veto.Vetoed {
 				p.logger.Info("tool.invoke vetoed", "tool", tc.Name, "reason", veto.Reason)
 				// Emit a synthetic tool result so the agent loop can continue.
-				_ = p.bus.Emit("tool.result", events.ToolResult{
+				syntheticResult := events.ToolResult{
 					ID:     tc.ID,
 					Name:   tc.Name,
 					Error:  fmt.Sprintf("Tool call vetoed: %s", veto.Reason),
 					TurnID: turnID,
-				})
+				}
+				if rv, rvErr := p.bus.EmitVetoable("before:tool.result", &syntheticResult); rvErr == nil && rv.Vetoed {
+					p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", rv.Reason)
+					continue
+				}
+				_ = p.bus.Emit("tool.result", syntheticResult)
 				continue
 			}
 

--- a/plugins/agents/subagent/plugin.go
+++ b/plugins/agents/subagent/plugin.go
@@ -145,6 +145,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 func (p *Plugin) Emissions() []string {
 	return []string{
 		"tool.register",
+		"before:tool.result",
 		"tool.result",
 		"llm.request",
 		"before:llm.request",
@@ -174,12 +175,17 @@ func (p *Plugin) handleToolInvoke(event engine.Event[any]) {
 
 	task, _ := tc.Arguments["task"].(string)
 	if task == "" {
-		_ = p.bus.Emit("tool.result", events.ToolResult{
+		errResult := events.ToolResult{
 			ID:     tc.ID,
 			Name:   tc.Name,
 			Error:  "task is required",
 			TurnID: tc.TurnID,
-		})
+		}
+		if veto, vErr := p.bus.EmitVetoable("before:tool.result", &errResult); vErr == nil && veto.Vetoed {
+			p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+			return
+		}
+		_ = p.bus.Emit("tool.result", errResult)
 		return
 	}
 
@@ -187,15 +193,20 @@ func (p *Plugin) handleToolInvoke(event engine.Event[any]) {
 	modelRole, _ := tc.Arguments["model_role"].(string)
 
 	spawnID := generateSpawnID()
-	result := p.runSubagent(spawnID, task, systemPrompt, modelRole, tc.TurnID)
+	subResult := p.runSubagent(spawnID, task, systemPrompt, modelRole, tc.TurnID)
 
-	_ = p.bus.Emit("tool.result", events.ToolResult{
+	toolResult := events.ToolResult{
 		ID:     tc.ID,
 		Name:   tc.Name,
-		Output: result.Result,
-		Error:  result.Error,
+		Output: subResult.Result,
+		Error:  subResult.Error,
 		TurnID: tc.TurnID,
-	})
+	}
+	if veto, vErr := p.bus.EmitVetoable("before:tool.result", &toolResult); vErr == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", toolResult)
 }
 
 // runSubagent executes an isolated agent loop and returns the result.

--- a/plugins/tools/ask/plugin.go
+++ b/plugins/tools/ask/plugin.go
@@ -87,6 +87,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 
 func (p *Plugin) Emissions() []string {
 	return []string{
+		"before:tool.result",
 		"tool.result",
 		"tool.register",
 		"io.ask",
@@ -146,11 +147,16 @@ func (p *Plugin) handleAskResponse(event engine.Event[any]) {
 }
 
 func (p *Plugin) emitResult(tc events.ToolCall, output, errMsg string) {
-	_ = p.bus.Emit("tool.result", events.ToolResult{
+	result := events.ToolResult{
 		ID:     tc.ID,
 		Name:   tc.Name,
 		Output: output,
 		Error:  errMsg,
 		TurnID: tc.TurnID,
-	})
+	}
+	if veto, err := p.bus.EmitVetoable("before:tool.result", &result); err == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
 }

--- a/plugins/tools/fileio/plugin.go
+++ b/plugins/tools/fileio/plugin.go
@@ -209,6 +209,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 
 func (p *Plugin) Emissions() []string {
 	return []string{
+		"before:tool.result",
 		"tool.result",
 		"tool.register",
 		"core.error",
@@ -524,11 +525,16 @@ func (p *Plugin) handleListFiles(tc events.ToolCall) {
 }
 
 func (p *Plugin) emitResult(tc events.ToolCall, output, errMsg string) {
-	_ = p.bus.Emit("tool.result", events.ToolResult{
+	result := events.ToolResult{
 		ID:     tc.ID,
 		Name:   tc.Name,
 		Output: output,
 		Error:  errMsg,
 		TurnID: tc.TurnID,
-	})
+	}
+	if veto, err := p.bus.EmitVetoable("before:tool.result", &result); err == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
 }

--- a/plugins/tools/opener/plugin.go
+++ b/plugins/tools/opener/plugin.go
@@ -103,6 +103,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 
 func (p *Plugin) Emissions() []string {
 	return []string{
+		"before:tool.result",
 		"tool.result",
 		"tool.register",
 	}
@@ -160,11 +161,16 @@ func (p *Plugin) handleOpen(tc events.ToolCall) {
 }
 
 func (p *Plugin) emitResult(tc events.ToolCall, output, errMsg string) {
-	_ = p.bus.Emit("tool.result", events.ToolResult{
+	result := events.ToolResult{
 		ID:     tc.ID,
 		Name:   tc.Name,
 		Output: output,
 		Error:  errMsg,
 		TurnID: tc.TurnID,
-	})
+	}
+	if veto, err := p.bus.EmitVetoable("before:tool.result", &result); err == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
 }

--- a/plugins/tools/pdf/plugin.go
+++ b/plugins/tools/pdf/plugin.go
@@ -141,6 +141,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 
 func (p *Plugin) Emissions() []string {
 	return []string{
+		"before:tool.result",
 		"tool.result",
 		"tool.register",
 	}
@@ -286,11 +287,16 @@ func toInt(v any) (int, bool) {
 }
 
 func (p *Plugin) emitResult(tc events.ToolCall, output, errMsg string) {
-	_ = p.bus.Emit("tool.result", events.ToolResult{
+	result := events.ToolResult{
 		ID:     tc.ID,
 		Name:   tc.Name,
 		Output: output,
 		Error:  errMsg,
 		TurnID: tc.TurnID,
-	})
+	}
+	if veto, err := p.bus.EmitVetoable("before:tool.result", &result); err == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
 }

--- a/plugins/tools/shell/plugin.go
+++ b/plugins/tools/shell/plugin.go
@@ -114,6 +114,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 
 func (p *Plugin) Emissions() []string {
 	return []string{
+		"before:tool.result",
 		"tool.result",
 		"tool.register",
 		"core.error",
@@ -220,11 +221,16 @@ func (p *Plugin) isCommandAllowed(command string) bool {
 }
 
 func (p *Plugin) emitResult(tc events.ToolCall, output, errMsg string) {
-	_ = p.bus.Emit("tool.result", events.ToolResult{
+	result := events.ToolResult{
 		ID:     tc.ID,
 		Name:   tc.Name,
 		Output: output,
 		Error:  errMsg,
 		TurnID: tc.TurnID,
-	})
+	}
+	if veto, err := p.bus.EmitVetoable("before:tool.result", &result); err == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
 }


### PR DESCRIPTION
## Summary

Adds a `before:tool.result` event to all current tools. This allows us to intercept, alter and veto a tool response before injecting it back into the agent loop.

## Changes

- Updated all tools to include trigger `before:tool.result` event.
- No gates added yet.

## Testing

- [x] `make test` passes
- [x] `make lint` passes
- [x] Manual testing done (describe below)

Verified that the event is actually triggered when tools are called. No consumers added yet.

## Related Issues

Closes #17 
