### PR TITLE
feat: native cost tracking with provider pricing

### DIFF
--- a/cmd/desktop/internal/matcher/plugin.go
+++ b/cmd/desktop/internal/matcher/plugin.go
@@ -362,7 +362,7 @@ func (p *Plugin) runMatch(req MatchRequest) {
 			})
 			return
 		}
-		cost := calculateCost(resp.Usage, latencyMs)
+		cost := buildCost(resp, latencyMs)
 		p.logger.Info("match complete",
 			"request_id", req.RequestID,
 			"candidates", len(candidates),

--- a/cmd/desktop/internal/matcher/rank.go
+++ b/cmd/desktop/internal/matcher/rank.go
@@ -9,40 +9,17 @@ import (
 	"github.com/frankbardon/nexus/pkg/events"
 )
 
-// Pricing constants for the model configured in config.yaml. Rates
-// are USD per million tokens, which is how Anthropic publishes
-// their pricing. These MUST be updated when:
-//   - the config.yaml model ID changes,
-//   - Anthropic publishes new rates for the same model,
-//   - a new pricing tier (caching, batch, etc.) is introduced.
-//
-// Kept as plain constants rather than config-driven because this
-// is a PoC with one model and two numbers; YAML-driven pricing
-// would be more machinery than value. Pricing is not a moving
-// target the customer can edit, so baking it into the binary on
-// every build is the right tradeoff.
-//
-// Current: claude-sonnet-4-6 pricing as of the session this was
-// written. The official source is https://www.anthropic.com/pricing
-// — check there before release and before any config.yaml model
-// change.
-const (
-	pricePerMillionInputTokens  = 3.0
-	pricePerMillionOutputTokens = 15.0
-)
-
-// calculateCost converts an Anthropic Usage record into a Cost
-// struct for display. Latency is passed in separately because the
-// Usage struct only knows about tokens, not wall-clock time —
-// latency is measured at the bus round-trip boundary in runMatch.
-func calculateCost(usage events.Usage, latencyMs int64) Cost {
-	inputCost := float64(usage.PromptTokens) / 1_000_000 * pricePerMillionInputTokens
-	outputCost := float64(usage.CompletionTokens) / 1_000_000 * pricePerMillionOutputTokens
+// buildCost assembles a Cost struct from the provider-computed LLM response.
+// CostUSD is sourced from the provider's pricing table — the matcher no
+// longer maintains its own pricing constants. Latency is passed in
+// separately because it is measured at the bus round-trip boundary in
+// runMatch, not by the provider.
+func buildCost(resp events.LLMResponse, latencyMs int64) Cost {
 	return Cost{
-		PromptTokens:     usage.PromptTokens,
-		CompletionTokens: usage.CompletionTokens,
-		TotalTokens:      usage.TotalTokens,
-		USD:              inputCost + outputCost,
+		PromptTokens:     resp.Usage.PromptTokens,
+		CompletionTokens: resp.Usage.CompletionTokens,
+		TotalTokens:      resp.Usage.TotalTokens,
+		USD:              resp.CostUSD,
 		LatencyMs:        latencyMs,
 	}
 }

--- a/docs/src/architecture/sessions.md
+++ b/docs/src/architecture/sessions.md
@@ -26,15 +26,18 @@ Each session tracks metadata in `metadata/session.json`:
 
 ```go
 type SessionMeta struct {
-    ID         string            // Random hex identifier
-    StartedAt  time.Time         // When the session began
-    EndedAt    *time.Time        // When the session ended (nil if active)
-    Profile    string            // Config profile name
-    Plugins    []string          // Active plugin IDs
-    Labels     map[string]string // User-defined labels
-    TurnCount  int               // Number of conversation turns
-    TokensUsed int               // Total tokens consumed
-    Status     string            // "active" or "ended"
+    ID                   string            // Random hex identifier
+    StartedAt            time.Time         // When the session began
+    EndedAt              *time.Time        // When the session ended (nil if active)
+    Profile              string            // Config profile name
+    Plugins              []string          // Active plugin IDs
+    Labels               map[string]string // User-defined labels
+    TurnCount            int               // Number of conversation turns
+    TokensUsed           int               // Total tokens consumed
+    PromptTokensUsed     int               // Input tokens consumed
+    CompletionTokensUsed int               // Output tokens consumed
+    CostUSD              float64           // Accumulated cost in USD
+    Status               string            // "active" or "ended"
 }
 ```
 

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -191,6 +191,7 @@ Complete reference for all event types in Nexus, organized by domain.
 | `Content` | string | Response text |
 | `ToolCalls` | []ToolCallRequest | Tool calls in the response |
 | `Usage` | Usage | Token usage statistics |
+| `CostUSD` | float64 | Provider-computed cost in USD for this request |
 | `Model` | string | Model that was used |
 | `FinishReason` | string | Why the response ended |
 | `Metadata` | map[string]any | Additional context |
@@ -320,6 +321,7 @@ Complete reference for all event types in Nexus, organized by domain.
 | `Error` | string | Error (if failed) |
 | `Iterations` | int | Number of iterations used |
 | `TokensUsed` | Usage | Token consumption |
+| `CostUSD` | float64 | Accumulated cost in USD |
 | `ParentTurnID` | string | Parent's turn ID |
 
 ---

--- a/docs/src/plugins/agents/subagent.md
+++ b/docs/src/plugins/agents/subagent.md
@@ -82,7 +82,7 @@ When a subagent runs, these events are emitted:
 | `subagent.spawn` | SpawnID, Task, ParentTurnID | Subagent created |
 | `subagent.started` | SpawnID, Task, ParentTurnID | Subagent begins execution |
 | `subagent.iteration` | SpawnID, Iteration, Content | Each reasoning iteration |
-| `subagent.complete` | SpawnID, Result, TokensUsed | Subagent finished |
+| `subagent.complete` | SpawnID, Result, TokensUsed, CostUSD | Subagent finished |
 
 ## Example
 

--- a/docs/src/plugins/providers/anthropic.md
+++ b/docs/src/plugins/providers/anthropic.md
@@ -15,6 +15,7 @@ The Anthropic provider calls the Claude API via direct HTTP requests — no SDK 
 |-----|------|---------|-------------|
 | `api_key_env` | string | `ANTHROPIC_API_KEY` | Name of the environment variable containing the API key |
 | `debug` | bool | `false` | Log raw request/response bodies to the session plugin directory |
+| `pricing` | map | (embedded defaults) | Per-model pricing overrides. Keys are model IDs, values have `input_per_million` and `output_per_million` (USD) |
 
 ## Events
 
@@ -59,6 +60,20 @@ Subscribes to `cancel.active` at priority 5. When a cancellation arrives, the in
 ### Retry Logic
 
 Transient errors (rate limits, server errors) are retried with exponential backoff.
+
+### Cost Tracking
+
+The provider computes `CostUSD` on every `llm.response` using per-model pricing rates. Embedded defaults cover common Claude models. Override via config for enterprise pricing tiers or new models:
+
+```yaml
+nexus.llm.anthropic:
+  pricing:
+    claude-sonnet-4-6-20250514:
+      input_per_million: 3.0
+      output_per_million: 15.0
+```
+
+Config overrides are merged with embedded defaults — only override the models you need to change. Cost is accumulated into `SessionMeta.CostUSD` by the engine.
 
 ### Debug Mode
 

--- a/docs/src/plugins/providers/openai.md
+++ b/docs/src/plugins/providers/openai.md
@@ -16,6 +16,7 @@ The OpenAI provider calls the Chat Completions API via direct HTTP requests — 
 | `api_key_env` | string | `OPENAI_API_KEY` | Name of the environment variable containing the API key |
 | `base_url` | string | `https://api.openai.com/v1/chat/completions` | API endpoint URL (override for Azure, local proxies, etc.) |
 | `debug` | bool | `false` | Log raw request/response bodies to the session plugin directory |
+| `pricing` | map | (embedded defaults) | Per-model pricing overrides. Keys are model IDs, values have `input_per_million` and `output_per_million` (USD) |
 
 ## Events
 
@@ -60,6 +61,20 @@ Subscribes to `cancel.active` at priority 5. When a cancellation arrives, the in
 ### Retry Logic
 
 Transient errors (rate limits, server errors) are retried with exponential backoff.
+
+### Cost Tracking
+
+The provider computes `CostUSD` on every `llm.response` using per-model pricing rates. Embedded defaults cover common OpenAI models. Override via config for enterprise pricing tiers or new models:
+
+```yaml
+nexus.llm.openai:
+  pricing:
+    gpt-4o:
+      input_per_million: 2.50
+      output_per_million: 10.0
+```
+
+Config overrides are merged with embedded defaults — only override the models you need to change. Cost is accumulated into `SessionMeta.CostUSD` by the engine.
 
 ### Debug Mode
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -139,7 +139,7 @@ func (e *Engine) Boot(ctx context.Context) error {
 		}
 	}
 
-	// Track token usage from LLM responses.
+	// Track token usage and cost from LLM responses.
 	e.runUnsubs = append(e.runUnsubs, e.Bus.Subscribe("llm.response", func(event Event[any]) {
 		resp, ok := event.Payload.(events.LLMResponse)
 		if !ok || e.Session == nil {
@@ -150,6 +150,9 @@ func (e *Engine) Boot(ctx context.Context) error {
 			return
 		}
 		meta.TokensUsed += resp.Usage.TotalTokens
+		meta.PromptTokensUsed += resp.Usage.PromptTokens
+		meta.CompletionTokensUsed += resp.Usage.CompletionTokens
+		meta.CostUSD += resp.CostUSD
 		_ = e.Session.SaveMeta(meta)
 	}))
 

--- a/pkg/engine/session.go
+++ b/pkg/engine/session.go
@@ -45,15 +45,18 @@ type SessionWorkspace struct {
 
 // SessionMeta holds metadata about a session.
 type SessionMeta struct {
-	ID         string            `json:"id"`
-	StartedAt  time.Time         `json:"started_at"`
-	EndedAt    *time.Time        `json:"ended_at,omitempty"`
-	Profile    string            `json:"profile"`
-	Plugins    []string          `json:"plugins"`
-	Labels     map[string]string `json:"labels"`
-	TurnCount  int               `json:"turn_count"`
-	TokensUsed int               `json:"tokens_used"`
-	Status     string            `json:"status"`
+	ID                   string            `json:"id"`
+	StartedAt            time.Time         `json:"started_at"`
+	EndedAt              *time.Time        `json:"ended_at,omitempty"`
+	Profile              string            `json:"profile"`
+	Plugins              []string          `json:"plugins"`
+	Labels               map[string]string `json:"labels"`
+	TurnCount            int               `json:"turn_count"`
+	TokensUsed           int               `json:"tokens_used"`
+	PromptTokensUsed     int               `json:"prompt_tokens_used"`
+	CompletionTokensUsed int               `json:"completion_tokens_used"`
+	CostUSD              float64           `json:"cost_usd"`
+	Status               string            `json:"status"`
 }
 
 // NewSessionWorkspace creates a new session workspace with the standard directory structure.

--- a/pkg/events/agent.go
+++ b/pkg/events/agent.go
@@ -59,5 +59,6 @@ type SubagentComplete struct {
 	Error        string
 	Iterations   int
 	TokensUsed   Usage
+	CostUSD      float64
 	ParentTurnID string
 }

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -54,6 +54,7 @@ type LLMResponse struct {
 	Content      string
 	ToolCalls    []ToolCallRequest
 	Usage        Usage
+	CostUSD      float64 // provider-computed cost for this request
 	Model        string
 	FinishReason string
 	Metadata     map[string]any

--- a/plugins/agents/subagent/plugin.go
+++ b/plugins/agents/subagent/plugin.go
@@ -251,6 +251,7 @@ func (p *Plugin) runSubagent(spawnID, task, systemPrompt, modelRole, parentTurnI
 	})
 
 	var totalUsage events.Usage
+	var totalCost float64
 
 	// Iteration limiting now handled by nexus.gate.endless_loop plugin.
 	for iteration := 0; ; iteration++ {
@@ -294,12 +295,13 @@ func (p *Plugin) runSubagent(spawnID, task, systemPrompt, modelRole, parentTurnI
 		select {
 		case resp = <-respCh:
 		default:
-			return p.completeSubagent(spawnID, parentTurnID, "", "no LLM response received", iteration, totalUsage)
+			return p.completeSubagent(spawnID, parentTurnID, "", "no LLM response received", iteration, totalUsage, totalCost)
 		}
 
 		totalUsage.PromptTokens += resp.Usage.PromptTokens
 		totalUsage.CompletionTokens += resp.Usage.CompletionTokens
 		totalUsage.TotalTokens += resp.Usage.TotalTokens
+		totalCost += resp.CostUSD
 
 		// Add assistant message to history.
 		history = append(history, events.Message{
@@ -318,7 +320,7 @@ func (p *Plugin) runSubagent(spawnID, task, systemPrompt, modelRole, parentTurnI
 
 		// No tool calls means we're done.
 		if len(resp.ToolCalls) == 0 {
-			return p.completeSubagent(spawnID, parentTurnID, resp.Content, "", iteration+1, totalUsage)
+			return p.completeSubagent(spawnID, parentTurnID, resp.Content, "", iteration+1, totalUsage, totalCost)
 		}
 
 		// Execute tool calls and collect results.
@@ -344,7 +346,7 @@ func (p *Plugin) runSubagent(spawnID, task, systemPrompt, modelRole, parentTurnI
 			break
 		}
 	}
-	return p.completeSubagent(spawnID, parentTurnID, lastContent, "loop terminated", 0, totalUsage)
+	return p.completeSubagent(spawnID, parentTurnID, lastContent, "loop terminated", 0, totalUsage, totalCost)
 }
 
 // executeToolCalls invokes tools and collects their results.
@@ -408,13 +410,14 @@ func (p *Plugin) executeToolCalls(toolCalls []events.ToolCallRequest, turnID str
 	return results
 }
 
-func (p *Plugin) completeSubagent(spawnID, parentTurnID, result, errMsg string, iterations int, usage events.Usage) events.SubagentComplete {
+func (p *Plugin) completeSubagent(spawnID, parentTurnID, result, errMsg string, iterations int, usage events.Usage, costUSD float64) events.SubagentComplete {
 	complete := events.SubagentComplete{
 		SpawnID:      spawnID,
 		Result:       result,
 		Error:        errMsg,
 		Iterations:   iterations,
 		TokensUsed:   usage,
+		CostUSD:      costUSD,
 		ParentTurnID: parentTurnID,
 	}
 
@@ -423,6 +426,7 @@ func (p *Plugin) completeSubagent(spawnID, parentTurnID, result, errMsg string, 
 		"spawn_id", spawnID,
 		"iterations", iterations,
 		"tokens", usage.TotalTokens,
+		"cost_usd", costUSD,
 		"has_error", errMsg != "",
 	)
 

--- a/plugins/observe/otel/attributes.go
+++ b/plugins/observe/otel/attributes.go
@@ -67,6 +67,7 @@ func llmResponseAttrs(r *events.LLMResponse) []attribute.KeyValue {
 		attribute.Int("nexus.llm.usage.prompt_tokens", r.Usage.PromptTokens),
 		attribute.Int("nexus.llm.usage.completion_tokens", r.Usage.CompletionTokens),
 		attribute.Int("nexus.llm.usage.total_tokens", r.Usage.TotalTokens),
+		attribute.Float64("nexus.llm.cost_usd", r.CostUSD),
 		attribute.Int("nexus.llm.tool_call_count", len(r.ToolCalls)),
 	}
 }
@@ -123,7 +124,10 @@ func subagentCompleteAttrs(s *events.SubagentComplete) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String("nexus.subagent.spawn_id", s.SpawnID),
 		attribute.Int("nexus.subagent.iterations", s.Iterations),
+		attribute.Int("nexus.subagent.usage.prompt_tokens", s.TokensUsed.PromptTokens),
+		attribute.Int("nexus.subagent.usage.completion_tokens", s.TokensUsed.CompletionTokens),
 		attribute.Int("nexus.subagent.usage.total_tokens", s.TokensUsed.TotalTokens),
+		attribute.Float64("nexus.subagent.cost_usd", s.CostUSD),
 		attribute.String("nexus.subagent.parent_turn_id", s.ParentTurnID),
 		attribute.Bool("nexus.subagent.has_error", s.Error != ""),
 	}

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -25,6 +25,30 @@ const (
 	apiURL     = "https://api.anthropic.com/v1/messages"
 )
 
+// modelPricing holds per-model token rates in USD per million tokens.
+type modelPricing struct {
+	InputPerMillion  float64
+	OutputPerMillion float64
+}
+
+// defaultPricing is the embedded fallback pricing table. Updated via patch
+// releases when providers change rates. Config override always wins.
+var defaultPricing = map[string]modelPricing{
+	"claude-sonnet-4-6-20250514":    {InputPerMillion: 3.0, OutputPerMillion: 15.0},
+	"claude-sonnet-4-5-20250514":    {InputPerMillion: 3.0, OutputPerMillion: 15.0},
+	"claude-haiku-4-5-20251001":     {InputPerMillion: 0.80, OutputPerMillion: 4.0},
+	"claude-opus-4-6-20250602":      {InputPerMillion: 15.0, OutputPerMillion: 75.0},
+	"claude-3-5-sonnet-20241022":    {InputPerMillion: 3.0, OutputPerMillion: 15.0},
+	"claude-3-5-haiku-20241022":     {InputPerMillion: 0.80, OutputPerMillion: 4.0},
+	"claude-3-opus-20240229":        {InputPerMillion: 15.0, OutputPerMillion: 75.0},
+}
+
+// calculateCost computes the USD cost for a single LLM call.
+func calculateCost(usage events.Usage, rates modelPricing) float64 {
+	return float64(usage.PromptTokens)/1_000_000*rates.InputPerMillion +
+		float64(usage.CompletionTokens)/1_000_000*rates.OutputPerMillion
+}
+
 // Plugin implements the Anthropic LLM provider.
 type Plugin struct {
 	bus     engine.EventBus
@@ -38,6 +62,7 @@ type Plugin struct {
 	unsubs  []func()
 	debug   bool
 	retry   retryConfig
+	pricing map[string]modelPricing // merged: config overrides + embedded defaults
 
 	mu                 sync.Mutex
 	currentRequestMeta map[string]any
@@ -83,6 +108,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		Timeout: 5 * time.Minute,
 	}
 	p.prompts = ctx.Prompts
+
+	p.pricing = parsePricingConfig(ctx.Config)
 
 	p.retry = parseRetryConfig(ctx.Config)
 	if p.retry.Enabled {
@@ -454,14 +481,17 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 		}
 	}
 
+	usage := events.Usage{
+		PromptTokens:     apiResp.Usage.InputTokens,
+		CompletionTokens: apiResp.Usage.OutputTokens,
+		TotalTokens:      apiResp.Usage.InputTokens + apiResp.Usage.OutputTokens,
+	}
+
 	return events.LLMResponse{
-		Content:   content.String(),
-		ToolCalls: toolCalls,
-		Usage: events.Usage{
-			PromptTokens:     apiResp.Usage.InputTokens,
-			CompletionTokens: apiResp.Usage.OutputTokens,
-			TotalTokens:      apiResp.Usage.InputTokens + apiResp.Usage.OutputTokens,
-		},
+		Content:      content.String(),
+		ToolCalls:    toolCalls,
+		Usage:        usage,
+		CostUSD:      p.costForModel(apiResp.Model, usage),
 		Model:        apiResp.Model,
 		FinishReason: apiResp.StopReason,
 	}
@@ -519,15 +549,18 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		p.emitError(fmt.Errorf("anthropic: stream read error: %w", err))
 	}
 
+	// Build final usage.
+	finalUsage := events.Usage{
+		PromptTokens:     usage.InputTokens,
+		CompletionTokens: usage.OutputTokens,
+		TotalTokens:      usage.InputTokens + usage.OutputTokens,
+	}
+
 	// Emit stream end.
 	_ = p.bus.Emit("llm.stream.end", events.StreamEnd{
 		TurnID:       turnID,
 		FinishReason: finishReason,
-		Usage: events.Usage{
-			PromptTokens:     usage.InputTokens,
-			CompletionTokens: usage.OutputTokens,
-			TotalTokens:      usage.InputTokens + usage.OutputTokens,
-		},
+		Usage:        finalUsage,
 	})
 
 	// Also emit the complete llm.response for downstream consumers.
@@ -536,13 +569,10 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 	p.mu.Unlock()
 
 	_ = p.bus.Emit("llm.response", events.LLMResponse{
-		Content:   fullContent.String(),
-		ToolCalls: toolCalls,
-		Usage: events.Usage{
-			PromptTokens:     usage.InputTokens,
-			CompletionTokens: usage.OutputTokens,
-			TotalTokens:      usage.InputTokens + usage.OutputTokens,
-		},
+		Content:      fullContent.String(),
+		ToolCalls:    toolCalls,
+		Usage:        finalUsage,
+		CostUSD:      p.costForModel(model, finalUsage),
 		Model:        model,
 		FinishReason: finishReason,
 		Metadata:     meta,
@@ -665,6 +695,50 @@ func (p *Plugin) processSSEEvent(
 			p.emitError(fmt.Errorf("anthropic: stream error: %s: %s", data.Error.Type, data.Error.Message))
 		}
 	}
+}
+
+// parsePricingConfig merges embedded defaults with optional config overrides.
+// Config format:
+//
+//	pricing:
+//	  claude-sonnet-4-6-20250514:
+//	    input_per_million: 3.0
+//	    output_per_million: 15.0
+func parsePricingConfig(cfg map[string]any) map[string]modelPricing {
+	merged := make(map[string]modelPricing, len(defaultPricing))
+	for k, v := range defaultPricing {
+		merged[k] = v
+	}
+
+	raw, ok := cfg["pricing"].(map[string]any)
+	if !ok {
+		return merged
+	}
+
+	for model, val := range raw {
+		entry, ok := val.(map[string]any)
+		if !ok {
+			continue
+		}
+		p := merged[model]
+		if v, ok := entry["input_per_million"].(float64); ok {
+			p.InputPerMillion = v
+		}
+		if v, ok := entry["output_per_million"].(float64); ok {
+			p.OutputPerMillion = v
+		}
+		merged[model] = p
+	}
+
+	return merged
+}
+
+// costForModel returns the USD cost for a response from the given model.
+func (p *Plugin) costForModel(model string, usage events.Usage) float64 {
+	if rates, ok := p.pricing[model]; ok {
+		return calculateCost(usage, rates)
+	}
+	return 0
 }
 
 func (p *Plugin) debugLog(label string, data []byte) {

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -25,6 +25,34 @@ const (
 	apiURL     = "https://api.openai.com/v1/chat/completions"
 )
 
+// modelPricing holds per-model token rates in USD per million tokens.
+type modelPricing struct {
+	InputPerMillion  float64
+	OutputPerMillion float64
+}
+
+// defaultPricing is the embedded fallback pricing table. Updated via patch
+// releases when providers change rates. Config override always wins.
+var defaultPricing = map[string]modelPricing{
+	"gpt-4o":            {InputPerMillion: 2.50, OutputPerMillion: 10.0},
+	"gpt-4o-mini":       {InputPerMillion: 0.15, OutputPerMillion: 0.60},
+	"gpt-4o-2024-11-20": {InputPerMillion: 2.50, OutputPerMillion: 10.0},
+	"gpt-4-turbo":       {InputPerMillion: 10.0, OutputPerMillion: 30.0},
+	"gpt-4":             {InputPerMillion: 30.0, OutputPerMillion: 60.0},
+	"gpt-3.5-turbo":     {InputPerMillion: 0.50, OutputPerMillion: 1.50},
+	"o1":                {InputPerMillion: 15.0, OutputPerMillion: 60.0},
+	"o1-mini":           {InputPerMillion: 3.0, OutputPerMillion: 12.0},
+	"o3":                {InputPerMillion: 10.0, OutputPerMillion: 40.0},
+	"o3-mini":           {InputPerMillion: 1.10, OutputPerMillion: 4.40},
+	"o4-mini":           {InputPerMillion: 1.10, OutputPerMillion: 4.40},
+}
+
+// calculateCost computes the USD cost for a single LLM call.
+func calculateCost(usage events.Usage, rates modelPricing) float64 {
+	return float64(usage.PromptTokens)/1_000_000*rates.InputPerMillion +
+		float64(usage.CompletionTokens)/1_000_000*rates.OutputPerMillion
+}
+
 // Plugin implements the OpenAI LLM provider.
 type Plugin struct {
 	bus     engine.EventBus
@@ -39,6 +67,7 @@ type Plugin struct {
 	unsubs  []func()
 	debug   bool
 	retry   retryConfig
+	pricing map[string]modelPricing // merged: config overrides + embedded defaults
 
 	mu                 sync.Mutex
 	currentRequestMeta map[string]any
@@ -90,6 +119,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		Timeout: 5 * time.Minute,
 	}
 	p.prompts = ctx.Prompts
+
+	p.pricing = parsePricingConfig(ctx.Config)
 
 	p.retry = parseRetryConfig(ctx.Config)
 	if p.retry.Enabled {
@@ -451,13 +482,16 @@ func (p *Plugin) handleSyncResponse(body io.Reader) {
 }
 
 func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
+	usage := events.Usage{
+		PromptTokens:     apiResp.Usage.PromptTokens,
+		CompletionTokens: apiResp.Usage.CompletionTokens,
+		TotalTokens:      apiResp.Usage.TotalTokens,
+	}
+
 	resp := events.LLMResponse{
-		Model: apiResp.Model,
-		Usage: events.Usage{
-			PromptTokens:     apiResp.Usage.PromptTokens,
-			CompletionTokens: apiResp.Usage.CompletionTokens,
-			TotalTokens:      apiResp.Usage.TotalTokens,
-		},
+		Model:   apiResp.Model,
+		Usage:   usage,
+		CostUSD: p.costForModel(apiResp.Model, usage),
 	}
 
 	if len(apiResp.Choices) > 0 {
@@ -619,15 +653,18 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		chunkIndex++
 	}
 
+	// Build final usage.
+	finalUsage := events.Usage{
+		PromptTokens:     usage.PromptTokens,
+		CompletionTokens: usage.CompletionTokens,
+		TotalTokens:      usage.TotalTokens,
+	}
+
 	// Emit stream end.
 	_ = p.bus.Emit("llm.stream.end", events.StreamEnd{
 		TurnID:       turnID,
 		FinishReason: finishReason,
-		Usage: events.Usage{
-			PromptTokens:     usage.PromptTokens,
-			CompletionTokens: usage.CompletionTokens,
-			TotalTokens:      usage.TotalTokens,
-		},
+		Usage:        finalUsage,
 	})
 
 	// Also emit the complete llm.response for downstream consumers.
@@ -636,17 +673,52 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 	p.mu.Unlock()
 
 	_ = p.bus.Emit("llm.response", events.LLMResponse{
-		Content:   fullContent.String(),
-		ToolCalls: toolCalls,
-		Usage: events.Usage{
-			PromptTokens:     usage.PromptTokens,
-			CompletionTokens: usage.CompletionTokens,
-			TotalTokens:      usage.TotalTokens,
-		},
+		Content:      fullContent.String(),
+		ToolCalls:    toolCalls,
+		Usage:        finalUsage,
+		CostUSD:      p.costForModel(model, finalUsage),
 		Model:        model,
 		FinishReason: finishReason,
 		Metadata:     meta,
 	})
+}
+
+// parsePricingConfig merges embedded defaults with optional config overrides.
+func parsePricingConfig(cfg map[string]any) map[string]modelPricing {
+	merged := make(map[string]modelPricing, len(defaultPricing))
+	for k, v := range defaultPricing {
+		merged[k] = v
+	}
+
+	raw, ok := cfg["pricing"].(map[string]any)
+	if !ok {
+		return merged
+	}
+
+	for model, val := range raw {
+		entry, ok := val.(map[string]any)
+		if !ok {
+			continue
+		}
+		p := merged[model]
+		if v, ok := entry["input_per_million"].(float64); ok {
+			p.InputPerMillion = v
+		}
+		if v, ok := entry["output_per_million"].(float64); ok {
+			p.OutputPerMillion = v
+		}
+		merged[model] = p
+	}
+
+	return merged
+}
+
+// costForModel returns the USD cost for a response from the given model.
+func (p *Plugin) costForModel(model string, usage events.Usage) float64 {
+	if rates, ok := p.pricing[model]; ok {
+		return calculateCost(usage, rates)
+	}
+	return 0
 }
 
 func (p *Plugin) debugLog(label string, data []byte) {


### PR DESCRIPTION
## Summary
- Providers compute `CostUSD` per LLM request using embedded default pricing tables with YAML config overrides
- `SessionMeta` tracks `PromptTokensUsed`, `CompletionTokensUsed`, and `CostUSD` alongside existing `TokensUsed`
- Desktop matcher sources cost from provider response instead of hardcoded constants
- OTel spans include `nexus.llm.cost_usd` and `nexus.subagent.cost_usd` attributes
- Subagent plugin accumulates cost across iterations into `SubagentComplete.CostUSD`

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all existing tests green)
- [x] Verify session metadata JSON includes new fields after a real session
- [x] Verify config pricing override merges correctly with embedded defaults
- [x] Verify unknown models return `CostUSD: 0` (no panic)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)