### PR TITLE
Add tool choice and tool filtering (#9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ plugins/
   gates/output_length/   # Output length limit with LLM retry
   gates/content_safety/  # PII/secrets/sensitive content detection (block or redact)
   gates/context_window/  # Context size estimation, triggers compaction
+  gates/tool_filter/     # Tool allowlist/blocklist filtering
   gates/internal/retry/  # Shared retry-with-LLM helper for gates
 ```
 
@@ -170,7 +171,62 @@ nexus.gate.context_window:
   max_context_tokens: 100000
   trigger_ratio: 0.85    # trigger at 85% of max
   chars_per_token: 4.0
+
+# Tool filtering (allowlist or blocklist).
+nexus.gate.tool_filter:
+  include: [file_read, file_write]  # only these tools (empty = all)
+  # or
+  exclude: [shell]                  # remove these tools
 ```
+
+## Tool Choice
+
+Controls which tools the LLM is allowed or required to use per request. Three layers compose:
+
+### LLMRequest fields
+
+`ToolChoice *events.ToolChoice` — mode (`auto`|`required`|`none`|`tool`) + optional tool name.
+`ToolFilter *events.ToolFilter` — include/exclude tool lists. Include takes precedence.
+
+### Provider mapping
+
+Providers map `ToolChoice` to native API format:
+
+| Mode | Anthropic | OpenAI |
+|------|-----------|--------|
+| `auto` | `{"type": "auto"}` | `"auto"` |
+| `required` | `{"type": "any"}` | `"required"` |
+| `none` | strips tools | `"none"` |
+| `tool` | `{"type": "tool", "name": "X"}` | `{"type": "function", "function": {"name": "X"}}` |
+
+For providers without native support, simulation: `none` strips tools, `required`/`tool` use system prompt injection + tool restriction.
+
+### Agent config
+
+ReAct agent supports static default, shorthand, and per-iteration sequences:
+
+```yaml
+nexus.agent.react:
+  tool_choice: required             # shorthand
+  tool_choice:
+    mode: auto                      # static default
+  tool_choice:
+    sequence:                       # per-iteration pattern
+      - mode: required              # iteration 1
+      - mode: tool                  # iteration 2
+        name: shell
+      - mode: auto                  # iteration 3+ (last entry repeats)
+```
+
+### Dynamic override via events
+
+Any plugin can emit `agent.tool_choice` with `AgentToolChoice{Mode, ToolName, Duration}`:
+- `Duration: "once"` — next request only, reverts to config default.
+- `Duration: "sticky"` — persists until replaced. Reset on new turn.
+
+### Evaluation order
+
+1. All registered tools → 2. `nexus.gate.tool_filter` (config include/exclude) → 3. `before:llm.request` gate modifications → 4. Resolve tool choice (event override > config sequence > config default) → 5. Validate (named tool filtered out → fall back to required) → 6. Provider maps to native or simulates.
 
 ## Code Conventions
 

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -39,6 +39,7 @@ import (
 	ratelimitergate "github.com/frankbardon/nexus/plugins/gates/rate_limiter"
 	stopwordsgate "github.com/frankbardon/nexus/plugins/gates/stop_words"
 	tokenbudgetgate "github.com/frankbardon/nexus/plugins/gates/token_budget"
+	toolfiltergate "github.com/frankbardon/nexus/plugins/gates/tool_filter"
 
 	"github.com/frankbardon/nexus/plugins/tools/ask"
 	"github.com/frankbardon/nexus/plugins/tools/fileio"
@@ -108,6 +109,7 @@ func main() {
 	eng.Registry.Register("nexus.gate.rate_limiter", ratelimitergate.New)
 	eng.Registry.Register("nexus.gate.stop_words", stopwordsgate.New)
 	eng.Registry.Register("nexus.gate.token_budget", tokenbudgetgate.New)
+	eng.Registry.Register("nexus.gate.tool_filter", toolfiltergate.New)
 
 	// Run handles SIGINT/SIGTERM internally; embedders call Boot/Stop directly.
 	if err := eng.Run(context.Background()); err != nil {

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -57,6 +57,22 @@ plugins:
   #   # prompt: "custom compaction prompt inline"
   #   # prompt_file: ./prompts/compaction.md
 
+  # nexus.agent.react tool_choice examples:
+  #   tool_choice: required           # shorthand: force tool use every iteration
+  #   tool_choice:
+  #     mode: auto                    # static default
+  #   tool_choice:
+  #     sequence:                     # per-iteration pattern
+  #       - mode: required            # iteration 1: force tool use
+  #       - mode: tool                # iteration 2: force specific tool
+  #         name: shell
+  #       - mode: auto                # iteration 3+: last entry repeats
+
+  # nexus.gate.tool_filter:          # Tool filtering gate
+  #   include: [file_read, file_write]  # allowlist (only these tools)
+  #   # or
+  #   exclude: [shell]                  # blocklist (remove these tools)
+
   nexus.observe.logger:
     output: stderr
     level: warn

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -144,6 +144,8 @@ Complete reference for all event types in Nexus, organized by domain.
 | `Model` | string | Explicit model ID (optional, overrides role) |
 | `Messages` | []Message | Conversation messages |
 | `Tools` | []ToolDef | Available tools |
+| `ToolChoice` | *ToolChoice | Tool choice constraint (nil = provider default) |
+| `ToolFilter` | *ToolFilter | Tool include/exclude filter (nil = no filtering) |
 | `MaxTokens` | int | Max response tokens |
 | `Temperature` | *float64 | Sampling temperature (nil = provider default) |
 | `Stream` | bool | Enable streaming |
@@ -170,6 +172,18 @@ Complete reference for all event types in Nexus, organized by domain.
 | `Name` | string | Tool name |
 | `Description` | string | What the tool does |
 | `Parameters` | string | JSON Schema for parameters |
+
+**ToolChoice**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Mode` | string | `"auto"`, `"required"`, `"none"`, `"tool"` |
+| `Name` | string | Tool name (only when Mode is `"tool"`) |
+
+**ToolFilter**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Include` | []string | Only these tools (empty = all). Takes precedence over Exclude |
+| `Exclude` | []string | Remove these tools |
 
 **LLMResponse**
 | Field | Type | Description |
@@ -245,6 +259,7 @@ Complete reference for all event types in Nexus, organized by domain.
 | `agent.turn.start` | `TurnInfo` | Agent began processing |
 | `agent.turn.end` | `TurnInfo` | Agent finished processing |
 | `agent.plan` | `Plan` | Agent's current plan |
+| `agent.tool_choice` | `AgentToolChoice` | Dynamic tool choice override |
 
 ### Payloads
 
@@ -266,6 +281,13 @@ Complete reference for all event types in Nexus, organized by domain.
 |-------|------|-------------|
 | `Description` | string | What this step does |
 | `Status` | string | `"pending"`, `"active"`, `"completed"`, `"failed"` |
+
+**AgentToolChoice**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Mode` | string | `"auto"`, `"required"`, `"none"`, `"tool"` |
+| `ToolName` | string | Tool name when Mode is `"tool"` |
+| `Duration` | string | `"once"` (next request only) or `"sticky"` (until replaced) |
 
 ---
 

--- a/docs/src/plugins/agents/react.md
+++ b/docs/src/plugins/agents/react.md
@@ -18,6 +18,7 @@ The ReAct (Reason + Act) agent is the default and most commonly used agent strat
 | `model_role` | string | *(default)* | Model role to use (e.g., `reasoning`, `balanced`, `quick`) |
 | `system_prompt` | string | *(none)* | Inline system prompt text |
 | `system_prompt_file` | string | *(none)* | Path to a system prompt markdown file |
+| `tool_choice` | string/object | *(none)* | Tool choice mode — shorthand string or object with `mode`/`name`/`sequence` |
 
 ## Events
 
@@ -36,6 +37,8 @@ The ReAct (Reason + Act) agent is the default and most commonly used agent strat
 | `cancel.active` | 5 | Handles cancellation |
 | `cancel.resume` | 5 | Handles resumption after cancel |
 | `memory.compacted` | 50 | Updates conversation history after compaction |
+| `gate.llm.retry` | 50 | Retries previously vetoed LLM request |
+| `agent.tool_choice` | 50 | Dynamic tool choice override from other plugins |
 
 ### Emits
 
@@ -78,6 +81,39 @@ When `planning: true`, the agent requests a plan before starting iteration:
 4. The plan steps are injected into the system prompt as context
 5. Normal ReAct iteration begins with the plan as guidance
 
+## Tool Choice
+
+Controls whether the LLM must use tools. Supports static defaults, per-iteration sequences, and dynamic overrides.
+
+### Static default (shorthand or object)
+
+```yaml
+nexus.agent.react:
+  tool_choice: required              # shorthand: force tool use every iteration
+  # or
+  tool_choice:
+    mode: auto                       # "auto" | "required" | "none" | "tool"
+    name: shell                      # only when mode == "tool"
+```
+
+### Per-iteration sequence
+
+```yaml
+nexus.agent.react:
+  tool_choice:
+    sequence:
+      - mode: required               # iteration 1: force tool use
+      - mode: tool                   # iteration 2: force specific tool
+        name: shell
+      - mode: auto                   # iteration 3+: last entry repeats
+```
+
+### Dynamic override
+
+Any plugin can emit `agent.tool_choice` with `AgentToolChoice{Mode, ToolName, Duration}`:
+- `Duration: "once"` — applies to next LLM request only, then reverts to config default.
+- `Duration: "sticky"` — persists until replaced by another override. Reset on new turn.
+
 ## Example Configuration
 
 ```yaml
@@ -86,6 +122,10 @@ nexus.agent.react:
   planning: true
   model_role: balanced
   system_prompt_file: ./prompts/coding-assistant.md
+  tool_choice:
+    sequence:
+      - mode: required
+      - mode: auto
 ```
 
 ## Tool Discovery

--- a/pkg/events/agent.go
+++ b/pkg/events/agent.go
@@ -44,6 +44,14 @@ type SubagentIteration struct {
 	ToolCalls []ToolCallRequest // tool calls made this iteration
 }
 
+// AgentToolChoice is emitted by plugins to dynamically override the agent's
+// tool choice for subsequent LLM requests.
+type AgentToolChoice struct {
+	Mode     string // "auto" | "required" | "none" | "tool"
+	ToolName string // when Mode == "tool"
+	Duration string // "once" = next request only; "sticky" = until replaced
+}
+
 // SubagentComplete signals that a subagent has finished execution.
 type SubagentComplete struct {
 	SpawnID      string

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -1,11 +1,26 @@
 package events
 
+// ToolChoice controls which tools the LLM is allowed or required to use.
+type ToolChoice struct {
+	Mode string `json:"mode"` // "auto" | "required" | "none" | "tool"
+	Name string `json:"name,omitempty"` // tool name when Mode == "tool"
+}
+
+// ToolFilter restricts which tools are available for an LLM request.
+// Include and Exclude are mutually exclusive; Include takes precedence.
+type ToolFilter struct {
+	Include []string `json:"include,omitempty"` // only these tools (empty = all)
+	Exclude []string `json:"exclude,omitempty"` // remove these tools
+}
+
 // LLMRequest describes a request to a language model.
 type LLMRequest struct {
 	Role        string // Model role (e.g., "reasoning", "balanced", "quick")
 	Model       string // Explicit model ID override (takes precedence over Role)
 	Messages    []Message
 	Tools       []ToolDef
+	ToolChoice  *ToolChoice  // nil = provider default (auto)
+	ToolFilter  *ToolFilter  // nil = no filtering
 	MaxTokens   int
 	Temperature *float64
 	Stream      bool

--- a/plugins/agents/react/plugin.go
+++ b/plugins/agents/react/plugin.go
@@ -29,19 +29,21 @@ type Plugin struct {
 	systemPromptFile string
 	planningEnabled  bool
 	modelRole        string
+	toolChoiceCfg    toolChoiceConfig
 
-	mu               sync.Mutex
-	history          []events.Message
-	registeredTools  []events.ToolDef
-	skillContexts    []string
-	currentTurnID    string
-	currentPlan      *events.PlanResult
-	currentPlanStep  int // index into currentPlan.Steps; -1 when no plan is active
-	iteration        int
-	pendingToolCalls int
-	streamed         bool
-	cancelled        bool
-	unsubs           []func()
+	mu                sync.Mutex
+	history           []events.Message
+	registeredTools   []events.ToolDef
+	skillContexts     []string
+	currentTurnID     string
+	currentPlan       *events.PlanResult
+	currentPlanStep   int // index into currentPlan.Steps; -1 when no plan is active
+	iteration         int
+	pendingToolCalls  int
+	streamed          bool
+	cancelled         bool
+	toolChoiceOverride *toolChoiceOverride
+	unsubs            []func()
 }
 
 // New creates a new ReAct agent plugin.
@@ -79,6 +81,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.systemPrompt = sp
 	}
 
+	p.toolChoiceCfg = parseToolChoiceConfig(ctx.Config)
+
 	// Register event handlers.
 	p.unsubs = append(p.unsubs,
 		p.bus.Subscribe("io.input", p.handleInputEvent,
@@ -104,6 +108,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.bus.Subscribe("memory.compacted", p.handleCompactedEvent,
 			engine.WithPriority(50), engine.WithSource(pluginID)),
 		p.bus.Subscribe("gate.llm.retry", p.handleGateRetry,
+			engine.WithPriority(50), engine.WithSource(pluginID)),
+		p.bus.Subscribe("agent.tool_choice", p.handleToolChoiceEvent,
 			engine.WithPriority(50), engine.WithSource(pluginID)),
 	)
 
@@ -132,6 +138,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "cancel.resume", Priority: 50},
 		{EventType: "memory.compacted", Priority: 50},
 		{EventType: "gate.llm.retry", Priority: 50},
+		{EventType: "agent.tool_choice", Priority: 50},
 	}
 }
 
@@ -345,6 +352,24 @@ func (p *Plugin) handleCompactedEvent(event engine.Event[any]) {
 	p.logger.Info("history replaced by compaction", "messages", len(cc.Messages))
 }
 
+// handleToolChoiceEvent processes dynamic tool choice overrides from other plugins.
+func (p *Plugin) handleToolChoiceEvent(event engine.Event[any]) {
+	atc, ok := event.Payload.(events.AgentToolChoice)
+	if !ok {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.toolChoiceOverride = &toolChoiceOverride{
+		Choice: events.ToolChoice{
+			Mode: atc.Mode,
+			Name: atc.ToolName,
+		},
+		Duration: atc.Duration,
+	}
+	p.logger.Info("tool choice override set", "mode", atc.Mode, "name", atc.ToolName, "duration", atc.Duration)
+}
+
 // handleGateRetry is called when a gate (rate limiter, context window, etc.)
 // signals that a previously vetoed LLM request should be retried.
 func (p *Plugin) handleGateRetry(_ engine.Event[any]) {
@@ -391,6 +416,7 @@ func (p *Plugin) handleInput(input events.UserInput) {
 	p.iteration = 0
 	p.pendingToolCalls = 0
 	p.streamed = false
+	p.toolChoiceOverride = nil
 
 	// Add user message to history.
 	p.history = append(p.history, events.Message{
@@ -639,13 +665,17 @@ func (p *Plugin) sendLLMRequest() {
 	tools := make([]events.ToolDef, len(p.registeredTools))
 	copy(tools, p.registeredTools)
 
+	// Resolve tool choice for this iteration.
+	tc := resolveToolChoice(p.toolChoiceCfg, p.iteration, &p.toolChoiceOverride)
+
 	p.mu.Unlock()
 
 	req := events.LLMRequest{
-		Role:     p.modelRole,
-		Messages: messages,
-		Tools:    tools,
-		Stream:   true,
+		Role:       p.modelRole,
+		Messages:   messages,
+		Tools:      tools,
+		ToolChoice: tc,
+		Stream:     true,
 	}
 
 	if veto, err := p.bus.EmitVetoable("before:llm.request", &req); err == nil && veto.Vetoed {

--- a/plugins/agents/react/tool_choice.go
+++ b/plugins/agents/react/tool_choice.go
@@ -1,0 +1,111 @@
+package react
+
+import "github.com/frankbardon/nexus/pkg/events"
+
+// toolChoiceConfig holds the parsed tool_choice configuration for the ReAct agent.
+type toolChoiceConfig struct {
+	// Default mode applied when no sequence or override is active.
+	Default *events.ToolChoice
+
+	// Sequence of tool choices applied per-iteration. The last entry repeats
+	// for all subsequent iterations.
+	Sequence []events.ToolChoice
+}
+
+// toolChoiceOverride is a dynamic override set by an agent.tool_choice event.
+type toolChoiceOverride struct {
+	Choice   events.ToolChoice
+	Duration string // "once" | "sticky"
+}
+
+// parseToolChoiceConfig extracts tool_choice settings from plugin config.
+func parseToolChoiceConfig(cfg map[string]any) toolChoiceConfig {
+	raw, ok := cfg["tool_choice"]
+	if !ok {
+		return toolChoiceConfig{}
+	}
+
+	switch v := raw.(type) {
+	case map[string]any:
+		// Check for sequence first.
+		if seqRaw, ok := v["sequence"]; ok {
+			return toolChoiceConfig{
+				Sequence: parseToolChoiceSequence(seqRaw),
+			}
+		}
+		// Otherwise it's a single default.
+		tc := parseOneToolChoice(v)
+		if tc != nil {
+			return toolChoiceConfig{Default: tc}
+		}
+
+	case string:
+		// Shorthand: tool_choice: "required"
+		return toolChoiceConfig{
+			Default: &events.ToolChoice{Mode: v},
+		}
+	}
+
+	return toolChoiceConfig{}
+}
+
+// parseToolChoiceSequence parses a sequence list from config.
+func parseToolChoiceSequence(raw any) []events.ToolChoice {
+	list, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+
+	var seq []events.ToolChoice
+	for _, item := range list {
+		switch v := item.(type) {
+		case map[string]any:
+			if tc := parseOneToolChoice(v); tc != nil {
+				seq = append(seq, *tc)
+			}
+		case string:
+			seq = append(seq, events.ToolChoice{Mode: v})
+		}
+	}
+	return seq
+}
+
+// parseOneToolChoice parses a single tool_choice map entry.
+func parseOneToolChoice(m map[string]any) *events.ToolChoice {
+	mode, _ := m["mode"].(string)
+	if mode == "" {
+		return nil
+	}
+	tc := &events.ToolChoice{Mode: mode}
+	if name, ok := m["name"].(string); ok {
+		tc.Name = name
+	}
+	return tc
+}
+
+// resolveToolChoice determines the effective ToolChoice for a given iteration,
+// consuming any pending override.
+func resolveToolChoice(cfg toolChoiceConfig, iteration int, override **toolChoiceOverride) *events.ToolChoice {
+	// Dynamic override takes priority.
+	if override != nil && *override != nil {
+		ov := *override
+		tc := ov.Choice
+		if ov.Duration == "once" {
+			*override = nil
+		}
+		return &tc
+	}
+
+	// Sequence: index into list, last entry is sticky.
+	if len(cfg.Sequence) > 0 {
+		idx := iteration
+		if idx >= len(cfg.Sequence) {
+			idx = len(cfg.Sequence) - 1
+		}
+		tc := cfg.Sequence[idx]
+		return &tc
+	}
+
+	// Static default.
+	return cfg.Default
+}

--- a/plugins/agents/react/tool_choice_test.go
+++ b/plugins/agents/react/tool_choice_test.go
@@ -1,0 +1,168 @@
+package react
+
+import (
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestParseToolChoiceConfig_Empty(t *testing.T) {
+	cfg := parseToolChoiceConfig(map[string]any{})
+	if cfg.Default != nil {
+		t.Error("expected nil default for empty config")
+	}
+	if len(cfg.Sequence) != 0 {
+		t.Error("expected empty sequence for empty config")
+	}
+}
+
+func TestParseToolChoiceConfig_Shorthand(t *testing.T) {
+	cfg := parseToolChoiceConfig(map[string]any{
+		"tool_choice": "required",
+	})
+	if cfg.Default == nil || cfg.Default.Mode != "required" {
+		t.Errorf("expected default mode=required, got %+v", cfg.Default)
+	}
+}
+
+func TestParseToolChoiceConfig_StaticDefault(t *testing.T) {
+	cfg := parseToolChoiceConfig(map[string]any{
+		"tool_choice": map[string]any{
+			"mode": "none",
+		},
+	})
+	if cfg.Default == nil || cfg.Default.Mode != "none" {
+		t.Errorf("expected default mode=none, got %+v", cfg.Default)
+	}
+}
+
+func TestParseToolChoiceConfig_ToolMode(t *testing.T) {
+	cfg := parseToolChoiceConfig(map[string]any{
+		"tool_choice": map[string]any{
+			"mode": "tool",
+			"name": "shell",
+		},
+	})
+	if cfg.Default == nil || cfg.Default.Mode != "tool" || cfg.Default.Name != "shell" {
+		t.Errorf("expected mode=tool name=shell, got %+v", cfg.Default)
+	}
+}
+
+func TestParseToolChoiceConfig_Sequence(t *testing.T) {
+	cfg := parseToolChoiceConfig(map[string]any{
+		"tool_choice": map[string]any{
+			"sequence": []any{
+				map[string]any{"mode": "required"},
+				map[string]any{"mode": "tool", "name": "shell"},
+				"auto",
+			},
+		},
+	})
+	if len(cfg.Sequence) != 3 {
+		t.Fatalf("expected 3 sequence entries, got %d", len(cfg.Sequence))
+	}
+	if cfg.Sequence[0].Mode != "required" {
+		t.Errorf("seq[0] mode=%s, want required", cfg.Sequence[0].Mode)
+	}
+	if cfg.Sequence[1].Mode != "tool" || cfg.Sequence[1].Name != "shell" {
+		t.Errorf("seq[1] = %+v, want mode=tool name=shell", cfg.Sequence[1])
+	}
+	if cfg.Sequence[2].Mode != "auto" {
+		t.Errorf("seq[2] mode=%s, want auto", cfg.Sequence[2].Mode)
+	}
+}
+
+func TestResolveToolChoice_NilDefault(t *testing.T) {
+	cfg := toolChoiceConfig{}
+	var override *toolChoiceOverride
+	tc := resolveToolChoice(cfg, 0, &override)
+	if tc != nil {
+		t.Errorf("expected nil, got %+v", tc)
+	}
+}
+
+func TestResolveToolChoice_StaticDefault(t *testing.T) {
+	cfg := toolChoiceConfig{
+		Default: &events.ToolChoice{Mode: "required"},
+	}
+	var override *toolChoiceOverride
+	tc := resolveToolChoice(cfg, 0, &override)
+	if tc == nil || tc.Mode != "required" {
+		t.Errorf("expected mode=required, got %+v", tc)
+	}
+}
+
+func TestResolveToolChoice_Sequence(t *testing.T) {
+	cfg := toolChoiceConfig{
+		Sequence: []events.ToolChoice{
+			{Mode: "required"},
+			{Mode: "tool", Name: "shell"},
+			{Mode: "auto"},
+		},
+	}
+	var override *toolChoiceOverride
+
+	// Iteration 0 → first entry.
+	tc := resolveToolChoice(cfg, 0, &override)
+	if tc.Mode != "required" {
+		t.Errorf("iter 0: mode=%s, want required", tc.Mode)
+	}
+
+	// Iteration 1 → second entry.
+	tc = resolveToolChoice(cfg, 1, &override)
+	if tc.Mode != "tool" || tc.Name != "shell" {
+		t.Errorf("iter 1: %+v, want mode=tool name=shell", tc)
+	}
+
+	// Iteration 5 → last entry (sticky).
+	tc = resolveToolChoice(cfg, 5, &override)
+	if tc.Mode != "auto" {
+		t.Errorf("iter 5: mode=%s, want auto", tc.Mode)
+	}
+}
+
+func TestResolveToolChoice_OverrideOnce(t *testing.T) {
+	cfg := toolChoiceConfig{
+		Default: &events.ToolChoice{Mode: "auto"},
+	}
+	override := &toolChoiceOverride{
+		Choice:   events.ToolChoice{Mode: "required"},
+		Duration: "once",
+	}
+
+	// First call consumes the override.
+	tc := resolveToolChoice(cfg, 0, &override)
+	if tc.Mode != "required" {
+		t.Errorf("first call: mode=%s, want required", tc.Mode)
+	}
+	if override != nil {
+		t.Error("expected override to be consumed after once")
+	}
+
+	// Second call falls back to default.
+	tc = resolveToolChoice(cfg, 1, &override)
+	if tc.Mode != "auto" {
+		t.Errorf("second call: mode=%s, want auto", tc.Mode)
+	}
+}
+
+func TestResolveToolChoice_OverrideSticky(t *testing.T) {
+	cfg := toolChoiceConfig{
+		Default: &events.ToolChoice{Mode: "auto"},
+	}
+	override := &toolChoiceOverride{
+		Choice:   events.ToolChoice{Mode: "none"},
+		Duration: "sticky",
+	}
+
+	// Should persist across calls.
+	for i := 0; i < 3; i++ {
+		tc := resolveToolChoice(cfg, i, &override)
+		if tc.Mode != "none" {
+			t.Errorf("iter %d: mode=%s, want none", i, tc.Mode)
+		}
+	}
+	if override == nil {
+		t.Error("sticky override should not be consumed")
+	}
+}

--- a/plugins/gates/tool_filter/plugin.go
+++ b/plugins/gates/tool_filter/plugin.go
@@ -1,0 +1,123 @@
+package toolfilter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const pluginID = "nexus.gate.tool_filter"
+
+// New creates a new tool filter gate plugin instance.
+func New() engine.Plugin {
+	return &Plugin{}
+}
+
+// Plugin gates before:llm.request events by filtering the available tool set.
+// Supports include (allowlist) or exclude (blocklist) modes via config.
+// Include takes precedence if both are specified.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+
+	include []string
+	exclude []string
+
+	unsubs []func()
+}
+
+func (p *Plugin) ID() string             { return pluginID }
+func (p *Plugin) Name() string           { return "Tool Filter Gate" }
+func (p *Plugin) Version() string        { return "0.1.0" }
+func (p *Plugin) Dependencies() []string { return nil }
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+
+	if v, ok := ctx.Config["include"].([]any); ok {
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				p.include = append(p.include, s)
+			}
+		}
+	}
+
+	if v, ok := ctx.Config["exclude"].([]any); ok {
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				p.exclude = append(p.exclude, s)
+			}
+		}
+	}
+
+	if len(p.include) > 0 && len(p.exclude) > 0 {
+		p.logger.Warn("both include and exclude configured; include takes precedence")
+		p.exclude = nil
+	}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("before:llm.request", p.handleBeforeLLMRequest,
+			engine.WithPriority(10), engine.WithSource(pluginID)),
+	)
+
+	mode := "passthrough"
+	if len(p.include) > 0 {
+		mode = fmt.Sprintf("include(%d tools)", len(p.include))
+	} else if len(p.exclude) > 0 {
+		mode = fmt.Sprintf("exclude(%d tools)", len(p.exclude))
+	}
+	p.logger.Info("tool filter gate initialized", "mode", mode)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	return nil
+}
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "before:llm.request", Priority: 10},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return nil
+}
+
+func (p *Plugin) handleBeforeLLMRequest(event engine.Event[any]) {
+	vp, ok := event.Payload.(*engine.VetoablePayload)
+	if !ok {
+		return
+	}
+
+	req, ok := vp.Original.(*events.LLMRequest)
+	if !ok {
+		return
+	}
+
+	// Skip gate-originated or planner LLM requests.
+	if src, _ := req.Metadata["_source"].(string); src != "" {
+		return
+	}
+
+	// Merge gate config into the request's ToolFilter.
+	// Request-level filter (set by agent or other plugin) takes precedence.
+	if req.ToolFilter != nil {
+		return
+	}
+
+	if len(p.include) > 0 {
+		req.ToolFilter = &events.ToolFilter{Include: p.include}
+	} else if len(p.exclude) > 0 {
+		req.ToolFilter = &events.ToolFilter{Exclude: p.exclude}
+	}
+}

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -307,10 +307,16 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 	}
 	body["messages"] = apiMessages
 
+	// Apply tool filtering. Mode "none" strips all tools.
+	filteredTools := applyToolFilter(req.Tools, req.ToolFilter)
+	if req.ToolChoice != nil && req.ToolChoice.Mode == "none" {
+		filteredTools = nil
+	}
+
 	// Convert tool definitions.
-	if len(req.Tools) > 0 {
+	if len(filteredTools) > 0 {
 		var tools []map[string]any
-		for _, t := range req.Tools {
+		for _, t := range filteredTools {
 			tools = append(tools, map[string]any{
 				"name":         t.Name,
 				"description":  t.Description,
@@ -318,6 +324,11 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 			})
 		}
 		body["tools"] = tools
+	}
+
+	// Map tool choice to Anthropic API format.
+	if tc := resolveToolChoice(req.ToolChoice, filteredTools); tc != nil {
+		body["tool_choice"] = tc
 	}
 
 	return body

--- a/plugins/providers/anthropic/tool_choice.go
+++ b/plugins/providers/anthropic/tool_choice.go
@@ -1,0 +1,82 @@
+package anthropic
+
+import "github.com/frankbardon/nexus/pkg/events"
+
+// applyToolFilter returns a filtered copy of tools based on the filter config.
+// Include takes precedence over Exclude. Nil filter returns tools unchanged.
+func applyToolFilter(tools []events.ToolDef, filter *events.ToolFilter) []events.ToolDef {
+	if filter == nil {
+		return tools
+	}
+
+	if len(filter.Include) > 0 {
+		allowed := make(map[string]bool, len(filter.Include))
+		for _, name := range filter.Include {
+			allowed[name] = true
+		}
+		var out []events.ToolDef
+		for _, t := range tools {
+			if allowed[t.Name] {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	if len(filter.Exclude) > 0 {
+		blocked := make(map[string]bool, len(filter.Exclude))
+		for _, name := range filter.Exclude {
+			blocked[name] = true
+		}
+		var out []events.ToolDef
+		for _, t := range tools {
+			if !blocked[t.Name] {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	return tools
+}
+
+// resolveToolChoice maps an events.ToolChoice to the Anthropic API tool_choice format.
+// Returns nil when no tool_choice should be sent (default auto behavior).
+func resolveToolChoice(tc *events.ToolChoice, tools []events.ToolDef) map[string]any {
+	if tc == nil {
+		return nil
+	}
+
+	switch tc.Mode {
+	case "auto":
+		return map[string]any{"type": "auto"}
+	case "required":
+		return map[string]any{"type": "any"}
+	case "none":
+		// Anthropic doesn't have a native "none" — handled by stripping tools.
+		// But if caller still sends tool_choice, omit it and let empty tools do the work.
+		return nil
+	case "tool":
+		if tc.Name == "" {
+			return map[string]any{"type": "any"}
+		}
+		// Validate the named tool exists in the filtered set.
+		found := false
+		for _, t := range tools {
+			if t.Name == tc.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Fall back to "any" (required) if named tool was filtered out.
+			return map[string]any{"type": "any"}
+		}
+		return map[string]any{
+			"type": "tool",
+			"name": tc.Name,
+		}
+	default:
+		return nil
+	}
+}

--- a/plugins/providers/anthropic/tool_choice_test.go
+++ b/plugins/providers/anthropic/tool_choice_test.go
@@ -1,0 +1,106 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestApplyToolFilter_Nil(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}}
+	result := applyToolFilter(tools, nil)
+	if len(result) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(result))
+	}
+}
+
+func TestApplyToolFilter_Include(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	result := applyToolFilter(tools, &events.ToolFilter{Include: []string{"a", "c"}})
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(result))
+	}
+	if result[0].Name != "a" || result[1].Name != "c" {
+		t.Errorf("expected [a, c], got [%s, %s]", result[0].Name, result[1].Name)
+	}
+}
+
+func TestApplyToolFilter_Exclude(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	result := applyToolFilter(tools, &events.ToolFilter{Exclude: []string{"b"}})
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(result))
+	}
+	if result[0].Name != "a" || result[1].Name != "c" {
+		t.Errorf("expected [a, c], got [%s, %s]", result[0].Name, result[1].Name)
+	}
+}
+
+func TestApplyToolFilter_IncludePrecedence(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}}
+	result := applyToolFilter(tools, &events.ToolFilter{
+		Include: []string{"a"},
+		Exclude: []string{"a"},
+	})
+	// Include takes precedence — "a" should be kept.
+	if len(result) != 1 || result[0].Name != "a" {
+		t.Errorf("expected [a], got %+v", result)
+	}
+}
+
+func TestResolveToolChoice_Auto(t *testing.T) {
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "auto"}, nil)
+	if tc == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if tc["type"] != "auto" {
+		t.Errorf("expected type=auto, got %v", tc["type"])
+	}
+}
+
+func TestResolveToolChoice_Required(t *testing.T) {
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "required"}, nil)
+	if tc == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if tc["type"] != "any" {
+		t.Errorf("expected type=any, got %v", tc["type"])
+	}
+}
+
+func TestResolveToolChoice_None(t *testing.T) {
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "none"}, nil)
+	if tc != nil {
+		t.Errorf("expected nil for none mode, got %+v", tc)
+	}
+}
+
+func TestResolveToolChoice_SpecificTool(t *testing.T) {
+	tools := []events.ToolDef{{Name: "shell"}, {Name: "file"}}
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "tool", Name: "shell"}, tools)
+	if tc == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if tc["type"] != "tool" || tc["name"] != "shell" {
+		t.Errorf("expected type=tool name=shell, got %+v", tc)
+	}
+}
+
+func TestResolveToolChoice_MissingToolFallback(t *testing.T) {
+	tools := []events.ToolDef{{Name: "file"}}
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "tool", Name: "shell"}, tools)
+	if tc == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// Should fall back to "any" (required).
+	if tc["type"] != "any" {
+		t.Errorf("expected fallback type=any, got %v", tc["type"])
+	}
+}
+
+func TestResolveToolChoice_Nil(t *testing.T) {
+	tc := resolveToolChoice(nil, nil)
+	if tc != nil {
+		t.Errorf("expected nil for nil input, got %+v", tc)
+	}
+}

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -316,10 +316,16 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 	}
 	body["messages"] = apiMessages
 
+	// Apply tool filtering. Mode "none" strips all tools.
+	filteredTools := applyToolFilter(req.Tools, req.ToolFilter)
+	if req.ToolChoice != nil && req.ToolChoice.Mode == "none" {
+		filteredTools = nil
+	}
+
 	// Convert tool definitions.
-	if len(req.Tools) > 0 {
+	if len(filteredTools) > 0 {
 		var tools []map[string]any
-		for _, t := range req.Tools {
+		for _, t := range filteredTools {
 			tools = append(tools, map[string]any{
 				"type": "function",
 				"function": map[string]any{
@@ -330,6 +336,11 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 			})
 		}
 		body["tools"] = tools
+	}
+
+	// Map tool choice to OpenAI API format.
+	if tc := resolveToolChoice(req.ToolChoice, filteredTools); tc != nil {
+		body["tool_choice"] = tc
 	}
 
 	return body

--- a/plugins/providers/openai/tool_choice.go
+++ b/plugins/providers/openai/tool_choice.go
@@ -1,0 +1,81 @@
+package openai
+
+import "github.com/frankbardon/nexus/pkg/events"
+
+// applyToolFilter returns a filtered copy of tools based on the filter config.
+// Include takes precedence over Exclude. Nil filter returns tools unchanged.
+func applyToolFilter(tools []events.ToolDef, filter *events.ToolFilter) []events.ToolDef {
+	if filter == nil {
+		return tools
+	}
+
+	if len(filter.Include) > 0 {
+		allowed := make(map[string]bool, len(filter.Include))
+		for _, name := range filter.Include {
+			allowed[name] = true
+		}
+		var out []events.ToolDef
+		for _, t := range tools {
+			if allowed[t.Name] {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	if len(filter.Exclude) > 0 {
+		blocked := make(map[string]bool, len(filter.Exclude))
+		for _, name := range filter.Exclude {
+			blocked[name] = true
+		}
+		var out []events.ToolDef
+		for _, t := range tools {
+			if !blocked[t.Name] {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	return tools
+}
+
+// resolveToolChoice maps an events.ToolChoice to the OpenAI API tool_choice format.
+// Returns nil when no tool_choice should be sent (default auto behavior).
+func resolveToolChoice(tc *events.ToolChoice, tools []events.ToolDef) any {
+	if tc == nil {
+		return nil
+	}
+
+	switch tc.Mode {
+	case "auto":
+		return "auto"
+	case "required":
+		return "required"
+	case "none":
+		return "none"
+	case "tool":
+		if tc.Name == "" {
+			return "required"
+		}
+		// Validate the named tool exists in the filtered set.
+		found := false
+		for _, t := range tools {
+			if t.Name == tc.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return "required"
+		}
+		return map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name": tc.Name,
+			},
+		}
+	default:
+		return nil
+	}
+}

--- a/plugins/providers/openai/tool_choice_test.go
+++ b/plugins/providers/openai/tool_choice_test.go
@@ -1,0 +1,86 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestApplyToolFilter_Nil(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}}
+	result := applyToolFilter(tools, nil)
+	if len(result) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(result))
+	}
+}
+
+func TestApplyToolFilter_Include(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	result := applyToolFilter(tools, &events.ToolFilter{Include: []string{"b"}})
+	if len(result) != 1 || result[0].Name != "b" {
+		t.Errorf("expected [b], got %+v", result)
+	}
+}
+
+func TestApplyToolFilter_Exclude(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	result := applyToolFilter(tools, &events.ToolFilter{Exclude: []string{"a", "c"}})
+	if len(result) != 1 || result[0].Name != "b" {
+		t.Errorf("expected [b], got %+v", result)
+	}
+}
+
+func TestResolveToolChoice_Auto(t *testing.T) {
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "auto"}, nil)
+	if tc != "auto" {
+		t.Errorf("expected \"auto\", got %v", tc)
+	}
+}
+
+func TestResolveToolChoice_Required(t *testing.T) {
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "required"}, nil)
+	if tc != "required" {
+		t.Errorf("expected \"required\", got %v", tc)
+	}
+}
+
+func TestResolveToolChoice_None(t *testing.T) {
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "none"}, nil)
+	if tc != "none" {
+		t.Errorf("expected \"none\", got %v", tc)
+	}
+}
+
+func TestResolveToolChoice_SpecificTool(t *testing.T) {
+	tools := []events.ToolDef{{Name: "shell"}}
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "tool", Name: "shell"}, tools)
+	m, ok := tc.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", tc)
+	}
+	if m["type"] != "function" {
+		t.Errorf("expected type=function, got %v", m["type"])
+	}
+	fn, ok := m["function"].(map[string]any)
+	if !ok {
+		t.Fatal("expected function map")
+	}
+	if fn["name"] != "shell" {
+		t.Errorf("expected name=shell, got %v", fn["name"])
+	}
+}
+
+func TestResolveToolChoice_MissingToolFallback(t *testing.T) {
+	tools := []events.ToolDef{{Name: "file"}}
+	tc := resolveToolChoice(&events.ToolChoice{Mode: "tool", Name: "shell"}, tools)
+	if tc != "required" {
+		t.Errorf("expected fallback \"required\", got %v", tc)
+	}
+}
+
+func TestResolveToolChoice_Nil(t *testing.T) {
+	tc := resolveToolChoice(nil, nil)
+	if tc != nil {
+		t.Errorf("expected nil, got %v", tc)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ToolChoice` (auto/required/none/tool) and `ToolFilter` (include/exclude) structs on `LLMRequest`
- Both Anthropic and OpenAI providers map `ToolChoice` to native API format; `mode: none` strips tools entirely
- ReAct agent supports static default, shorthand string, per-iteration sequences, and dynamic `agent.tool_choice` event overrides (once/sticky)
- New `nexus.gate.tool_filter` gate plugin for config-driven tool allowlist/blocklist at priority 10
- 30 unit tests covering config parsing, sequence resolution, override consumption, tool filtering, and provider mapping

## Test plan

- [x] All existing tests pass (`make test`)
- [x] Clean build (`make build`)
- [x] New tests cover: config parsing (empty, shorthand, static, tool mode, sequence), resolve logic (nil default, static, sequence sticky, override once, override sticky), tool filtering (nil, include, exclude, include precedence), Anthropic mapping (auto, required, none, specific tool, missing tool fallback, nil), OpenAI mapping (auto, required, none, specific tool, missing tool fallback, nil)

Closes #9
