### PR TITLE
feat: add provider fallback with config-driven fallback chains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ plugins/
   apps/helloworld/       # Built-in hello-world placeholder agent
   providers/anthropic/   # Claude LLM provider (direct HTTP, no SDK; supports api_key config or api_key_env env var)
   providers/openai/      # OpenAI LLM provider (direct HTTP, no SDK; supports api_key config, api_key_env env var, base_url override)
+  providers/fallback/    # Automatic provider failover coordinator (config-driven fallback chains in core.models)
   tools/shell/           # Sandboxed shell execution
   tools/fileio/          # File read/write with base dir restriction
   io/tui/                # Terminal UI

--- a/configs/browser-planned.yaml
+++ b/configs/browser-planned.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/browser.yaml
+++ b/configs/browser.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/coding.yaml
+++ b/configs/coding.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/oneshot-planned.yaml
+++ b/configs/oneshot-planned.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/oneshot.yaml
+++ b/configs/oneshot.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/orchestrator.yaml
+++ b/configs/orchestrator.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/planexec.yaml
+++ b/configs/planexec.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/planned-static.yaml
+++ b/configs/planned-static.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/planned.yaml
+++ b/configs/planned.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/research.yaml
+++ b/configs/research.yaml
@@ -16,6 +16,16 @@ core:
       provider: nexus.llm.anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
+    # Provider fallback: use an ordered array instead of a single map.
+    # First entry = primary, subsequent entries tried on failure.
+    # Requires nexus.provider.fallback in plugins.active + both provider plugins.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/configs/test-fallback.yaml
+++ b/configs/test-fallback.yaml
@@ -1,0 +1,71 @@
+# Test: Provider fallback chain — primary fails, fallback handles request
+# Validates: fallback chain config parsing, fallback plugin boot, event flow
+#
+# Run (automated):
+#   go test -tags integration ./tests/integration/ -run TestFallback
+#
+# Prerequisites:
+#   - ANTHROPIC_API_KEY set in env or .env (used by fallback provider)
+#
+# What to test:
+#   1. Boot: Engine starts with fallback chain config + nexus.provider.fallback active.
+#   2. Config parsing: balanced role parsed as 2-entry chain (OpenAI primary, Anthropic fallback).
+#   3. Fallback trigger: Primary (OpenAI with bad base_url) fails → fallback to Anthropic.
+#   4. User notification: provider.fallback event emitted.
+#   5. Response: Agent responds using the fallback provider.
+#
+# Design: OpenAI primary deliberately misconfigured (bogus base_url).
+# Anthropic fallback has valid API key. Fallback plugin intercepts the
+# OpenAI error and re-emits to Anthropic.
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: balanced
+    balanced:
+      - provider: nexus.llm.openai
+        model: gpt-4o
+        max_tokens: 4096
+      - provider: nexus.llm.anthropic
+        model: claude-haiku-4-5-20251001
+        max_tokens: 4096
+  sessions:
+    root: ~/.nexus/sessions
+    retention: 30d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.test
+    - nexus.llm.anthropic
+    - nexus.llm.openai
+    - nexus.provider.fallback
+    - nexus.agent.react
+    - nexus.memory.conversation
+    - nexus.observe.logger
+
+  nexus.io.test:
+    inputs:
+      - "Hello, respond with exactly: fallback works"
+    input_delay: 500ms
+    approval_mode: approve
+    timeout: 30s
+
+  nexus.llm.anthropic:
+    api_key_env: ANTHROPIC_API_KEY
+
+  nexus.llm.openai:
+    api_key: "sk-bogus-key-that-will-fail"
+    base_url: "http://localhost:1/v1/chat/completions"
+
+  nexus.agent.react:
+    system_prompt: "You are a test assistant. Follow instructions exactly."
+
+  nexus.memory.conversation:
+    max_messages: 4
+    persist: false
+
+  nexus.observe.logger:
+    output: stderr
+    level: info

--- a/configs/test-mixed-providers.yaml
+++ b/configs/test-mixed-providers.yaml
@@ -41,6 +41,15 @@ core:
       provider: nexus.llm.openai
       model: gpt-4o-mini
       max_tokens: 4096
+    # Provider fallback: balanced with OpenAI fallback.
+    # Requires nexus.provider.fallback in plugins.active.
+    # balanced:
+    #   - provider: nexus.llm.anthropic
+    #     model: claude-sonnet-4-20250514
+    #     max_tokens: 8192
+    #   - provider: nexus.llm.openai
+    #     model: gpt-4o
+    #     max_tokens: 8192
   sessions:
     root: ~/.nexus/sessions
     retention: 30d

--- a/docs/src/architecture/models.md
+++ b/docs/src/architecture/models.md
@@ -54,6 +54,33 @@ config, found := models.Resolve("reasoning")
 3. If the role is not found but contains a hyphen (e.g., `claude-sonnet-4-20250514`), treat it as a raw model ID for backward compatibility
 4. Otherwise, return not found
 
+## Provider Fallback Chains
+
+Role values can be ordered arrays instead of single maps. First entry = primary, subsequent entries are tried in order when the primary fails with a non-retryable error or exhausts its retry budget.
+
+```yaml
+core:
+  models:
+    balanced:
+      - provider: nexus.llm.anthropic
+        model: claude-sonnet-4-20250514
+        max_tokens: 8192
+      - provider: nexus.llm.openai
+        model: gpt-4o
+        max_tokens: 8192
+    quick:
+      provider: nexus.llm.anthropic    # single entry = no fallback
+      model: claude-haiku-4-5-20251001
+```
+
+Single-map format is backward compatible — parsed as a chain of length 1.
+
+**Requires**: `nexus.provider.fallback` in `plugins.active` + both provider plugins active.
+
+**Trigger conditions**: Fallback occurs when a provider error is non-retryable (4xx except 429, auth failures), or when the provider's own retry logic (429, 5xx backoff) has exhausted `max_retries`.
+
+**Streaming partial failure**: If a provider fails mid-stream, the fallback plugin emits `io.output.clear` to wipe partial content, then `provider.fallback` notification, then re-emits `llm.request` targeting the next provider. Clean restart — no spliced output from two models.
+
 ## API
 
 ```go
@@ -64,9 +91,11 @@ type ModelConfig struct {
 }
 
 type ModelRegistry struct {
-    Resolve(role string) (ModelConfig, bool)  // Look up a role
-    Default() ModelConfig                      // Get the default model
-    Roles() []string                           // List all registered role names
+    Resolve(role string) (ModelConfig, bool)       // Primary model for a role (index 0)
+    Fallback(role string, attempt int) (ModelConfig, bool) // Model at chain index
+    ChainLen(role string) int                      // Number of entries in fallback chain
+    Default() ModelConfig                          // Get the default model
+    Roles() []string                               // List all registered role names
 }
 ```
 

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -38,6 +38,11 @@ Complete reference for all event types in Nexus, organized by domain.
 | `Source` | string | Plugin that reported the error |
 | `Err` | error | The error |
 | `Fatal` | bool | Whether this should trigger shutdown |
+| `Retryable` | bool | Whether this error class is retryable (429, 5xx) |
+| `RetriesExhausted` | bool | Provider's own retry logic gave up |
+| `RequestMeta` | map[string]any | Echo of LLMRequest.Metadata for correlation |
+
+`core.error` is vetoable — providers emit `before:core.error` first. The fallback plugin can veto the error to suppress it and retry with an alternate provider.
 
 ---
 
@@ -49,6 +54,7 @@ Complete reference for all event types in Nexus, organized by domain.
 | `io.output` | `AgentOutput` | Agent produced output |
 | `io.output.stream` | `OutputChunk` | Streaming output chunk |
 | `io.output.stream.end` | `StreamRef` | Streaming complete |
+| `io.output.clear` | *(none)* | Clear partial streamed content (used by fallback) |
 | `io.status` | `StatusUpdate` | Agent state changed |
 | `io.approval.request` | `ApprovalRequest` | Approval needed for an action |
 | `io.approval.response` | `ApprovalResponse` | User responded to approval |
@@ -123,6 +129,27 @@ Complete reference for all event types in Nexus, organized by domain.
 |-------|------|-------------|
 | `PromptID` | string | Matches the request |
 | `Answer` | string | User's response |
+
+---
+
+## Provider Events
+
+| Event Type | Payload | Description |
+|------------|---------|-------------|
+| `provider.fallback` | `ProviderFallback` | Provider switch due to failure |
+
+### Payloads
+
+**ProviderFallback**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Role` | string | Model role being resolved |
+| `FailedProvider` | string | Plugin ID of the provider that failed |
+| `FailedModel` | string | Model that failed |
+| `Error` | string | Error description |
+| `NextProvider` | string | Plugin ID of the fallback provider |
+| `NextModel` | string | Model being tried next |
+| `Attempt` | int | 0-based index in the fallback chain |
 
 ---
 

--- a/docs/src/plugins/providers/fallback.md
+++ b/docs/src/plugins/providers/fallback.md
@@ -1,0 +1,80 @@
+# Provider Fallback
+
+**Plugin ID**: `nexus.provider.fallback`
+
+Automatic provider failover when the primary LLM provider returns a non-retryable error or exhausts its retry budget. Agents remain unaware — fallback is transparent at the provider layer.
+
+## Event Subscriptions
+
+| Event | Priority | Purpose |
+|-------|----------|---------|
+| `before:llm.request` | 3 | Inject fallback tracking metadata |
+| `before:core.error` | 5 | Intercept provider errors for fallback |
+
+## Event Emissions
+
+| Event | Payload | Purpose |
+|-------|---------|---------|
+| `io.output.clear` | *(none)* | Wipe partial streamed content from UI |
+| `provider.fallback` | `ProviderFallback` | Notify UI of provider switch |
+| `llm.request` | `LLMRequest` | Re-emit request targeting fallback provider |
+
+## Configuration
+
+No plugin-specific config. Fallback chains are defined in `core.models`:
+
+```yaml
+core:
+  models:
+    balanced:
+      - provider: nexus.llm.anthropic
+        model: claude-sonnet-4-20250514
+        max_tokens: 8192
+      - provider: nexus.llm.openai
+        model: gpt-4o
+        max_tokens: 8192
+
+plugins:
+  active:
+    - nexus.llm.anthropic
+    - nexus.llm.openai
+    - nexus.provider.fallback    # required for fallback to work
+```
+
+## Trigger Conditions
+
+Fallback occurs when:
+
+- **Non-retryable errors**: 4xx status codes (except 429), malformed responses, auth failures
+- **Retries exhausted**: Provider's own retry logic (429, 5xx backoff) has hit `max_retries` and given up
+
+Fallback does **not** occur for: cancellation, context deadline, or errors that the provider's built-in retry is still handling.
+
+## Streaming Partial Failure
+
+If a provider fails mid-stream:
+
+1. Emits `io.output.clear` to wipe partial streamed content from UI
+2. Emits `provider.fallback` notification so user sees "Switching to [provider]..."
+3. Re-emits `llm.request` targeting next provider in chain
+
+Clean restart — splicing output from two different models produces incoherent text.
+
+## What Stays Unchanged
+
+- **Agent plugins** — unaware of fallback. Emit `llm.request`, receive `llm.response`.
+- **Provider routing** — providers still check `cfg.Provider != pluginID` and skip non-matching requests.
+- **Single-provider configs** — backward compatible, parsed as chain of length 1.
+- **Gate plugins** — operate on `before:llm.request` as before. Fallback re-emits go through same gate checks.
+
+## Request Metadata
+
+The fallback plugin injects tracking metadata into requests for roles with fallback chains:
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `_fallback_id` | string | Unique ID for this fallback sequence |
+| `_fallback_attempt` | int | Current index in the chain (0 = primary) |
+| `_fallback_role` | string | Role name being resolved |
+
+This metadata flows through the provider and back via `ErrorInfo.RequestMeta` on failure, enabling the plugin to correlate errors with their original requests.

--- a/docs/src/plugins/providers/fallback.md
+++ b/docs/src/plugins/providers/fallback.md
@@ -76,5 +76,6 @@ The fallback plugin injects tracking metadata into requests for roles with fallb
 | `_fallback_id` | string | Unique ID for this fallback sequence |
 | `_fallback_attempt` | int | Current index in the chain (0 = primary) |
 | `_fallback_role` | string | Role name being resolved |
+| `_target_provider` | string | Plugin ID of the target provider (set on re-emission) |
 
 This metadata flows through the provider and back via `ErrorInfo.RequestMeta` on failure, enabling the plugin to correlate errors with their original requests.

--- a/docs/src/plugins/providers/index.md
+++ b/docs/src/plugins/providers/index.md
@@ -8,6 +8,7 @@ LLM provider plugins handle communication with AI model APIs. They receive `llm.
 |--------|----|---------|
 | [Anthropic](./anthropic.md) | `nexus.llm.anthropic` | Claude (direct HTTP, no SDK) |
 | [OpenAI](./openai.md) | `nexus.llm.openai` | GPT / o-series (direct HTTP, no SDK) |
+| [Fallback](./fallback.md) | `nexus.provider.fallback` | Automatic provider failover coordinator |
 
 ## Provider Architecture
 

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -37,6 +37,7 @@ import (
 
 	// Provider plugins.
 	"github.com/frankbardon/nexus/plugins/providers/anthropic"
+	fallbackplugin "github.com/frankbardon/nexus/plugins/providers/fallback"
 	"github.com/frankbardon/nexus/plugins/providers/openai"
 
 	// Skill plugins.
@@ -101,6 +102,7 @@ func RegisterAll(r *engine.PluginRegistry) {
 	// Providers
 	r.Register("nexus.llm.anthropic", anthropic.New)
 	r.Register("nexus.llm.openai", openai.New)
+	r.Register("nexus.provider.fallback", fallbackplugin.New)
 
 	// Skills
 	r.Register("nexus.skills", skills.New)

--- a/pkg/engine/bus.go
+++ b/pkg/engine/bus.go
@@ -145,7 +145,7 @@ func (b *eventBus) SubscribeAll(handler HandlerFunc) func() {
 func (b *eventBus) Emit(eventType string, payload any) error {
 	event := Event[any]{
 		Type:      eventType,
-		ID:        generateID(),
+		ID:        GenerateID(),
 		Timestamp: time.Now(),
 		Payload:   payload,
 	}
@@ -193,7 +193,7 @@ func (b *eventBus) EmitVetoable(eventType string, payload any) (VetoResult, erro
 	vp := &VetoablePayload{Original: payload}
 	event := Event[any]{
 		Type:      eventType,
-		ID:        generateID(),
+		ID:        GenerateID(),
 		Timestamp: time.Now(),
 		Payload:   vp,
 	}

--- a/pkg/engine/event.go
+++ b/pkg/engine/event.go
@@ -57,8 +57,8 @@ type VetoablePayload struct {
 	Veto     VetoResult // handlers set this to veto the action
 }
 
-// generateID produces a random hex-encoded UUID-style identifier.
-func generateID() string {
+// GenerateID produces a random hex-encoded UUID-style identifier.
+func GenerateID() string {
 	b := make([]byte, 16)
 	_, _ = rand.Read(b)
 	return fmt.Sprintf("%x", b)

--- a/pkg/engine/models.go
+++ b/pkg/engine/models.go
@@ -10,17 +10,38 @@ type ModelConfig struct {
 }
 
 // ModelRegistry resolves model role names to concrete model configurations.
+// Each role maps to an ordered chain of ModelConfigs. The first entry is the
+// primary; subsequent entries are fallbacks tried in order when the primary
+// (or prior fallback) fails with a non-retryable error or exhausts retries.
 type ModelRegistry struct {
-	roles       map[string]ModelConfig
+	chains      map[string][]ModelConfig
 	defaultRole string
 }
 
+// parseModelConfig extracts a ModelConfig from a raw config map.
+func parseModelConfig(m map[string]any) ModelConfig {
+	cfg := ModelConfig{}
+	if v, ok := m["provider"].(string); ok {
+		cfg.Provider = v
+	}
+	if v, ok := m["model"].(string); ok {
+		cfg.Model = v
+	}
+	if v, ok := m["max_tokens"].(int); ok {
+		cfg.MaxTokens = v
+	} else if v, ok := m["max_tokens"].(float64); ok {
+		cfg.MaxTokens = int(v)
+	}
+	return cfg
+}
+
 // NewModelRegistry builds a ModelRegistry from the core.models config section.
-// The modelsRaw map may contain string values (for "default" alias) and
-// map[string]any values (for role definitions).
+// The modelsRaw map may contain string values (for "default" alias),
+// map[string]any values (single model — backward compatible), and
+// []any values (ordered fallback chain).
 func NewModelRegistry(modelsRaw map[string]any) *ModelRegistry {
 	r := &ModelRegistry{
-		roles:       make(map[string]ModelConfig),
+		chains:      make(map[string][]ModelConfig),
 		defaultRole: "balanced",
 	}
 
@@ -36,31 +57,29 @@ func NewModelRegistry(modelsRaw map[string]any) *ModelRegistry {
 			continue
 		}
 
-		m, ok := val.(map[string]any)
-		if !ok {
-			continue
-		}
+		switch v := val.(type) {
+		case map[string]any:
+			// Single model config (backward compatible).
+			r.chains[key] = []ModelConfig{parseModelConfig(v)}
 
-		cfg := ModelConfig{}
-		if v, ok := m["provider"].(string); ok {
-			cfg.Provider = v
+		case []any:
+			// Ordered fallback chain.
+			chain := make([]ModelConfig, 0, len(v))
+			for _, entry := range v {
+				if m, ok := entry.(map[string]any); ok {
+					chain = append(chain, parseModelConfig(m))
+				}
+			}
+			if len(chain) > 0 {
+				r.chains[key] = chain
+			}
 		}
-		if v, ok := m["model"].(string); ok {
-			cfg.Model = v
-		}
-		if v, ok := m["max_tokens"].(int); ok {
-			cfg.MaxTokens = v
-		} else if v, ok := m["max_tokens"].(float64); ok {
-			cfg.MaxTokens = int(v)
-		}
-
-		r.roles[key] = cfg
 	}
 
 	return r
 }
 
-// Resolve returns the ModelConfig for the given role name.
+// Resolve returns the primary ModelConfig for the given role name (index 0).
 // If role is empty, the default role is used.
 // If the role is not found but looks like a raw model ID (contains "-"),
 // it is returned as-is with an empty provider for backward compatibility.
@@ -70,8 +89,8 @@ func (r *ModelRegistry) Resolve(role string) (ModelConfig, bool) {
 		role = r.defaultRole
 	}
 
-	if cfg, ok := r.roles[role]; ok {
-		return cfg, true
+	if chain, ok := r.chains[role]; ok && len(chain) > 0 {
+		return chain[0], true
 	}
 
 	// Backward compat: treat as raw model ID if it contains a hyphen.
@@ -82,6 +101,31 @@ func (r *ModelRegistry) Resolve(role string) (ModelConfig, bool) {
 	return ModelConfig{}, false
 }
 
+// Fallback returns the ModelConfig at the given attempt index in the fallback
+// chain for the specified role. Attempt 0 is the primary (same as Resolve).
+// Returns false if the chain is exhausted or the role doesn't exist.
+func (r *ModelRegistry) Fallback(role string, attempt int) (ModelConfig, bool) {
+	if role == "" {
+		role = r.defaultRole
+	}
+
+	chain, ok := r.chains[role]
+	if !ok || attempt < 0 || attempt >= len(chain) {
+		return ModelConfig{}, false
+	}
+
+	return chain[attempt], true
+}
+
+// ChainLen returns the number of entries in the fallback chain for a role.
+// Returns 0 if the role doesn't exist.
+func (r *ModelRegistry) ChainLen(role string) int {
+	if role == "" {
+		role = r.defaultRole
+	}
+	return len(r.chains[role])
+}
+
 // Default returns the ModelConfig for the default role.
 func (r *ModelRegistry) Default() ModelConfig {
 	cfg, _ := r.Resolve("")
@@ -90,8 +134,8 @@ func (r *ModelRegistry) Default() ModelConfig {
 
 // Roles returns the names of all registered roles.
 func (r *ModelRegistry) Roles() []string {
-	roles := make([]string, 0, len(r.roles))
-	for k := range r.roles {
+	roles := make([]string, 0, len(r.chains))
+	for k := range r.chains {
 		roles = append(roles, k)
 	}
 	return roles

--- a/pkg/engine/models_test.go
+++ b/pkg/engine/models_test.go
@@ -1,0 +1,183 @@
+package engine
+
+import (
+	"testing"
+)
+
+func TestNewModelRegistry_SingleMap(t *testing.T) {
+	raw := map[string]any{
+		"default": "balanced",
+		"balanced": map[string]any{
+			"provider":   "nexus.llm.anthropic",
+			"model":      "claude-sonnet-4-20250514",
+			"max_tokens": 8192,
+		},
+	}
+
+	r := NewModelRegistry(raw)
+
+	cfg, ok := r.Resolve("balanced")
+	if !ok {
+		t.Fatal("expected balanced role to exist")
+	}
+	if cfg.Provider != "nexus.llm.anthropic" {
+		t.Fatalf("expected provider nexus.llm.anthropic, got %s", cfg.Provider)
+	}
+	if cfg.Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("expected model claude-sonnet-4-20250514, got %s", cfg.Model)
+	}
+	if cfg.MaxTokens != 8192 {
+		t.Fatalf("expected max_tokens 8192, got %d", cfg.MaxTokens)
+	}
+}
+
+func TestNewModelRegistry_FallbackChain(t *testing.T) {
+	raw := map[string]any{
+		"default": "balanced",
+		"balanced": []any{
+			map[string]any{
+				"provider":   "nexus.llm.anthropic",
+				"model":      "claude-sonnet-4-20250514",
+				"max_tokens": 8192,
+			},
+			map[string]any{
+				"provider":   "nexus.llm.openai",
+				"model":      "gpt-4o",
+				"max_tokens": 8192,
+			},
+		},
+		"quick": map[string]any{
+			"provider": "nexus.llm.anthropic",
+			"model":    "claude-haiku-4-5-20251001",
+		},
+	}
+
+	r := NewModelRegistry(raw)
+
+	// Resolve returns primary (index 0).
+	cfg, ok := r.Resolve("balanced")
+	if !ok {
+		t.Fatal("expected balanced role to exist")
+	}
+	if cfg.Provider != "nexus.llm.anthropic" {
+		t.Fatalf("expected primary provider nexus.llm.anthropic, got %s", cfg.Provider)
+	}
+
+	// Fallback(0) == Resolve primary.
+	cfg0, ok := r.Fallback("balanced", 0)
+	if !ok || cfg0.Provider != "nexus.llm.anthropic" {
+		t.Fatalf("expected Fallback(0) = primary, got %+v", cfg0)
+	}
+
+	// Fallback(1) = OpenAI.
+	cfg1, ok := r.Fallback("balanced", 1)
+	if !ok {
+		t.Fatal("expected fallback at index 1")
+	}
+	if cfg1.Provider != "nexus.llm.openai" || cfg1.Model != "gpt-4o" {
+		t.Fatalf("expected openai/gpt-4o, got %s/%s", cfg1.Provider, cfg1.Model)
+	}
+
+	// Fallback(2) = exhausted.
+	_, ok = r.Fallback("balanced", 2)
+	if ok {
+		t.Fatal("expected chain exhausted at index 2")
+	}
+
+	// ChainLen.
+	if r.ChainLen("balanced") != 2 {
+		t.Fatalf("expected chain length 2, got %d", r.ChainLen("balanced"))
+	}
+
+	// Single-entry role has chain of 1.
+	if r.ChainLen("quick") != 1 {
+		t.Fatalf("expected chain length 1 for quick, got %d", r.ChainLen("quick"))
+	}
+}
+
+func TestNewModelRegistry_NilConfig(t *testing.T) {
+	r := NewModelRegistry(nil)
+
+	cfg := r.Default()
+	if cfg.Model != "" {
+		t.Fatalf("expected empty default model, got %s", cfg.Model)
+	}
+	if r.ChainLen("balanced") != 0 {
+		t.Fatalf("expected chain length 0, got %d", r.ChainLen("balanced"))
+	}
+}
+
+func TestModelRegistry_Fallback_NonexistentRole(t *testing.T) {
+	r := NewModelRegistry(map[string]any{
+		"balanced": map[string]any{
+			"provider": "nexus.llm.anthropic",
+			"model":    "claude-sonnet-4-20250514",
+		},
+	})
+
+	_, ok := r.Fallback("nonexistent", 0)
+	if ok {
+		t.Fatal("expected false for nonexistent role")
+	}
+}
+
+func TestModelRegistry_Fallback_NegativeIndex(t *testing.T) {
+	r := NewModelRegistry(map[string]any{
+		"balanced": []any{
+			map[string]any{
+				"provider": "nexus.llm.anthropic",
+				"model":    "claude-sonnet-4-20250514",
+			},
+		},
+	})
+
+	_, ok := r.Fallback("balanced", -1)
+	if ok {
+		t.Fatal("expected false for negative index")
+	}
+}
+
+func TestModelRegistry_BackwardCompatRawModel(t *testing.T) {
+	r := NewModelRegistry(map[string]any{})
+
+	cfg, ok := r.Resolve("claude-sonnet-4-20250514")
+	if !ok {
+		t.Fatal("expected raw model ID to resolve")
+	}
+	if cfg.Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("expected model passthrough, got %s", cfg.Model)
+	}
+
+	// Raw model IDs don't have fallback chains.
+	if r.ChainLen("claude-sonnet-4-20250514") != 0 {
+		t.Fatal("expected no chain for raw model ID")
+	}
+}
+
+func TestModelRegistry_FloatMaxTokens(t *testing.T) {
+	// YAML parsers sometimes decode integers as float64.
+	r := NewModelRegistry(map[string]any{
+		"balanced": map[string]any{
+			"provider":   "nexus.llm.anthropic",
+			"model":      "claude-sonnet-4-20250514",
+			"max_tokens": float64(8192),
+		},
+	})
+
+	cfg, _ := r.Resolve("balanced")
+	if cfg.MaxTokens != 8192 {
+		t.Fatalf("expected 8192 from float64, got %d", cfg.MaxTokens)
+	}
+}
+
+func TestModelRegistry_EmptyChain(t *testing.T) {
+	// Empty array should not create a role.
+	r := NewModelRegistry(map[string]any{
+		"balanced": []any{},
+	})
+
+	_, ok := r.Resolve("balanced")
+	if ok {
+		t.Fatal("expected empty chain to not create a role")
+	}
+}

--- a/pkg/engine/session.go
+++ b/pkg/engine/session.go
@@ -61,7 +61,7 @@ type SessionMeta struct {
 
 // NewSessionWorkspace creates a new session workspace with the standard directory structure.
 func NewSessionWorkspace(rootDir string, bus EventBus) (*SessionWorkspace, error) {
-	id := generateID()
+	id := GenerateID()
 	now := time.Now()
 	sessionDir := filepath.Join(rootDir, id)
 

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -16,9 +16,12 @@ type ShutdownReason struct {
 
 // ErrorInfo describes an error originating from a specific source.
 type ErrorInfo struct {
-	Source string // plugin ID
-	Err    error
-	Fatal  bool
+	Source           string         // plugin ID
+	Err              error
+	Fatal            bool
+	Retryable        bool           // whether this error class is retryable (429, 5xx)
+	RetriesExhausted bool           // provider's own retry logic gave up
+	RequestMeta      map[string]any // echo of LLMRequest.Metadata for correlation
 }
 
 // TickInfo carries periodic tick metadata.

--- a/pkg/events/provider.go
+++ b/pkg/events/provider.go
@@ -1,0 +1,13 @@
+package events
+
+// ProviderFallback notifies IO plugins and observers that a provider switch
+// occurred due to the primary provider failing.
+type ProviderFallback struct {
+	Role           string // model role being resolved (e.g. "balanced")
+	FailedProvider string // plugin ID of the provider that failed
+	FailedModel    string // model that failed
+	Error          string // error description
+	NextProvider   string // plugin ID of the fallback provider
+	NextModel      string // model being tried next
+	Attempt        int    // 0-based index in the fallback chain
+}

--- a/plugins/io/browser/plugin.go
+++ b/plugins/io/browser/plugin.go
@@ -44,6 +44,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "io.output", Priority: 50},
 		{EventType: "io.output.stream", Priority: 50},
 		{EventType: "io.output.stream.end", Priority: 50},
+		{EventType: "io.output.clear", Priority: 50},
 		{EventType: "io.status", Priority: 50},
 		{EventType: "io.approval.request", Priority: 50},
 		{EventType: "io.ask", Priority: 50},
@@ -51,6 +52,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "plan.approval.request", Priority: 50},
 		{EventType: "plan.created", Priority: 50},
 		{EventType: "agent.plan", Priority: 50},
+		{EventType: "provider.fallback", Priority: 50},
 		{EventType: "session.file.created", Priority: 50},
 		{EventType: "session.file.updated", Priority: 50},
 		{EventType: "io.history.replay", Priority: 50},
@@ -142,6 +144,7 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.bus.Subscribe("io.output", p.handleOutput, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.output.stream", p.handleStreamChunk, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.output.stream.end", p.handleStreamEnd, engine.WithSource(pluginID)),
+		p.bus.Subscribe("io.output.clear", p.handleOutputClear, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.status", p.handleStatus, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.approval.request", p.handleApprovalRequest, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.ask", p.handleAskUser, engine.WithSource(pluginID)),
@@ -149,6 +152,7 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.bus.Subscribe("plan.approval.request", p.handlePlanApprovalRequest, engine.WithSource(pluginID)),
 		p.bus.Subscribe("plan.created", p.handlePlanCreated, engine.WithSource(pluginID)),
 		p.bus.Subscribe("agent.plan", p.handleAgentPlan, engine.WithSource(pluginID)),
+		p.bus.Subscribe("provider.fallback", p.handleProviderFallback, engine.WithSource(pluginID)),
 		p.bus.Subscribe("session.file.created", p.handleFileChanged, engine.WithSource(pluginID)),
 		p.bus.Subscribe("session.file.updated", p.handleFileChanged, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.history.replay", p.handleHistoryReplay, engine.WithSource(pluginID)),
@@ -236,6 +240,18 @@ func (p *Plugin) handleStreamEnd(e engine.Event[any]) {
 		TurnID:   ref.TurnID,
 		Metadata: ref.Metadata,
 	})
+}
+
+func (p *Plugin) handleOutputClear(_ engine.Event[any]) {
+	_ = p.adapter.broadcast("output_clear", nil)
+}
+
+func (p *Plugin) handleProviderFallback(e engine.Event[any]) {
+	fb, ok := e.Payload.(events.ProviderFallback)
+	if !ok {
+		return
+	}
+	_ = p.adapter.broadcast("provider_fallback", fb)
 }
 
 func (p *Plugin) handleStatus(e engine.Event[any]) {

--- a/plugins/io/tui/chatview.go
+++ b/plugins/io/tui/chatview.go
@@ -116,6 +116,28 @@ func (c *chatView) EndStream() {
 	c.rebuildViewport()
 }
 
+// ClearStream removes the current partial stream message and any fully
+// rendered content from the active streaming turn. Used by provider
+// fallback to wipe incomplete output before retrying with another model.
+func (c *chatView) ClearStream() {
+	if c.streamTurnID == "" {
+		return
+	}
+	turnID := c.streamTurnID
+	c.streamTurnID = ""
+
+	// Remove the partial stream message for this turn.
+	filtered := c.messages[:0]
+	for _, msg := range c.messages {
+		if msg.TurnID == turnID && msg.IsStream {
+			continue
+		}
+		filtered = append(filtered, msg)
+	}
+	c.messages = filtered
+	c.rebuildViewport()
+}
+
 func (c *chatView) SetStatus(msg statusMsg) {
 	wasWorking := c.isWorking
 	c.status = msg

--- a/plugins/io/tui/messages.go
+++ b/plugins/io/tui/messages.go
@@ -62,5 +62,8 @@ type cancelCompleteMsg struct {
 	Resumable bool
 }
 
+// outputClearMsg tells the chat view to wipe the current partial stream.
+type outputClearMsg struct{}
+
 // quitMsg tells the program to exit.
 type quitMsg struct{}

--- a/plugins/io/tui/model.go
+++ b/plugins/io/tui/model.go
@@ -227,6 +227,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamChunkMsg:
 		m.chat.AppendToStream(msg.TurnID, msg.Content)
 
+	case outputClearMsg:
+		m.chat.ClearStream()
+
 	case streamEndMsg:
 		// Apply markdown to the completed stream message
 		if m.markdown != nil {

--- a/plugins/io/tui/plugin.go
+++ b/plugins/io/tui/plugin.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/frankbardon/nexus/pkg/engine"
@@ -34,6 +35,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "io.output", Priority: 50},
 		{EventType: "io.output.stream", Priority: 50},
 		{EventType: "io.output.stream.end", Priority: 50},
+		{EventType: "io.output.clear", Priority: 50},
 		{EventType: "io.status", Priority: 50},
 		{EventType: "io.approval.request", Priority: 50},
 		{EventType: "io.ask", Priority: 50},
@@ -41,6 +43,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "plan.approval.request", Priority: 50},
 		{EventType: "plan.created", Priority: 50},
 		{EventType: "agent.plan", Priority: 50},
+		{EventType: "provider.fallback", Priority: 50},
 		{EventType: "session.file.created", Priority: 50},
 		{EventType: "session.file.updated", Priority: 50},
 		{EventType: "io.history.replay", Priority: 50},
@@ -104,6 +107,7 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.bus.Subscribe("io.output", p.handleOutput, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.output.stream", p.handleStreamChunk, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.output.stream.end", p.handleStreamEnd, engine.WithSource(pluginID)),
+		p.bus.Subscribe("io.output.clear", p.handleOutputClear, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.status", p.handleStatus, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.approval.request", p.handleApprovalRequest, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.ask", p.handleAskUser, engine.WithSource(pluginID)),
@@ -111,6 +115,7 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.bus.Subscribe("plan.approval.request", p.handlePlanApprovalRequest, engine.WithSource(pluginID)),
 		p.bus.Subscribe("plan.created", p.handlePlanCreated, engine.WithSource(pluginID)),
 		p.bus.Subscribe("agent.plan", p.handleAgentPlan, engine.WithSource(pluginID)),
+		p.bus.Subscribe("provider.fallback", p.handleProviderFallback, engine.WithSource(pluginID)),
 		p.bus.Subscribe("session.file.created", p.handleFileChanged, engine.WithSource(pluginID)),
 		p.bus.Subscribe("session.file.updated", p.handleFileChanged, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.history.replay", p.handleHistoryReplay, engine.WithSource(pluginID)),
@@ -318,6 +323,25 @@ func (p *Plugin) handleCancelComplete(e engine.Event[any]) {
 	if cc.Resumable {
 		_ = p.adapter.SendCancelComplete(cc.TurnID, true)
 	}
+}
+
+func (p *Plugin) handleOutputClear(_ engine.Event[any]) {
+	if p.adapter.program != nil {
+		p.adapter.program.Send(outputClearMsg{})
+	}
+}
+
+func (p *Plugin) handleProviderFallback(e engine.Event[any]) {
+	fb, ok := e.Payload.(events.ProviderFallback)
+	if !ok {
+		return
+	}
+	msg := fmt.Sprintf("Provider %s unavailable — switching to %s (%s)",
+		fb.FailedProvider, fb.NextProvider, fb.NextModel)
+	_ = p.adapter.SendOutput(ui.OutputMessage{
+		Content: msg,
+		Role:    "system",
+	})
 }
 
 func (p *Plugin) handleHistoryReplay(e engine.Event[any]) {

--- a/plugins/io/wails/plugin.go
+++ b/plugins/io/wails/plugin.go
@@ -93,6 +93,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "io.output", Priority: 50},
 		{EventType: "io.output.stream", Priority: 50},
 		{EventType: "io.output.stream.end", Priority: 50},
+		{EventType: "io.output.clear", Priority: 50},
 		{EventType: "io.status", Priority: 50},
 		{EventType: "io.approval.request", Priority: 50},
 		{EventType: "io.ask", Priority: 50},
@@ -100,6 +101,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "plan.approval.request", Priority: 50},
 		{EventType: "plan.created", Priority: 50},
 		{EventType: "agent.plan", Priority: 50},
+		{EventType: "provider.fallback", Priority: 50},
 		{EventType: "session.file.created", Priority: 50},
 		{EventType: "session.file.updated", Priority: 50},
 		{EventType: "io.history.replay", Priority: 50},
@@ -258,6 +260,7 @@ func (p *Plugin) initLegacy() {
 		p.bus.Subscribe("io.output", p.handleOutput, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.output.stream", p.handleStreamChunk, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.output.stream.end", p.handleStreamEnd, engine.WithSource(pluginID)),
+		p.bus.Subscribe("io.output.clear", p.handleOutputClear, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.status", p.handleStatus, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.approval.request", p.handleApprovalRequest, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.ask", p.handleAskUser, engine.WithSource(pluginID)),
@@ -265,6 +268,7 @@ func (p *Plugin) initLegacy() {
 		p.bus.Subscribe("plan.approval.request", p.handlePlanApprovalRequest, engine.WithSource(pluginID)),
 		p.bus.Subscribe("plan.created", p.handlePlanCreated, engine.WithSource(pluginID)),
 		p.bus.Subscribe("agent.plan", p.handleAgentPlan, engine.WithSource(pluginID)),
+		p.bus.Subscribe("provider.fallback", p.handleProviderFallback, engine.WithSource(pluginID)),
 		p.bus.Subscribe("session.file.created", p.handleFileChanged, engine.WithSource(pluginID)),
 		p.bus.Subscribe("session.file.updated", p.handleFileChanged, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.history.replay", p.handleHistoryReplay, engine.WithSource(pluginID)),
@@ -292,6 +296,18 @@ func (p *Plugin) Shutdown(_ context.Context) error {
 	p.unsubs = nil
 	p.hub.Close()
 	return nil
+}
+
+func (p *Plugin) handleOutputClear(_ engine.Event[any]) {
+	_ = p.adapter.broadcast("output_clear", nil)
+}
+
+func (p *Plugin) handleProviderFallback(e engine.Event[any]) {
+	fb, ok := e.Payload.(events.ProviderFallback)
+	if !ok {
+		return
+	}
+	_ = p.adapter.broadcast("provider_fallback", fb)
 }
 
 func (p *Plugin) handleOutput(e engine.Event[any]) {

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -189,6 +189,12 @@ func (p *Plugin) handleCancel(event engine.Event[any]) {
 }
 
 func (p *Plugin) handleRequest(req events.LLMRequest) {
+	// If a specific provider is targeted (e.g. by fallback plugin), skip
+	// if it's not us.
+	if target, ok := req.Metadata["_target_provider"].(string); ok && target != pluginID {
+		return
+	}
+
 	model := req.Model
 	maxTokens := req.MaxTokens
 

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -158,6 +158,7 @@ func (p *Plugin) Emissions() []string {
 		"llm.response",
 		"llm.stream.chunk",
 		"llm.stream.end",
+		"before:core.error",
 		"core.error",
 	}
 }
@@ -260,14 +261,23 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 			p.logger.Info("LLM request cancelled")
 			return
 		}
-		p.emitError(fmt.Errorf("anthropic: HTTP request failed: %w", err))
+		p.emitErrorInfo(events.ErrorInfo{
+			Err:              fmt.Errorf("anthropic: HTTP request failed: %w", err),
+			Retryable:        true,
+			RetriesExhausted: p.retry.Enabled,
+			RequestMeta:      req.Metadata,
+		})
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		p.emitError(fmt.Errorf("anthropic: API returned status %d: %s", resp.StatusCode, string(respBody)))
+		p.emitErrorInfo(events.ErrorInfo{
+			Err:         fmt.Errorf("anthropic: API returned status %d: %s", resp.StatusCode, string(respBody)),
+			Retryable:   false,
+			RequestMeta: req.Metadata,
+		})
 		return
 	}
 
@@ -803,10 +813,26 @@ func (p *Plugin) debugLog(label string, data []byte) {
 }
 
 func (p *Plugin) emitError(err error) {
-	p.logger.Error(err.Error())
-	_ = p.bus.Emit("core.error", events.ErrorInfo{
+	p.emitErrorInfo(events.ErrorInfo{
 		Source: pluginID,
 		Err:    err,
 		Fatal:  false,
 	})
+}
+
+func (p *Plugin) emitErrorInfo(info events.ErrorInfo) {
+	info.Source = pluginID
+	p.logger.Error(info.Err.Error())
+
+	// Vetoable gate: fallback plugin can intercept and suppress.
+	result, vErr := p.bus.EmitVetoable("before:core.error", &info)
+	if vErr != nil {
+		p.logger.Error("failed to emit before:core.error", "error", vErr)
+		return
+	}
+	if result.Vetoed {
+		return
+	}
+
+	_ = p.bus.Emit("core.error", info)
 }

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -264,7 +264,7 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 		p.emitErrorInfo(events.ErrorInfo{
 			Err:              fmt.Errorf("anthropic: HTTP request failed: %w", err),
 			Retryable:        true,
-			RetriesExhausted: p.retry.Enabled,
+			RetriesExhausted: true,
 			RequestMeta:      req.Metadata,
 		})
 		return

--- a/plugins/providers/fallback/plugin.go
+++ b/plugins/providers/fallback/plugin.go
@@ -1,0 +1,276 @@
+// Package fallback provides automatic provider failover when the primary
+// LLM provider returns a non-retryable error or exhausts its retry budget.
+//
+// The plugin uses two subscription points:
+//   - before:llm.request (priority 3): injects fallback tracking metadata into
+//     requests for roles with fallback chains, and stores the original request.
+//   - before:core.error (priority 5): intercepts provider errors, vetoes them
+//     when a fallback is available, and re-emits llm.request targeting the next
+//     provider in the chain.
+package fallback
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const pluginID = "nexus.provider.fallback"
+
+// Plugin coordinates provider fallback on error.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+	models *engine.ModelRegistry
+	unsubs []func()
+
+	mu       sync.Mutex
+	inflight map[string]*fallbackState // keyed by fallback ID
+}
+
+// fallbackState tracks an in-flight fallback sequence.
+type fallbackState struct {
+	role    string
+	attempt int
+	request events.LLMRequest
+}
+
+// New creates a new fallback coordinator plugin.
+func New() engine.Plugin {
+	return &Plugin{
+		inflight: make(map[string]*fallbackState),
+	}
+}
+
+func (p *Plugin) ID() string             { return pluginID }
+func (p *Plugin) Name() string           { return "Provider Fallback" }
+func (p *Plugin) Version() string        { return "0.1.0" }
+func (p *Plugin) Dependencies() []string { return nil }
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		// Inject tracking metadata before gates (priority 3, before gates at 10).
+		{EventType: "before:llm.request", Priority: 3},
+		// Intercept errors before engine's error→output handler.
+		{EventType: "before:core.error", Priority: 5},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"io.output.clear",
+		"provider.fallback",
+		"llm.request",
+	}
+}
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+	p.models = ctx.Models
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("before:llm.request", p.handleBeforeRequest, engine.WithSource(pluginID)),
+		p.bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+	)
+
+	p.logger.Info("provider fallback plugin initialized")
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	return nil
+}
+
+// handleBeforeRequest injects fallback tracking metadata into LLM requests
+// for roles that have fallback chains (len > 1). The metadata flows through
+// the provider and back via ErrorInfo.RequestMeta on failure.
+func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
+	vp, ok := event.Payload.(*engine.VetoablePayload)
+	if !ok {
+		return
+	}
+	req, ok := vp.Original.(*events.LLMRequest)
+	if !ok {
+		return
+	}
+
+	// Skip requests already in a fallback sequence.
+	if req.Metadata != nil {
+		if _, ok := req.Metadata["_fallback_id"]; ok {
+			return
+		}
+	}
+
+	// Only track requests for roles with fallback chains.
+	role := req.Role
+	if role == "" {
+		return
+	}
+	if p.models.ChainLen(role) <= 1 {
+		return
+	}
+
+	// Inject tracking metadata into the request.
+	fallbackID := engine.GenerateID()
+	if req.Metadata == nil {
+		req.Metadata = make(map[string]any)
+	}
+	req.Metadata["_fallback_id"] = fallbackID
+	req.Metadata["_fallback_attempt"] = 0
+	req.Metadata["_fallback_role"] = role
+
+	// Store original request for re-emission on fallback.
+	// Deep copy metadata to avoid mutation issues.
+	storedMeta := make(map[string]any, len(req.Metadata))
+	for k, v := range req.Metadata {
+		storedMeta[k] = v
+	}
+	storedReq := *req
+	storedReq.Metadata = storedMeta
+
+	p.mu.Lock()
+	p.inflight[fallbackID] = &fallbackState{
+		role:    role,
+		attempt: 0,
+		request: storedReq,
+	}
+	p.mu.Unlock()
+}
+
+// handleBeforeError intercepts provider errors and triggers fallback when
+// the error is non-retryable or retries are exhausted and a fallback
+// provider exists in the chain.
+func (p *Plugin) handleBeforeError(event engine.Event[any]) {
+	vp, ok := event.Payload.(*engine.VetoablePayload)
+	if !ok {
+		return
+	}
+	errInfo, ok := vp.Original.(*events.ErrorInfo)
+	if !ok {
+		return
+	}
+
+	// Only intercept provider errors (nexus.llm.* sources).
+	if !strings.HasPrefix(errInfo.Source, "nexus.llm.") {
+		return
+	}
+
+	// Only intercept when error is non-retryable, or retries are exhausted.
+	if errInfo.Retryable && !errInfo.RetriesExhausted {
+		return
+	}
+
+	// Extract fallback tracking metadata from the original request.
+	meta := errInfo.RequestMeta
+	if meta == nil {
+		return
+	}
+
+	fallbackID, _ := meta["_fallback_id"].(string)
+	if fallbackID == "" {
+		return
+	}
+
+	role, _ := meta["_fallback_role"].(string)
+	attempt, _ := meta["_fallback_attempt"].(int)
+
+	// Recover state from inflight tracking.
+	p.mu.Lock()
+	state, exists := p.inflight[fallbackID]
+	if exists {
+		if role == "" {
+			role = state.role
+		}
+		if attempt == 0 && state.attempt > 0 {
+			attempt = state.attempt
+		}
+	}
+	p.mu.Unlock()
+
+	if role == "" || !exists {
+		return
+	}
+
+	// Try next in chain.
+	nextAttempt := attempt + 1
+	nextCfg, ok := p.models.Fallback(role, nextAttempt)
+	if !ok {
+		// Chain exhausted. Clean up and let error propagate.
+		p.mu.Lock()
+		delete(p.inflight, fallbackID)
+		p.mu.Unlock()
+		return
+	}
+
+	// Determine failed provider/model for notification.
+	failedProvider := errInfo.Source
+	failedModel := ""
+	if currentCfg, ok := p.models.Fallback(role, attempt); ok {
+		failedModel = currentCfg.Model
+	}
+
+	// Veto the error — we're handling it.
+	vp.Veto = engine.VetoResult{
+		Vetoed: true,
+		Reason: fmt.Sprintf("fallback: switching from %s to %s/%s", failedProvider, nextCfg.Provider, nextCfg.Model),
+	}
+
+	p.logger.Info("provider fallback triggered",
+		"role", role,
+		"failed_provider", failedProvider,
+		"failed_model", failedModel,
+		"next_provider", nextCfg.Provider,
+		"next_model", nextCfg.Model,
+		"attempt", nextAttempt,
+	)
+
+	// Emit io.output.clear to wipe partial streamed content.
+	_ = p.bus.Emit("io.output.clear", nil)
+
+	// Emit provider.fallback notification for UI.
+	_ = p.bus.Emit("provider.fallback", events.ProviderFallback{
+		Role:           role,
+		FailedProvider: failedProvider,
+		FailedModel:    failedModel,
+		Error:          errInfo.Err.Error(),
+		NextProvider:   nextCfg.Provider,
+		NextModel:      nextCfg.Model,
+		Attempt:        nextAttempt,
+	})
+
+	// Update inflight state.
+	p.mu.Lock()
+	state.attempt = nextAttempt
+	origReq := state.request
+	p.mu.Unlock()
+
+	// Build new metadata with updated fallback tracking.
+	newMeta := make(map[string]any, len(origReq.Metadata))
+	for k, v := range origReq.Metadata {
+		newMeta[k] = v
+	}
+	newMeta["_fallback_attempt"] = nextAttempt
+	newMeta["_fallback_role"] = role
+	newMeta["_fallback_id"] = fallbackID
+
+	// Re-emit request targeting the fallback provider.
+	retryReq := origReq
+	retryReq.Model = nextCfg.Model
+	retryReq.Metadata = newMeta
+	if nextCfg.MaxTokens > 0 && retryReq.MaxTokens == 0 {
+		retryReq.MaxTokens = nextCfg.MaxTokens
+	}
+
+	_ = p.bus.Emit("llm.request", retryReq)
+}

--- a/plugins/providers/fallback/plugin.go
+++ b/plugins/providers/fallback/plugin.go
@@ -96,41 +96,28 @@ func (p *Plugin) Shutdown(_ context.Context) error {
 // for roles that have fallback chains (len > 1). The metadata flows through
 // the provider and back via ErrorInfo.RequestMeta on failure.
 func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
-	p.logger.Info("handleBeforeRequest: entered", "event_type", event.Type)
-
 	vp, ok := event.Payload.(*engine.VetoablePayload)
 	if !ok {
-		p.logger.Info("handleBeforeRequest: payload not VetoablePayload")
 		return
 	}
 	req, ok := vp.Original.(*events.LLMRequest)
 	if !ok {
-		p.logger.Info("handleBeforeRequest: original not *LLMRequest")
 		return
 	}
-
-	p.logger.Info("handleBeforeRequest: request details", "role", req.Role, "model", req.Model, "has_meta", req.Metadata != nil)
 
 	// Skip requests already in a fallback sequence.
 	if req.Metadata != nil {
 		if _, ok := req.Metadata["_fallback_id"]; ok {
-			p.logger.Info("handleBeforeRequest: already in fallback sequence")
 			return
 		}
 	}
 
-	// Only track requests for roles with fallback chains.
+	// Role may be empty — providers resolve "" to the default role,
+	// and so do ChainLen/Fallback. Keep it as-is for tracking.
 	role := req.Role
-	if role == "" {
-		p.logger.Info("handleBeforeRequest: empty role")
+	if p.models.ChainLen(role) <= 1 {
 		return
 	}
-	chainLen := p.models.ChainLen(role)
-	if chainLen <= 1 {
-		p.logger.Info("handleBeforeRequest: chain too short", "role", role, "chain_len", chainLen)
-		return
-	}
-	p.logger.Info("handleBeforeRequest: injecting fallback tracking", "role", role, "chain_len", chainLen)
 
 	// Inject tracking metadata into the request.
 	fallbackID := engine.GenerateID()
@@ -163,43 +150,28 @@ func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
 // the error is non-retryable or retries are exhausted and a fallback
 // provider exists in the chain.
 func (p *Plugin) handleBeforeError(event engine.Event[any]) {
-	p.logger.Info("handleBeforeError: entered", "event_type", event.Type)
-
 	vp, ok := event.Payload.(*engine.VetoablePayload)
 	if !ok {
-		p.logger.Info("handleBeforeError: payload not VetoablePayload")
 		return
 	}
 	errInfo, ok := vp.Original.(*events.ErrorInfo)
 	if !ok {
-		p.logger.Info("handleBeforeError: original not *ErrorInfo")
 		return
 	}
 
-	p.logger.Info("handleBeforeError: error details",
-		"source", errInfo.Source,
-		"retryable", errInfo.Retryable,
-		"retries_exhausted", errInfo.RetriesExhausted,
-		"has_meta", errInfo.RequestMeta != nil,
-		"error", errInfo.Err.Error(),
-	)
-
 	// Only intercept provider errors (nexus.llm.* sources).
 	if !strings.HasPrefix(errInfo.Source, "nexus.llm.") {
-		p.logger.Info("handleBeforeError: not a provider error")
 		return
 	}
 
 	// Only intercept when error is non-retryable, or retries are exhausted.
 	if errInfo.Retryable && !errInfo.RetriesExhausted {
-		p.logger.Info("handleBeforeError: retryable but not exhausted, skipping")
 		return
 	}
 
 	// Extract fallback tracking metadata from the original request.
 	meta := errInfo.RequestMeta
 	if meta == nil {
-		p.logger.Info("handleBeforeError: no request meta")
 		return
 	}
 
@@ -224,7 +196,7 @@ func (p *Plugin) handleBeforeError(event engine.Event[any]) {
 	}
 	p.mu.Unlock()
 
-	if role == "" || !exists {
+	if !exists {
 		return
 	}
 

--- a/plugins/providers/fallback/plugin.go
+++ b/plugins/providers/fallback/plugin.go
@@ -96,21 +96,25 @@ func (p *Plugin) Shutdown(_ context.Context) error {
 // for roles that have fallback chains (len > 1). The metadata flows through
 // the provider and back via ErrorInfo.RequestMeta on failure.
 func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
+	p.logger.Info("handleBeforeRequest: entered", "event_type", event.Type)
+
 	vp, ok := event.Payload.(*engine.VetoablePayload)
 	if !ok {
-		p.logger.Debug("handleBeforeRequest: payload not VetoablePayload")
+		p.logger.Info("handleBeforeRequest: payload not VetoablePayload")
 		return
 	}
 	req, ok := vp.Original.(*events.LLMRequest)
 	if !ok {
-		p.logger.Debug("handleBeforeRequest: original not *LLMRequest")
+		p.logger.Info("handleBeforeRequest: original not *LLMRequest")
 		return
 	}
+
+	p.logger.Info("handleBeforeRequest: request details", "role", req.Role, "model", req.Model, "has_meta", req.Metadata != nil)
 
 	// Skip requests already in a fallback sequence.
 	if req.Metadata != nil {
 		if _, ok := req.Metadata["_fallback_id"]; ok {
-			p.logger.Debug("handleBeforeRequest: already in fallback sequence")
+			p.logger.Info("handleBeforeRequest: already in fallback sequence")
 			return
 		}
 	}
@@ -118,12 +122,12 @@ func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
 	// Only track requests for roles with fallback chains.
 	role := req.Role
 	if role == "" {
-		p.logger.Debug("handleBeforeRequest: empty role")
+		p.logger.Info("handleBeforeRequest: empty role")
 		return
 	}
 	chainLen := p.models.ChainLen(role)
 	if chainLen <= 1 {
-		p.logger.Debug("handleBeforeRequest: chain too short", "role", role, "chain_len", chainLen)
+		p.logger.Info("handleBeforeRequest: chain too short", "role", role, "chain_len", chainLen)
 		return
 	}
 	p.logger.Info("handleBeforeRequest: injecting fallback tracking", "role", role, "chain_len", chainLen)

--- a/plugins/providers/fallback/plugin.go
+++ b/plugins/providers/fallback/plugin.go
@@ -98,16 +98,19 @@ func (p *Plugin) Shutdown(_ context.Context) error {
 func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
 	vp, ok := event.Payload.(*engine.VetoablePayload)
 	if !ok {
+		p.logger.Debug("handleBeforeRequest: payload not VetoablePayload")
 		return
 	}
 	req, ok := vp.Original.(*events.LLMRequest)
 	if !ok {
+		p.logger.Debug("handleBeforeRequest: original not *LLMRequest")
 		return
 	}
 
 	// Skip requests already in a fallback sequence.
 	if req.Metadata != nil {
 		if _, ok := req.Metadata["_fallback_id"]; ok {
+			p.logger.Debug("handleBeforeRequest: already in fallback sequence")
 			return
 		}
 	}
@@ -115,11 +118,15 @@ func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
 	// Only track requests for roles with fallback chains.
 	role := req.Role
 	if role == "" {
+		p.logger.Debug("handleBeforeRequest: empty role")
 		return
 	}
-	if p.models.ChainLen(role) <= 1 {
+	chainLen := p.models.ChainLen(role)
+	if chainLen <= 1 {
+		p.logger.Debug("handleBeforeRequest: chain too short", "role", role, "chain_len", chainLen)
 		return
 	}
+	p.logger.Info("handleBeforeRequest: injecting fallback tracking", "role", role, "chain_len", chainLen)
 
 	// Inject tracking metadata into the request.
 	fallbackID := engine.GenerateID()
@@ -152,28 +159,43 @@ func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
 // the error is non-retryable or retries are exhausted and a fallback
 // provider exists in the chain.
 func (p *Plugin) handleBeforeError(event engine.Event[any]) {
+	p.logger.Info("handleBeforeError: entered", "event_type", event.Type)
+
 	vp, ok := event.Payload.(*engine.VetoablePayload)
 	if !ok {
+		p.logger.Info("handleBeforeError: payload not VetoablePayload")
 		return
 	}
 	errInfo, ok := vp.Original.(*events.ErrorInfo)
 	if !ok {
+		p.logger.Info("handleBeforeError: original not *ErrorInfo")
 		return
 	}
 
+	p.logger.Info("handleBeforeError: error details",
+		"source", errInfo.Source,
+		"retryable", errInfo.Retryable,
+		"retries_exhausted", errInfo.RetriesExhausted,
+		"has_meta", errInfo.RequestMeta != nil,
+		"error", errInfo.Err.Error(),
+	)
+
 	// Only intercept provider errors (nexus.llm.* sources).
 	if !strings.HasPrefix(errInfo.Source, "nexus.llm.") {
+		p.logger.Info("handleBeforeError: not a provider error")
 		return
 	}
 
 	// Only intercept when error is non-retryable, or retries are exhausted.
 	if errInfo.Retryable && !errInfo.RetriesExhausted {
+		p.logger.Info("handleBeforeError: retryable but not exhausted, skipping")
 		return
 	}
 
 	// Extract fallback tracking metadata from the original request.
 	meta := errInfo.RequestMeta
 	if meta == nil {
+		p.logger.Info("handleBeforeError: no request meta")
 		return
 	}
 

--- a/plugins/providers/fallback/plugin.go
+++ b/plugins/providers/fallback/plugin.go
@@ -263,6 +263,7 @@ func (p *Plugin) handleBeforeError(event engine.Event[any]) {
 	newMeta["_fallback_attempt"] = nextAttempt
 	newMeta["_fallback_role"] = role
 	newMeta["_fallback_id"] = fallbackID
+	newMeta["_target_provider"] = nextCfg.Provider
 
 	// Re-emit request targeting the fallback provider.
 	retryReq := origReq

--- a/plugins/providers/fallback/plugin_test.go
+++ b/plugins/providers/fallback/plugin_test.go
@@ -1,0 +1,276 @@
+package fallback
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func makeTestRegistry() *engine.ModelRegistry {
+	return engine.NewModelRegistry(map[string]any{
+		"default": "balanced",
+		"balanced": []any{
+			map[string]any{
+				"provider":   "nexus.llm.anthropic",
+				"model":      "claude-sonnet-4-20250514",
+				"max_tokens": 8192,
+			},
+			map[string]any{
+				"provider":   "nexus.llm.openai",
+				"model":      "gpt-4o",
+				"max_tokens": 8192,
+			},
+		},
+		"quick": map[string]any{
+			"provider": "nexus.llm.anthropic",
+			"model":    "claude-haiku-4-5-20251001",
+		},
+	})
+}
+
+func TestFallback_VetoesProviderError(t *testing.T) {
+	bus := engine.NewEventBus()
+	models := makeTestRegistry()
+
+	p := New().(*Plugin)
+	p.bus = bus
+	p.models = models
+	p.logger = slog.Default()
+
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("before:llm.request", p.handleBeforeRequest, engine.WithSource(pluginID)),
+		bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+	)
+
+	// Track outbound events.
+	var gotClear, gotFallback, gotRetry bool
+	bus.Subscribe("io.output.clear", func(_ engine.Event[any]) { gotClear = true })
+	bus.Subscribe("provider.fallback", func(e engine.Event[any]) {
+		fb, ok := e.Payload.(events.ProviderFallback)
+		if !ok {
+			t.Fatal("expected ProviderFallback payload")
+		}
+		if fb.NextProvider != "nexus.llm.openai" || fb.NextModel != "gpt-4o" {
+			t.Fatalf("unexpected fallback target: %s/%s", fb.NextProvider, fb.NextModel)
+		}
+		gotFallback = true
+	})
+	bus.Subscribe("llm.request", func(e engine.Event[any]) {
+		req, ok := e.Payload.(events.LLMRequest)
+		if !ok {
+			t.Fatal("expected LLMRequest payload")
+		}
+		if req.Model != "gpt-4o" {
+			t.Fatalf("expected retry with gpt-4o, got %s", req.Model)
+		}
+		gotRetry = true
+	})
+
+	// Simulate: agent emits llm.request with before: gate.
+	origReq := &events.LLMRequest{
+		Role: "balanced",
+		Messages: []events.Message{
+			{Role: "user", Content: "hello"},
+		},
+	}
+	_, _ = bus.EmitVetoable("before:llm.request", origReq)
+
+	// Simulate: provider fails with non-retryable error.
+	errInfo := &events.ErrorInfo{
+		Source:      "nexus.llm.anthropic",
+		Err:         fmt.Errorf("anthropic: API returned status 401: unauthorized"),
+		Retryable:   false,
+		RequestMeta: origReq.Metadata,
+	}
+	result, err := bus.EmitVetoable("before:core.error", errInfo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Vetoed {
+		t.Fatal("expected error to be vetoed by fallback plugin")
+	}
+
+	if !gotClear {
+		t.Error("expected io.output.clear to be emitted")
+	}
+	if !gotFallback {
+		t.Error("expected provider.fallback to be emitted")
+	}
+	if !gotRetry {
+		t.Error("expected llm.request re-emission")
+	}
+}
+
+func TestFallback_ChainExhausted_NoVeto(t *testing.T) {
+	bus := engine.NewEventBus()
+	models := makeTestRegistry()
+
+	p := New().(*Plugin)
+	p.bus = bus
+	p.models = models
+	p.logger = slog.Default()
+
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("before:llm.request", p.handleBeforeRequest, engine.WithSource(pluginID)),
+		bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+	)
+
+	// Inject request.
+	origReq := &events.LLMRequest{
+		Role:     "balanced",
+		Messages: []events.Message{{Role: "user", Content: "hello"}},
+	}
+	_, _ = bus.EmitVetoable("before:llm.request", origReq)
+
+	// First failure → fallback to index 1.
+	errInfo1 := &events.ErrorInfo{
+		Source:      "nexus.llm.anthropic",
+		Err:         fmt.Errorf("anthropic: error"),
+		Retryable:   false,
+		RequestMeta: origReq.Metadata,
+	}
+	result1, _ := bus.EmitVetoable("before:core.error", errInfo1)
+	if !result1.Vetoed {
+		t.Fatal("expected first error to be vetoed")
+	}
+
+	// Second failure (now at index 1) → chain exhausted.
+	errInfo2 := &events.ErrorInfo{
+		Source:    "nexus.llm.openai",
+		Err:       fmt.Errorf("openai: error"),
+		Retryable: false,
+		RequestMeta: map[string]any{
+			"_fallback_id":      origReq.Metadata["_fallback_id"],
+			"_fallback_attempt": 1,
+			"_fallback_role":    "balanced",
+		},
+	}
+	result2, _ := bus.EmitVetoable("before:core.error", errInfo2)
+	if result2.Vetoed {
+		t.Fatal("expected chain-exhausted error NOT to be vetoed")
+	}
+}
+
+func TestFallback_IgnoresNonProviderErrors(t *testing.T) {
+	bus := engine.NewEventBus()
+	models := makeTestRegistry()
+
+	p := New().(*Plugin)
+	p.bus = bus
+	p.models = models
+	p.logger = slog.Default()
+
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+	)
+
+	// Error from a non-provider source.
+	errInfo := &events.ErrorInfo{
+		Source: "nexus.tool.shell",
+		Err:    fmt.Errorf("shell: command failed"),
+	}
+	result, _ := bus.EmitVetoable("before:core.error", errInfo)
+	if result.Vetoed {
+		t.Fatal("expected non-provider error to pass through")
+	}
+}
+
+func TestFallback_IgnoresRetryableInProgress(t *testing.T) {
+	bus := engine.NewEventBus()
+	models := makeTestRegistry()
+
+	p := New().(*Plugin)
+	p.bus = bus
+	p.models = models
+	p.logger = slog.Default()
+
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("before:llm.request", p.handleBeforeRequest, engine.WithSource(pluginID)),
+		bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+	)
+
+	origReq := &events.LLMRequest{
+		Role:     "balanced",
+		Messages: []events.Message{{Role: "user", Content: "hello"}},
+	}
+	_, _ = bus.EmitVetoable("before:llm.request", origReq)
+
+	// Error is retryable and retries NOT exhausted — provider still handling.
+	errInfo := &events.ErrorInfo{
+		Source:           "nexus.llm.anthropic",
+		Err:              fmt.Errorf("anthropic: 429 rate limited"),
+		Retryable:        true,
+		RetriesExhausted: false,
+		RequestMeta:      origReq.Metadata,
+	}
+	result, _ := bus.EmitVetoable("before:core.error", errInfo)
+	if result.Vetoed {
+		t.Fatal("expected retryable-in-progress error to pass through")
+	}
+}
+
+func TestFallback_RetriesExhausted_TriggersFallback(t *testing.T) {
+	bus := engine.NewEventBus()
+	models := makeTestRegistry()
+
+	p := New().(*Plugin)
+	p.bus = bus
+	p.models = models
+	p.logger = slog.Default()
+
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("before:llm.request", p.handleBeforeRequest, engine.WithSource(pluginID)),
+		bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+	)
+
+	origReq := &events.LLMRequest{
+		Role:     "balanced",
+		Messages: []events.Message{{Role: "user", Content: "hello"}},
+	}
+	_, _ = bus.EmitVetoable("before:llm.request", origReq)
+
+	// Error is retryable but retries exhausted.
+	errInfo := &events.ErrorInfo{
+		Source:           "nexus.llm.anthropic",
+		Err:              fmt.Errorf("anthropic: max retries exceeded"),
+		Retryable:        true,
+		RetriesExhausted: true,
+		RequestMeta:      origReq.Metadata,
+	}
+	result, _ := bus.EmitVetoable("before:core.error", errInfo)
+	if !result.Vetoed {
+		t.Fatal("expected retries-exhausted error to trigger fallback")
+	}
+}
+
+func TestFallback_NoChain_NoIntercept(t *testing.T) {
+	bus := engine.NewEventBus()
+	models := makeTestRegistry()
+
+	p := New().(*Plugin)
+	p.bus = bus
+	p.models = models
+	p.logger = slog.Default()
+
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("before:llm.request", p.handleBeforeRequest, engine.WithSource(pluginID)),
+		bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+	)
+
+	// Request for "quick" role — only 1 entry, no fallback chain.
+	origReq := &events.LLMRequest{
+		Role:     "quick",
+		Messages: []events.Message{{Role: "user", Content: "hello"}},
+	}
+	_, _ = bus.EmitVetoable("before:llm.request", origReq)
+
+	// Should not have tracking metadata since chain <= 1.
+	if origReq.Metadata != nil {
+		if _, ok := origReq.Metadata["_fallback_id"]; ok {
+			t.Fatal("expected no fallback tracking for single-entry role")
+		}
+	}
+}

--- a/plugins/providers/fallback/plugin_test.go
+++ b/plugins/providers/fallback/plugin_test.go
@@ -246,6 +246,61 @@ func TestFallback_RetriesExhausted_TriggersFallback(t *testing.T) {
 	}
 }
 
+func TestFallback_EmptyRole_UsesDefault(t *testing.T) {
+	bus := engine.NewEventBus()
+	models := makeTestRegistry() // default = "balanced" which has a 2-entry chain
+
+	p := New().(*Plugin)
+	p.bus = bus
+	p.models = models
+	p.logger = slog.Default()
+
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("before:llm.request", p.handleBeforeRequest, engine.WithSource(pluginID)),
+		bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+	)
+
+	var gotRetry bool
+	bus.Subscribe("llm.request", func(e engine.Event[any]) {
+		req, ok := e.Payload.(events.LLMRequest)
+		if !ok {
+			return
+		}
+		if req.Model == "gpt-4o" {
+			gotRetry = true
+		}
+	})
+
+	// Empty role — should resolve to default ("balanced") which has fallback.
+	origReq := &events.LLMRequest{
+		Role:     "",
+		Messages: []events.Message{{Role: "user", Content: "hello"}},
+	}
+	_, _ = bus.EmitVetoable("before:llm.request", origReq)
+
+	if origReq.Metadata == nil {
+		t.Fatal("expected fallback tracking metadata on empty-role request")
+	}
+	if _, ok := origReq.Metadata["_fallback_id"]; !ok {
+		t.Fatal("expected _fallback_id in metadata")
+	}
+
+	// Simulate provider failure.
+	errInfo := &events.ErrorInfo{
+		Source:           "nexus.llm.anthropic",
+		Err:              fmt.Errorf("anthropic: error"),
+		Retryable:        false,
+		RequestMeta:      origReq.Metadata,
+	}
+	result, _ := bus.EmitVetoable("before:core.error", errInfo)
+	if !result.Vetoed {
+		t.Fatal("expected error to be vetoed for empty-role fallback")
+	}
+	if !gotRetry {
+		t.Fatal("expected fallback re-emission with gpt-4o")
+	}
+}
+
 func TestFallback_NoChain_NoIntercept(t *testing.T) {
 	bus := engine.NewEventBus()
 	models := makeTestRegistry()

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -200,6 +200,12 @@ func (p *Plugin) handleCancel(event engine.Event[any]) {
 }
 
 func (p *Plugin) handleRequest(req events.LLMRequest) {
+	// If a specific provider is targeted (e.g. by fallback plugin), skip
+	// if it's not us.
+	if target, ok := req.Metadata["_target_provider"].(string); ok && target != pluginID {
+		return
+	}
+
 	model := req.Model
 	maxTokens := req.MaxTokens
 

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -169,6 +169,7 @@ func (p *Plugin) Emissions() []string {
 		"llm.response",
 		"llm.stream.chunk",
 		"llm.stream.end",
+		"before:core.error",
 		"core.error",
 	}
 }
@@ -269,14 +270,23 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 			p.logger.Info("LLM request cancelled")
 			return
 		}
-		p.emitError(fmt.Errorf("openai: HTTP request failed: %w", err))
+		p.emitErrorInfo(events.ErrorInfo{
+			Err:              fmt.Errorf("openai: HTTP request failed: %w", err),
+			Retryable:        true,
+			RetriesExhausted: p.retry.Enabled,
+			RequestMeta:      req.Metadata,
+		})
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		p.emitError(fmt.Errorf("openai: API returned status %d: %s", resp.StatusCode, string(respBody)))
+		p.emitErrorInfo(events.ErrorInfo{
+			Err:         fmt.Errorf("openai: API returned status %d: %s", resp.StatusCode, string(respBody)),
+			Retryable:   false,
+			RequestMeta: req.Metadata,
+		})
 		return
 	}
 
@@ -766,10 +776,26 @@ func (p *Plugin) debugLog(label string, data []byte) {
 }
 
 func (p *Plugin) emitError(err error) {
-	p.logger.Error(err.Error())
-	_ = p.bus.Emit("core.error", events.ErrorInfo{
+	p.emitErrorInfo(events.ErrorInfo{
 		Source: pluginID,
 		Err:    err,
 		Fatal:  false,
 	})
+}
+
+func (p *Plugin) emitErrorInfo(info events.ErrorInfo) {
+	info.Source = pluginID
+	p.logger.Error(info.Err.Error())
+
+	// Vetoable gate: fallback plugin can intercept and suppress.
+	result, vErr := p.bus.EmitVetoable("before:core.error", &info)
+	if vErr != nil {
+		p.logger.Error("failed to emit before:core.error", "error", vErr)
+		return
+	}
+	if result.Vetoed {
+		return
+	}
+
+	_ = p.bus.Emit("core.error", info)
 }

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -273,7 +273,7 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 		p.emitErrorInfo(events.ErrorInfo{
 			Err:              fmt.Errorf("openai: HTTP request failed: %w", err),
 			Retryable:        true,
-			RetriesExhausted: p.retry.Enabled,
+			RetriesExhausted: true,
 			RequestMeta:      req.Metadata,
 		})
 		return

--- a/tests/integration/fallback_test.go
+++ b/tests/integration/fallback_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/testharness"
+)
+
+// TestFallback_Boot validates that the engine boots cleanly with a fallback
+// chain config and the fallback coordinator plugin active.
+func TestFallback_Boot(t *testing.T) {
+	h := testharness.New(t, "configs/test-fallback.yaml", testharness.WithTimeout(30*time.Second))
+	h.Run()
+
+	h.AssertBooted(
+		"nexus.io.test",
+		"nexus.llm.anthropic",
+		"nexus.llm.openai",
+		"nexus.provider.fallback",
+		"nexus.agent.react",
+		"nexus.memory.conversation",
+	)
+	h.AssertEventEmitted("io.session.start")
+	h.AssertEventEmitted("io.session.end")
+}
+
+// TestFallback_TriggersOnPrimaryFailure validates that when the primary
+// provider fails (OpenAI with bogus base_url), the fallback plugin
+// intercepts the error and re-routes to the secondary provider (Anthropic).
+func TestFallback_TriggersOnPrimaryFailure(t *testing.T) {
+	h := testharness.New(t, "configs/test-fallback.yaml", testharness.WithTimeout(30*time.Second))
+	h.Run()
+
+	// Fallback plugin should have emitted these events.
+	h.AssertEventEmitted("io.output.clear")
+	h.AssertEventEmitted("provider.fallback")
+
+	// Agent should still produce output (via fallback provider).
+	h.AssertEventEmitted("io.output")
+
+	// The LLM response should have come through (from Anthropic fallback).
+	h.AssertEventEmitted("llm.response")
+}


### PR DESCRIPTION
## Summary

Closes #10

- **Config-driven fallback chains**: Role values in `core.models` accept ordered arrays. First entry = primary, subsequent entries tried on failure. Single-map format backward compatible.
- **Fallback coordinator plugin** (`nexus.provider.fallback`): Subscribes to `before:llm.request` (priority 3) to inject tracking metadata, and `before:core.error` (priority 5) to intercept provider errors and re-route to the next provider in the chain.
- **Vetoable `core.error`**: Providers now emit `before:core.error` before `core.error`. Fallback plugin vetoes the error when a fallback is available, preventing it from surfacing to the UI.
- **Error classification**: Both providers now set `Retryable`, `RetriesExhausted`, and `RequestMeta` on `ErrorInfo`, enabling the fallback plugin to distinguish between retryable-in-progress (don't intercept) and terminal failures (trigger fallback).
- **Streaming partial failure**: On mid-stream failure, emits `io.output.clear` to wipe partial content, `provider.fallback` notification, then re-emits `llm.request` to next provider. Clean restart — no spliced output.
- **IO parity**: All three IO plugins (TUI, browser, wails) handle `io.output.clear` and `provider.fallback` events.

### Files changed (37)

| Area | Files | What |
|------|-------|------|
| Engine | `models.go`, `event.go`, `bus.go`, `session.go` | Chain parsing, `Fallback()`, `GenerateID()` export |
| Events | `core.go`, `provider.go` | `ErrorInfo` extension, `ProviderFallback` struct |
| Providers | `anthropic/plugin.go`, `openai/plugin.go` | Vetoable error emission, error classification |
| Fallback | `fallback/plugin.go` | New coordinator plugin |
| IO | `tui/`, `browser/`, `wails/` | `io.output.clear` + `provider.fallback` handlers |
| Configs | 12 profiles + test config | Commented fallback examples, test-fallback.yaml |
| Tests | `models_test.go`, `plugin_test.go`, `fallback_test.go` | 14 unit + 2 integration tests |
| Docs | `models.md`, `reference.md`, `fallback.md`, `CLAUDE.md` | Architecture, events, plugin docs |

## Test plan

- [x] All existing unit tests pass (`go test ./...`)
- [x] 8 new ModelRegistry tests (chain parsing, fallback indexing, edge cases)
- [x] 6 new fallback plugin tests (veto, chain exhaustion, non-provider passthrough, retryable-in-progress, retries-exhausted, no-chain)
- [x] Integration test: `go test -tags integration ./tests/integration/ -run TestFallback` (requires `ANTHROPIC_API_KEY` — primary OpenAI with bogus URL fails, fallback to Anthropic succeeds)
- [x] Manual: boot with `configs/test-fallback.yaml`, verify fallback notification appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)