### PR TITLE
feat: add long-term memory plugin (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ plugins/
   io/browser/            # Browser IO (HTTP/WS transport for the Nexus web UI)
   io/wails/              # Wails-native transport for desktop shells (config-driven event bridging)
   memory/conversation/   # Conversation history persistence
+  memory/longterm/       # Cross-session long-term memory (file-per-entry, YAML frontmatter + markdown)
   observe/logger/        # Structured event logging
   observe/otel/          # OpenTelemetry trace export via OTLP
   observe/thinking/      # Thinking step persistence (JSONL)

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -19,6 +19,7 @@ import (
 	tuiplugin "github.com/frankbardon/nexus/plugins/io/tui"
 	compactionplugin "github.com/frankbardon/nexus/plugins/memory/compaction"
 	"github.com/frankbardon/nexus/plugins/memory/conversation"
+	longtermplugin "github.com/frankbardon/nexus/plugins/memory/longterm"
 	"github.com/frankbardon/nexus/plugins/observe/logger"
 	otelplugin "github.com/frankbardon/nexus/plugins/observe/otel"
 	thinkingplugin "github.com/frankbardon/nexus/plugins/observe/thinking"
@@ -87,6 +88,7 @@ func main() {
 	eng.Registry.Register("nexus.tool.ask", ask.New)
 	eng.Registry.Register("nexus.memory.conversation", conversation.New)
 	eng.Registry.Register("nexus.memory.compaction", compactionplugin.New)
+	eng.Registry.Register("nexus.memory.longterm", longtermplugin.New)
 	eng.Registry.Register("nexus.io.tui", tuiplugin.New)
 	eng.Registry.Register("nexus.io.browser", browserplugin.New)
 	eng.Registry.Register("nexus.io.oneshot", oneshotplugin.New)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -42,6 +42,7 @@
 - [Memory](./plugins/memory/index.md)
   - [Conversation History](./plugins/memory/conversation.md)
   - [Context Compaction](./plugins/memory/compaction.md)
+  - [Long-Term Memory](./plugins/memory/longterm.md)
 - [I/O Interfaces](./plugins/io/index.md)
   - [Terminal UI (TUI)](./plugins/io/tui.md)
   - [Browser UI](./plugins/io/browser.md)

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -387,6 +387,35 @@ Certain metadata keys carry special meaning:
 | `MessageCount` | int | Messages after compaction |
 | `PrevCount` | int | Messages before compaction |
 
+### Long-Term Memory Events
+
+| Event Type | Payload | Description |
+|------------|---------|-------------|
+| `memory.longterm.loaded` | `LongTermMemoryLoaded` | Memory index injected into system prompt |
+| `memory.longterm.store` | `LongTermMemoryStoreRequest` | Write or update a memory entry |
+| `memory.longterm.stored` | `LongTermMemoryStored` | Write confirmed |
+| `memory.longterm.read` | `LongTermMemoryReadRequest` | Read a memory entry |
+| `memory.longterm.result` | `LongTermMemoryReadResult` | Read result |
+| `memory.longterm.delete` | `LongTermMemoryDeleteRequest` | Delete a memory entry |
+| `memory.longterm.deleted` | `LongTermMemoryDeleted` | Delete confirmed |
+| `memory.longterm.list` | `LongTermMemoryQuery` | List/filter memories |
+| `memory.longterm.list.result` | `LongTermMemoryListResult` | List result |
+
+**LongTermMemoryIndex**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Key` | string | Memory key |
+| `Preview` | string | First line of content |
+| `Tags` | map[string]string | Key-value tags |
+| `Updated` | time.Time | Last update timestamp |
+
+**LongTermMemoryStoreRequest**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Key` | string | Memory key |
+| `Content` | string | Markdown content |
+| `Tags` | map[string]string | Optional tags |
+
 ---
 
 ## Plan Events

--- a/docs/src/plugins/memory/index.md
+++ b/docs/src/plugins/memory/index.md
@@ -8,9 +8,12 @@ Memory plugins manage conversation history and context window size. They persist
 |--------|----|---------|
 | [Conversation History](./conversation.md) | `nexus.memory.conversation` | Stores and replays conversation messages |
 | [Context Compaction](./compaction.md) | `nexus.memory.compaction` | Summarizes old messages to free context space |
+| [Long-Term Memory](./longterm.md) | `nexus.memory.longterm` | Cross-session memory persistence via file-per-entry storage |
 
 ## How Memory Works
 
 Memory plugins listen to I/O and tool events, building up a message buffer. When agents need conversation history (for `llm.request`), they query the memory plugin via `memory.query`.
 
 The compaction plugin monitors context size and automatically summarizes older messages when thresholds are exceeded, replacing them with a condensed summary.
+
+The long-term memory plugin operates independently from conversation memory. It persists knowledge across sessions as individual markdown files with YAML frontmatter, providing LLM tools for CRUD and injecting a lightweight memory index into the system prompt.

--- a/docs/src/plugins/memory/longterm.md
+++ b/docs/src/plugins/memory/longterm.md
@@ -1,0 +1,91 @@
+# Long-Term Memory
+
+**Plugin ID:** `nexus.memory.longterm`
+
+Cross-session memory persistence. Stores memories as individual markdown files with YAML frontmatter. Injects a lightweight index into the system prompt on boot and provides LLM tools for CRUD operations.
+
+## Configuration
+
+```yaml
+nexus.memory.longterm:
+  # Where memory files live.
+  # Default: ~/.nexus/memory/ (CLI), ~/.nexus/agents/<agentID>/memory/ (desktop shell)
+  path: "~/.nexus/memory/"
+
+  # Memory scope: "agent" (per-agent isolated), "global" (shared across agents), or "both".
+  # "both" merges global + agent-scoped memories, with agent-scoped taking precedence on key conflicts.
+  scope: "agent"
+
+  # Inject memory index (titles + keys + tags) into system prompt on session start.
+  auto_load: true
+
+  # Instructions injected into system prompt telling the LLM when to
+  # proactively save memories mid-session. Empty string = only save when
+  # user explicitly asks (tools still available, just no prompting to use them).
+  auto_save_instructions: ""
+
+  # Agent ID for agent-scoped storage (injected automatically by desktop shell).
+  agent_id: ""
+```
+
+### Scope Resolution
+
+| `scope` value | Paths searched | Write target |
+|---|---|---|
+| `agent` | `~/.nexus/agents/<agentID>/memory/` | agent path |
+| `global` | `~/.nexus/memory/` | global path |
+| `both` | global path + agent path (agent wins conflicts) | agent path |
+
+For CLI mode (no agent ID), `agent` and `global` behave identically --- both use the configured `path`.
+
+## Storage Format
+
+One file per memory entry at `<memory_path>/<key>.md`:
+
+```markdown
+---
+key: user_prefers_dark_mode
+tags:
+  category: preference
+  domain: ui
+created: 2026-04-10T14:30:00Z
+updated: 2026-04-15T09:00:00Z
+source_session: 20260410-143022
+---
+
+User strongly prefers dark mode across all interfaces.
+They mentioned eye strain with light themes during long sessions.
+```
+
+Keys are sanitized to lowercase alphanumeric with hyphens and underscores, truncated to 128 characters.
+
+## LLM Tools
+
+| Tool | Parameters | Description |
+|---|---|---|
+| `memory_write` | `key` (string), `content` (string), `tags` (map, optional) | Create or update a memory entry |
+| `memory_read` | `key` (string) | Read full content of a memory entry |
+| `memory_list` | `tags` (map, optional) | List all memories, optionally filtered by tags (AND semantics) |
+| `memory_delete` | `key` (string) | Delete a memory entry |
+
+## System Prompt Injection
+
+When `auto_load: true`, the plugin injects a section listing all available memories with key, tags, and a one-line preview (first line of content). Full content is retrieved on demand via `memory_read`.
+
+## Events
+
+| Event | Direction | Payload |
+|---|---|---|
+| `memory.longterm.loaded` | Plugin -> bus | `LongTermMemoryLoaded` |
+| `memory.longterm.store` | Any -> plugin | `LongTermMemoryStoreRequest` |
+| `memory.longterm.stored` | Plugin -> bus | `LongTermMemoryStored` |
+| `memory.longterm.read` | Any -> plugin | `LongTermMemoryReadRequest` |
+| `memory.longterm.result` | Plugin -> bus | `LongTermMemoryReadResult` |
+| `memory.longterm.delete` | Any -> plugin | `LongTermMemoryDeleteRequest` |
+| `memory.longterm.deleted` | Plugin -> bus | `LongTermMemoryDeleted` |
+| `memory.longterm.list` | Any -> plugin | `LongTermMemoryQuery` |
+| `memory.longterm.list.result` | Plugin -> bus | `LongTermMemoryListResult` |
+
+## Desktop Shell Integration
+
+The desktop shell automatically injects `agent_id` into the plugin config before boot, enabling per-agent memory isolation without manual configuration.

--- a/pkg/desktop/shell.go
+++ b/pkg/desktop/shell.go
@@ -70,6 +70,8 @@ const (
 	AgentStatusBooting AgentStatus = "booting"
 	AgentStatusRunning AgentStatus = "running"
 	AgentStatusError   AgentStatus = "error"
+
+	longtermPluginID = "nexus.memory.longterm"
 )
 
 // AgentInfo is the serializable projection of Agent for the frontend.
@@ -387,6 +389,12 @@ func (s *Shell) bootAgent(agentID, recallSessionID string) error {
 
 	if recallSessionID != "" {
 		eng.RecallSessionID = recallSessionID
+	}
+
+	// Inject agent_id into longterm memory plugin config so it can
+	// resolve agent-scoped storage paths.
+	if cfg := eng.Config.Plugins.Configs[longtermPluginID]; cfg != nil {
+		cfg["agent_id"] = agentID
 	}
 
 	// Create the nexus.io.wails plugin instance so we can inject the

--- a/pkg/events/memory.go
+++ b/pkg/events/memory.go
@@ -1,5 +1,7 @@
 package events
 
+import "time"
+
 // MemoryEntry represents a single memory record.
 type MemoryEntry struct {
 	Key       string
@@ -20,6 +22,79 @@ type MemoryResult struct {
 	Entries []MemoryEntry
 	Query   string
 }
+
+// --- Long-term memory events ---
+
+// LongTermMemoryIndex is a lightweight reference to a memory entry.
+type LongTermMemoryIndex struct {
+	Key     string            `json:"key"`
+	Preview string            `json:"preview"` // first line of content
+	Tags    map[string]string `json:"tags"`
+	Updated time.Time         `json:"updated"`
+}
+
+// LongTermMemoryEntry is a full memory record.
+type LongTermMemoryEntry struct {
+	Key           string            `json:"key"`
+	Content       string            `json:"content"`
+	Tags          map[string]string `json:"tags"`
+	Created       time.Time         `json:"created"`
+	Updated       time.Time         `json:"updated"`
+	SourceSession string            `json:"source_session"`
+}
+
+// LongTermMemoryLoaded signals that the memory index has been injected into
+// the system prompt.
+type LongTermMemoryLoaded struct {
+	Entries []LongTermMemoryIndex `json:"entries"`
+	Scope   string                `json:"scope"` // "agent", "global", or "both"
+}
+
+// LongTermMemoryStoreRequest is a request to write or update a memory entry.
+type LongTermMemoryStoreRequest struct {
+	Key     string            `json:"key"`
+	Content string            `json:"content"`
+	Tags    map[string]string `json:"tags,omitempty"`
+}
+
+// LongTermMemoryStored confirms a memory entry was written.
+type LongTermMemoryStored struct {
+	Key string `json:"key"`
+}
+
+// LongTermMemoryReadRequest is a request to read a memory entry by key.
+type LongTermMemoryReadRequest struct {
+	Key string `json:"key"`
+}
+
+// LongTermMemoryReadResult carries the full content of a memory entry.
+type LongTermMemoryReadResult struct {
+	Key     string            `json:"key"`
+	Content string            `json:"content"`
+	Tags    map[string]string `json:"tags"`
+}
+
+// LongTermMemoryDeleteRequest is a request to delete a memory entry.
+type LongTermMemoryDeleteRequest struct {
+	Key string `json:"key"`
+}
+
+// LongTermMemoryDeleted confirms a memory entry was deleted.
+type LongTermMemoryDeleted struct {
+	Key string `json:"key"`
+}
+
+// LongTermMemoryQuery is a request to list or filter memories.
+type LongTermMemoryQuery struct {
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// LongTermMemoryListResult carries filtered memory index entries.
+type LongTermMemoryListResult struct {
+	Entries []LongTermMemoryIndex `json:"entries"`
+}
+
+// --- Compaction events ---
 
 // CompactionTriggered signals that context compaction is starting.
 type CompactionTriggered struct {

--- a/plugins/memory/longterm/plugin.go
+++ b/plugins/memory/longterm/plugin.go
@@ -1,0 +1,624 @@
+package longterm
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID   = "nexus.memory.longterm"
+	pluginName = "Long-Term Memory"
+	version    = "0.1.0"
+)
+
+// Plugin provides cross-session memory persistence via file-per-entry storage
+// with YAML frontmatter and markdown content.
+type Plugin struct {
+	bus     engine.EventBus
+	logger  *slog.Logger
+	session *engine.SessionWorkspace
+	prompts *engine.PromptRegistry
+
+	mu     sync.RWMutex
+	index  []events.LongTermMemoryIndex
+	unsubs []func()
+
+	// Config.
+	paths                []string // resolved memory directories (1 or 2 for "both" scope)
+	writePath            string   // directory for writes
+	scope                string   // "agent", "global", or "both"
+	autoLoad             bool
+	autoSaveInstructions string
+	agentID              string
+}
+
+// New creates a new long-term memory plugin.
+func New() engine.Plugin {
+	return &Plugin{
+		scope:    "agent",
+		autoLoad: true,
+	}
+}
+
+func (p *Plugin) ID() string             { return pluginID }
+func (p *Plugin) Name() string           { return pluginName }
+func (p *Plugin) Version() string        { return version }
+func (p *Plugin) Dependencies() []string { return nil }
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "memory.longterm.store", Priority: 50},
+		{EventType: "memory.longterm.read", Priority: 50},
+		{EventType: "memory.longterm.delete", Priority: 50},
+		{EventType: "memory.longterm.list", Priority: 50},
+		{EventType: "tool.invoke", Priority: 50},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"memory.longterm.loaded",
+		"memory.longterm.stored",
+		"memory.longterm.result",
+		"memory.longterm.deleted",
+		"memory.longterm.list.result",
+		"tool.register",
+		"before:tool.result",
+		"tool.result",
+	}
+}
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+	p.session = ctx.Session
+	p.prompts = ctx.Prompts
+
+	// Parse config.
+	if v, ok := ctx.Config["scope"].(string); ok {
+		p.scope = v
+	}
+	if v, ok := ctx.Config["auto_load"].(bool); ok {
+		p.autoLoad = v
+	}
+	if v, ok := ctx.Config["auto_save_instructions"].(string); ok {
+		p.autoSaveInstructions = v
+	}
+	if v, ok := ctx.Config["agent_id"].(string); ok {
+		p.agentID = v
+	}
+
+	// Resolve storage paths based on scope.
+	basePath := "~/.nexus/memory/"
+	if v, ok := ctx.Config["path"].(string); ok {
+		basePath = v
+	}
+	basePath = expandHome(basePath)
+
+	switch p.scope {
+	case "global":
+		p.paths = []string{basePath}
+		p.writePath = basePath
+	case "both":
+		agentPath := p.agentMemoryPath()
+		p.paths = []string{basePath, agentPath}
+		p.writePath = agentPath
+	default: // "agent"
+		if p.agentID != "" {
+			agentPath := p.agentMemoryPath()
+			p.paths = []string{agentPath}
+			p.writePath = agentPath
+		} else {
+			p.paths = []string{basePath}
+			p.writePath = basePath
+		}
+	}
+
+	// Ensure write directory exists.
+	if err := os.MkdirAll(p.writePath, 0o755); err != nil {
+		return fmt.Errorf("longterm: creating memory directory %s: %w", p.writePath, err)
+	}
+
+	// Subscribe to events.
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("memory.longterm.store", p.handleStore, engine.WithPriority(50), engine.WithSource(pluginID)),
+		p.bus.Subscribe("memory.longterm.read", p.handleRead, engine.WithPriority(50), engine.WithSource(pluginID)),
+		p.bus.Subscribe("memory.longterm.delete", p.handleDelete, engine.WithPriority(50), engine.WithSource(pluginID)),
+		p.bus.Subscribe("memory.longterm.list", p.handleList, engine.WithPriority(50), engine.WithSource(pluginID)),
+		p.bus.Subscribe("tool.invoke", p.handleToolInvoke, engine.WithPriority(50), engine.WithSource(pluginID)),
+	)
+
+	// Register system prompt section.
+	if p.autoLoad && p.prompts != nil {
+		p.prompts.Register(pluginID, 40, p.buildPromptSection)
+	}
+
+	p.logger.Info("long-term memory plugin initialized",
+		"scope", p.scope,
+		"write_path", p.writePath,
+		"paths", p.paths,
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error {
+	// Register LLM tools.
+	tools := []events.ToolDef{
+		{
+			Name:        "memory_write",
+			Description: "Create or update a long-term memory entry that persists across sessions.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"key": map[string]any{
+						"type":        "string",
+						"description": "Unique identifier for the memory (alphanumeric, hyphens, underscores)",
+					},
+					"content": map[string]any{
+						"type":        "string",
+						"description": "The memory content (markdown)",
+					},
+					"tags": map[string]any{
+						"type":        "object",
+						"description": "Optional key-value tags for categorization and filtering",
+						"additionalProperties": map[string]any{"type": "string"},
+					},
+				},
+				"required": []string{"key", "content"},
+			},
+		},
+		{
+			Name:        "memory_read",
+			Description: "Read the full content of a long-term memory entry by key.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"key": map[string]any{
+						"type":        "string",
+						"description": "The memory key to read",
+					},
+				},
+				"required": []string{"key"},
+			},
+		},
+		{
+			Name:        "memory_list",
+			Description: "List all long-term memories, optionally filtered by tags.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tags": map[string]any{
+						"type":        "object",
+						"description": "Optional tag filters (AND semantics — all must match)",
+						"additionalProperties": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "memory_delete",
+			Description: "Delete a long-term memory entry by key.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"key": map[string]any{
+						"type":        "string",
+						"description": "The memory key to delete",
+					},
+				},
+				"required": []string{"key"},
+			},
+		},
+	}
+
+	for _, tool := range tools {
+		_ = p.bus.Emit("tool.register", tool)
+	}
+
+	// Load index and emit loaded event.
+	if err := p.loadIndex(); err != nil {
+		p.logger.Warn("failed to load memory index", "error", err)
+	}
+
+	return nil
+}
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	if p.prompts != nil {
+		p.prompts.Unregister(pluginID)
+	}
+	return nil
+}
+
+// --- Index loading ---
+
+func (p *Plugin) loadIndex() error {
+	var merged []events.LongTermMemoryIndex
+	seen := make(map[string]bool)
+
+	// Read paths in reverse so later paths (agent-scoped) win on conflict.
+	for i := len(p.paths) - 1; i >= 0; i-- {
+		entries, err := list(p.paths[i], nil)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if !seen[e.Key] {
+				seen[e.Key] = true
+				merged = append(merged, e)
+			}
+		}
+	}
+
+	p.mu.Lock()
+	p.index = merged
+	p.mu.Unlock()
+
+	_ = p.bus.Emit("memory.longterm.loaded", events.LongTermMemoryLoaded{
+		Entries: merged,
+		Scope:   p.scope,
+	})
+
+	p.logger.Info("memory index loaded", "count", len(merged))
+	return nil
+}
+
+// --- System prompt injection ---
+
+func (p *Plugin) buildPromptSection() string {
+	p.mu.RLock()
+	idx := p.index
+	p.mu.RUnlock()
+
+	if len(idx) == 0 && p.autoSaveInstructions == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Long-Term Memory\n\n")
+
+	if len(idx) > 0 {
+		b.WriteString("You have access to memories from previous sessions. Use memory_read to retrieve full details.\n\n")
+		b.WriteString("Available memories:\n")
+		for _, e := range idx {
+			b.WriteString("- ")
+			b.WriteString(e.Key)
+			if len(e.Tags) > 0 {
+				b.WriteString(" [")
+				first := true
+				for k, v := range e.Tags {
+					if !first {
+						b.WriteString(", ")
+					}
+					b.WriteString(k)
+					b.WriteString(":")
+					b.WriteString(v)
+					first = false
+				}
+				b.WriteString("]")
+			}
+			b.WriteString(" — ")
+			b.WriteString(e.Preview)
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString("No memories stored yet. Use memory_write to save information for future sessions.\n")
+	}
+
+	if p.autoSaveInstructions != "" {
+		b.WriteString("\n")
+		b.WriteString(p.autoSaveInstructions)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// --- Event handlers (bus events) ---
+
+func (p *Plugin) handleStore(e engine.Event[any]) {
+	req, ok := e.Payload.(events.LongTermMemoryStoreRequest)
+	if !ok {
+		return
+	}
+	p.doStore(req)
+}
+
+func (p *Plugin) handleRead(e engine.Event[any]) {
+	req, ok := e.Payload.(events.LongTermMemoryReadRequest)
+	if !ok {
+		return
+	}
+	p.doRead(req.Key)
+}
+
+func (p *Plugin) handleDelete(e engine.Event[any]) {
+	req, ok := e.Payload.(events.LongTermMemoryDeleteRequest)
+	if !ok {
+		return
+	}
+	p.doDelete(req.Key)
+}
+
+func (p *Plugin) handleList(e engine.Event[any]) {
+	req, ok := e.Payload.(events.LongTermMemoryQuery)
+	if !ok {
+		return
+	}
+	p.doList(req.Tags)
+}
+
+// --- Tool invocation handler ---
+
+func (p *Plugin) handleToolInvoke(e engine.Event[any]) {
+	tc, ok := e.Payload.(events.ToolCall)
+	if !ok {
+		return
+	}
+
+	switch tc.Name {
+	case "memory_write":
+		p.handleMemoryWrite(tc)
+	case "memory_read":
+		p.handleMemoryRead(tc)
+	case "memory_list":
+		p.handleMemoryList(tc)
+	case "memory_delete":
+		p.handleMemoryDelete(tc)
+	}
+}
+
+func (p *Plugin) handleMemoryWrite(tc events.ToolCall) {
+	key, _ := tc.Arguments["key"].(string)
+	content, _ := tc.Arguments["content"].(string)
+
+	if key == "" || content == "" {
+		p.emitToolResult(tc, "", "key and content are required")
+		return
+	}
+
+	tags := extractStringMap(tc.Arguments["tags"])
+
+	req := events.LongTermMemoryStoreRequest{
+		Key:     key,
+		Content: content,
+		Tags:    tags,
+	}
+
+	if err := p.doStore(req); err != nil {
+		p.emitToolResult(tc, "", err.Error())
+		return
+	}
+
+	p.emitToolResult(tc, fmt.Sprintf("Memory '%s' saved successfully.", sanitizeKey(key)), "")
+}
+
+func (p *Plugin) handleMemoryRead(tc events.ToolCall) {
+	key, _ := tc.Arguments["key"].(string)
+	if key == "" {
+		p.emitToolResult(tc, "", "key is required")
+		return
+	}
+
+	entry, err := p.doRead(key)
+	if err != nil {
+		p.emitToolResult(tc, "", err.Error())
+		return
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Key: %s\n", entry.Key)
+	if len(entry.Tags) > 0 {
+		b.WriteString("Tags: ")
+		first := true
+		for k, v := range entry.Tags {
+			if !first {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(&b, "%s:%s", k, v)
+			first = false
+		}
+		b.WriteString("\n")
+	}
+	fmt.Fprintf(&b, "Created: %s\n", entry.Created.Format("2006-01-02 15:04:05 UTC"))
+	fmt.Fprintf(&b, "Updated: %s\n\n", entry.Updated.Format("2006-01-02 15:04:05 UTC"))
+	b.WriteString(entry.Content)
+
+	p.emitToolResult(tc, b.String(), "")
+}
+
+func (p *Plugin) handleMemoryList(tc events.ToolCall) {
+	tags := extractStringMap(tc.Arguments["tags"])
+
+	entries, err := p.doList(tags)
+	if err != nil {
+		p.emitToolResult(tc, "", err.Error())
+		return
+	}
+
+	if len(entries) == 0 {
+		p.emitToolResult(tc, "No memories found.", "")
+		return
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Found %d memories:\n\n", len(entries))
+	for _, e := range entries {
+		fmt.Fprintf(&b, "- %s", e.Key)
+		if len(e.Tags) > 0 {
+			b.WriteString(" [")
+			first := true
+			for k, v := range e.Tags {
+				if !first {
+					b.WriteString(", ")
+				}
+				fmt.Fprintf(&b, "%s:%s", k, v)
+				first = false
+			}
+			b.WriteString("]")
+		}
+		fmt.Fprintf(&b, " — %s\n", e.Preview)
+	}
+
+	p.emitToolResult(tc, b.String(), "")
+}
+
+func (p *Plugin) handleMemoryDelete(tc events.ToolCall) {
+	key, _ := tc.Arguments["key"].(string)
+	if key == "" {
+		p.emitToolResult(tc, "", "key is required")
+		return
+	}
+
+	if err := p.doDelete(key); err != nil {
+		p.emitToolResult(tc, "", err.Error())
+		return
+	}
+
+	p.emitToolResult(tc, fmt.Sprintf("Memory '%s' deleted.", sanitizeKey(key)), "")
+}
+
+// --- Core operations ---
+
+func (p *Plugin) doStore(req events.LongTermMemoryStoreRequest) error {
+	sessionID := ""
+	if p.session != nil {
+		sessionID = p.session.ID
+	}
+
+	if err := store(p.writePath, req, sessionID); err != nil {
+		p.logger.Error("failed to store memory", "key", req.Key, "error", err)
+		return err
+	}
+
+	// Refresh index.
+	_ = p.loadIndex()
+
+	_ = p.bus.Emit("memory.longterm.stored", events.LongTermMemoryStored{
+		Key: sanitizeKey(req.Key),
+	})
+
+	p.logger.Info("memory stored", "key", sanitizeKey(req.Key))
+	return nil
+}
+
+func (p *Plugin) doRead(key string) (*events.LongTermMemoryEntry, error) {
+	// Search all paths, agent-scoped first.
+	for i := len(p.paths) - 1; i >= 0; i-- {
+		entry, err := read(p.paths[i], key)
+		if err == nil {
+			_ = p.bus.Emit("memory.longterm.result", events.LongTermMemoryReadResult{
+				Key:     entry.Key,
+				Content: entry.Content,
+				Tags:    entry.Tags,
+			})
+			return entry, nil
+		}
+	}
+	return nil, fmt.Errorf("memory '%s' not found", sanitizeKey(key))
+}
+
+func (p *Plugin) doDelete(key string) error {
+	if err := remove(p.writePath, key); err != nil {
+		p.logger.Error("failed to delete memory", "key", key, "error", err)
+		return err
+	}
+
+	_ = p.loadIndex()
+
+	_ = p.bus.Emit("memory.longterm.deleted", events.LongTermMemoryDeleted{
+		Key: sanitizeKey(key),
+	})
+
+	p.logger.Info("memory deleted", "key", sanitizeKey(key))
+	return nil
+}
+
+func (p *Plugin) doList(tags map[string]string) ([]events.LongTermMemoryIndex, error) {
+	var merged []events.LongTermMemoryIndex
+	seen := make(map[string]bool)
+
+	for i := len(p.paths) - 1; i >= 0; i-- {
+		entries, err := list(p.paths[i], tags)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if !seen[e.Key] {
+				seen[e.Key] = true
+				merged = append(merged, e)
+			}
+		}
+	}
+
+	_ = p.bus.Emit("memory.longterm.list.result", events.LongTermMemoryListResult{
+		Entries: merged,
+	})
+
+	return merged, nil
+}
+
+// --- Helpers ---
+
+func (p *Plugin) emitToolResult(tc events.ToolCall, output, errMsg string) {
+	result := events.ToolResult{
+		ID:     tc.ID,
+		Name:   tc.Name,
+		Output: output,
+		Error:  errMsg,
+		TurnID: tc.TurnID,
+	}
+	if veto, err := p.bus.EmitVetoable("before:tool.result", &result); err == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
+}
+
+func (p *Plugin) agentMemoryPath() string {
+	if p.agentID != "" {
+		return expandHome(filepath.Join("~/.nexus/agents", p.agentID, "memory"))
+	}
+	return expandHome("~/.nexus/memory/")
+}
+
+// expandHome replaces a leading ~ with the user's home directory.
+func expandHome(path string) string {
+	if strings.HasPrefix(path, "~/") || path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[1:])
+	}
+	return path
+}
+
+// extractStringMap extracts a map[string]string from an any value (JSON-decoded map).
+func extractStringMap(v any) map[string]string {
+	if v == nil {
+		return nil
+	}
+	raw, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	result := make(map[string]string, len(raw))
+	for k, val := range raw {
+		if s, ok := val.(string); ok {
+			result[k] = s
+		}
+	}
+	return result
+}

--- a/plugins/memory/longterm/storage.go
+++ b/plugins/memory/longterm/storage.go
@@ -1,0 +1,196 @@
+package longterm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/events"
+	"gopkg.in/yaml.v3"
+)
+
+// memoryFile is the on-disk representation with YAML frontmatter.
+type memoryFile struct {
+	Key           string            `yaml:"key"`
+	Tags          map[string]string `yaml:"tags,omitempty"`
+	Created       time.Time         `yaml:"created"`
+	Updated       time.Time         `yaml:"updated"`
+	SourceSession string            `yaml:"source_session"`
+}
+
+var keySanitizer = regexp.MustCompile(`[^a-z0-9_-]`)
+
+// sanitizeKey normalises a key into a safe filename stem.
+func sanitizeKey(raw string) string {
+	k := strings.ToLower(strings.TrimSpace(raw))
+	k = keySanitizer.ReplaceAllString(k, "_")
+	if len(k) > 128 {
+		k = k[:128]
+	}
+	return k
+}
+
+// store persists a memory entry to disk, creating or updating the file.
+func store(dir string, req events.LongTermMemoryStoreRequest, sessionID string) error {
+	key := sanitizeKey(req.Key)
+	if key == "" {
+		return fmt.Errorf("longterm: empty key after sanitization")
+	}
+
+	path := filepath.Join(dir, key+".md")
+
+	now := time.Now().UTC()
+	mf := memoryFile{
+		Key:           key,
+		Tags:          req.Tags,
+		Updated:       now,
+		SourceSession: sessionID,
+	}
+
+	// Preserve original created timestamp on update.
+	if existing, err := readFile(path); err == nil {
+		mf.Created = existing.Created
+	} else {
+		mf.Created = now
+	}
+
+	return writeFile(path, mf, req.Content)
+}
+
+// read loads a memory entry from disk by key.
+func read(dir, key string) (*events.LongTermMemoryEntry, error) {
+	key = sanitizeKey(key)
+	path := filepath.Join(dir, key+".md")
+	return readFile(path)
+}
+
+// remove deletes a memory file by key.
+func remove(dir, key string) error {
+	key = sanitizeKey(key)
+	path := filepath.Join(dir, key+".md")
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("longterm: deleting %s: %w", path, err)
+	}
+	return nil
+}
+
+// list scans a directory for memory files and returns index entries,
+// optionally filtered by tags (AND semantics).
+func list(dir string, tags map[string]string) ([]events.LongTermMemoryIndex, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("longterm: listing %s: %w", dir, err)
+	}
+
+	var result []events.LongTermMemoryIndex
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		mem, err := readFile(path)
+		if err != nil {
+			continue // skip malformed files
+		}
+
+		if !matchTags(mem.Tags, tags) {
+			continue
+		}
+
+		result = append(result, events.LongTermMemoryIndex{
+			Key:     mem.Key,
+			Preview: firstLine(mem.Content),
+			Tags:    mem.Tags,
+			Updated: mem.Updated,
+		})
+	}
+
+	return result, nil
+}
+
+// readFile parses a single memory markdown file.
+func readFile(path string) (*events.LongTermMemoryEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	content := string(data)
+	var mf memoryFile
+	var body string
+
+	if strings.HasPrefix(strings.TrimSpace(content), "---") {
+		trimmed := strings.TrimSpace(content)
+		rest := trimmed[3:]
+		endIdx := strings.Index(rest, "\n---")
+		if endIdx == -1 {
+			body = content
+		} else {
+			frontmatter := rest[:endIdx]
+			body = strings.TrimSpace(rest[endIdx+4:])
+			if err := yaml.Unmarshal([]byte(frontmatter), &mf); err != nil {
+				return nil, fmt.Errorf("longterm: parsing frontmatter in %s: %w", path, err)
+			}
+		}
+	} else {
+		body = content
+	}
+
+	return &events.LongTermMemoryEntry{
+		Key:           mf.Key,
+		Content:       body,
+		Tags:          mf.Tags,
+		Created:       mf.Created,
+		Updated:       mf.Updated,
+		SourceSession: mf.SourceSession,
+	}, nil
+}
+
+// writeFile serialises a memory entry as YAML frontmatter + markdown body.
+func writeFile(path string, mf memoryFile, body string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("longterm: creating directory: %w", err)
+	}
+
+	fm, err := yaml.Marshal(mf)
+	if err != nil {
+		return fmt.Errorf("longterm: marshalling frontmatter: %w", err)
+	}
+
+	var buf strings.Builder
+	buf.WriteString("---\n")
+	buf.Write(fm)
+	buf.WriteString("---\n\n")
+	buf.WriteString(body)
+	buf.WriteString("\n")
+
+	return os.WriteFile(path, []byte(buf.String()), 0o644)
+}
+
+// matchTags returns true if entry tags contain all filter tags (AND).
+func matchTags(entryTags, filter map[string]string) bool {
+	for k, v := range filter {
+		if entryTags[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// firstLine returns the first non-empty line of s.
+func firstLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- New `nexus.memory.longterm` plugin — cross-session memory via file-per-entry markdown storage with YAML frontmatter
- 4 LLM tools: `memory_write`, `memory_read`, `memory_list`, `memory_delete`
- Auto-injects lightweight memory index into system prompt (keys + tags + preview)
- Scope modes: `agent` (per-agent isolated), `global` (shared), `both` (merged, agent wins conflicts)
- Desktop shell injects `agent_id` into plugin config for automatic per-agent isolation
- `auto_save_instructions` config for guiding proactive mid-session saves

## Deferred

- `auto_save` (session-end LLM request) — needs careful shutdown orchestration, planned for v2

## Files

- `plugins/memory/longterm/plugin.go` — plugin lifecycle, tool handlers, prompt injection
- `plugins/memory/longterm/storage.go` — file I/O, YAML frontmatter parsing, key sanitization
- `pkg/events/memory.go` — 9 new event structs
- `pkg/desktop/shell.go` — agent_id injection
- `cmd/nexus/main.go` — plugin registration
- `docs/` — plugin docs, event reference, SUMMARY

## Test plan

- [x] Build passes (`make build`)
- [x] All tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Add `nexus.memory.longterm` to a profile's `plugins.active`, verify tools register
- [x] Use `memory_write` to create entry, verify file on disk at `~/.nexus/memory/`
- [x] Use `memory_read` to retrieve it
- [x] Use `memory_list` with tag filter
- [x] Use `memory_delete`, verify file removed
- [x] New session sees memory index in system prompt
- [x] Desktop shell: verify agent-scoped path resolution with `agent_id`

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)