### PR TITLE
feat: add provider fanout with parallel multi-provider dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ plugins/
   providers/anthropic/   # Claude LLM provider (direct HTTP, no SDK; supports api_key config or api_key_env env var)
   providers/openai/      # OpenAI LLM provider (direct HTTP, no SDK; supports api_key config, api_key_env env var, base_url override)
   providers/fallback/    # Automatic provider failover coordinator (config-driven fallback chains in core.models)
+  providers/fanout/      # Parallel multi-provider dispatch (config-driven fanout roles in core.models)
   tools/shell/           # Sandboxed shell execution
   tools/fileio/          # File read/write with base dir restriction
   io/tui/                # Terminal UI

--- a/configs/test-fanout.yaml
+++ b/configs/test-fanout.yaml
@@ -1,0 +1,75 @@
+# Test: Provider fanout — send one request to multiple providers in parallel
+# Validates: fanout config parsing, parallel dispatch, response collection, combined response
+#
+# Run (automated):
+#   go test -tags integration ./tests/integration/ -run TestFanout
+#
+# What to test:
+#   1. Boot: Engine starts with fanout role config + nexus.provider.fanout active.
+#   2. Config parsing: compare role parsed as fanout with 2 providers.
+#   3. Parallel dispatch: Both providers receive the request.
+#   4. Response collection: Fanout collects both responses.
+#   5. Combined response: Agent receives single llm.response with Alternatives.
+#   6. Events: provider.fanout.start, provider.fanout.response (x2), provider.fanout.complete emitted.
+#
+# Design: Mock mode — no real LLM calls. Two mock responses simulate two providers.
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: compare
+    compare:
+      fanout: true
+      providers:
+        - provider: nexus.llm.anthropic
+          model: claude-sonnet-4-20250514
+          max_tokens: 4096
+        - provider: nexus.llm.openai
+          model: gpt-4o
+          max_tokens: 4096
+  sessions:
+    root: ~/.nexus/sessions
+    retention: 30d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.test
+    - nexus.llm.anthropic
+    - nexus.llm.openai
+    - nexus.provider.fanout
+    - nexus.agent.react
+    - nexus.memory.conversation
+    - nexus.observe.logger
+
+  nexus.io.test:
+    inputs:
+      - "Say hello"
+    input_delay: 500ms
+    approval_mode: approve
+    timeout: 30s
+    mock_responses:
+      - content: "Hello from provider A"
+      - content: "Hello from provider B"
+
+  nexus.llm.anthropic:
+    api_key: "sk-mock-not-used"
+
+  nexus.llm.openai:
+    api_key: "sk-mock-not-used"
+
+  nexus.provider.fanout:
+    strategy: all
+    deadline_ms: 10000
+
+  nexus.agent.react:
+    system_prompt: "You are a test assistant. Follow instructions exactly."
+
+  nexus.memory.conversation:
+    max_messages: 4
+    persist: false
+
+  nexus.observe.logger:
+    output: stderr
+    level: info

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,6 +33,8 @@
 - [LLM Providers](./plugins/providers/index.md)
   - [Anthropic (Claude)](./plugins/providers/anthropic.md)
   - [OpenAI](./plugins/providers/openai.md)
+  - [Fallback](./plugins/providers/fallback.md)
+  - [Fanout](./plugins/providers/fanout.md)
 - [Tools](./plugins/tools/index.md)
   - [Shell](./plugins/tools/shell.md)
   - [File I/O](./plugins/tools/file.md)

--- a/docs/src/architecture/event-bus.md
+++ b/docs/src/architecture/event-bus.md
@@ -8,6 +8,7 @@ The event bus is the central nervous system of Nexus. Every plugin communicates 
 type EventBus interface {
     Emit(eventType string, payload any) error
     EmitEvent(event Event[any]) error
+    EmitAsync(eventType string, payload any) <-chan error
     Subscribe(eventType string, handler HandlerFunc, opts ...SubscribeOption) (unsubscribe func())
     SubscribeAll(handler HandlerFunc) (unsubscribe func())
     EmitVetoable(eventType string, payload any) (VetoResult, error)
@@ -113,6 +114,20 @@ func (p *MyPlugin) Emissions() []string {
     return []string{"tool.result", "tool.register", "core.error"}
 }
 ```
+
+## Async Emit
+
+`EmitAsync()` dispatches an event in a separate goroutine, returning immediately with a channel that receives nil on success or an error:
+
+```go
+ch := ctx.Bus.EmitAsync("llm.request", request)
+// ... do other work ...
+if err := <-ch; err != nil {
+    // handle error
+}
+```
+
+Handlers still run synchronously within the goroutine — `EmitAsync` only makes the *dispatch* non-blocking relative to the caller. Used by the fanout plugin to send parallel requests to multiple providers.
 
 ## Vetoable Events
 

--- a/docs/src/architecture/models.md
+++ b/docs/src/architecture/models.md
@@ -81,6 +81,30 @@ Single-map format is backward compatible — parsed as a chain of length 1.
 
 **Streaming partial failure**: If a provider fails mid-stream, the fallback plugin emits `io.output.clear` to wipe partial content, then `provider.fallback` notification, then re-emits `llm.request` targeting the next provider. Clean restart — no spliced output from two models.
 
+## Provider Fanout
+
+Roles with `fanout: true` send requests to all listed providers in parallel instead of sequential fallback. The fanout plugin collects responses and returns them as a single `LLMResponse` with `Alternatives`.
+
+```yaml
+core:
+  models:
+    compare:
+      fanout: true
+      providers:
+        - provider: nexus.llm.anthropic
+          model: claude-sonnet-4-20250514
+          max_tokens: 4096
+        - provider: nexus.llm.openai
+          model: gpt-4o
+          max_tokens: 4096
+```
+
+**Requires**: `nexus.provider.fanout` in `plugins.active` + all listed provider plugins active.
+
+**Deadline**: Configurable via `nexus.provider.fanout.deadline_ms` (default 30s). If a provider doesn't respond in time, the fanout proceeds with available responses.
+
+**No per-leg fallback**: A fanout provider that fails is simply marked as failed. Fallback chains and fanout are separate concepts — a role is either a fallback chain or a fanout group, not both.
+
 ## API
 
 ```go
@@ -91,11 +115,13 @@ type ModelConfig struct {
 }
 
 type ModelRegistry struct {
-    Resolve(role string) (ModelConfig, bool)       // Primary model for a role (index 0)
+    Resolve(role string) (ModelConfig, bool)              // Primary model for a role (index 0)
     Fallback(role string, attempt int) (ModelConfig, bool) // Model at chain index
-    ChainLen(role string) int                      // Number of entries in fallback chain
-    Default() ModelConfig                          // Get the default model
-    Roles() []string                               // List all registered role names
+    ChainLen(role string) int                             // Number of entries in fallback chain
+    IsFanout(role string) bool                            // Whether a role uses parallel fanout
+    FanoutProviders(role string) []ModelConfig            // All providers in a fanout role
+    Default() ModelConfig                                 // Get the default model
+    Roles() []string                                      // List all registered role names
 }
 ```
 

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -137,6 +137,9 @@ Complete reference for all event types in Nexus, organized by domain.
 | Event Type | Payload | Description |
 |------------|---------|-------------|
 | `provider.fallback` | `ProviderFallback` | Provider switch due to failure |
+| `provider.fanout.start` | `ProviderFanoutStart` | Parallel fanout initiated |
+| `provider.fanout.response` | `ProviderFanoutResponse` | Individual provider responded |
+| `provider.fanout.complete` | `ProviderFanoutComplete` | All fanout responses collected |
 
 ### Payloads
 
@@ -150,6 +153,38 @@ Complete reference for all event types in Nexus, organized by domain.
 | `NextProvider` | string | Plugin ID of the fallback provider |
 | `NextModel` | string | Model being tried next |
 | `Attempt` | int | 0-based index in the fallback chain |
+
+**ProviderFanoutStart**
+| Field | Type | Description |
+|-------|------|-------------|
+| `FanoutID` | string | Unique fanout sequence identifier |
+| `Role` | string | Model role being resolved |
+| `Strategy` | string | Selection strategy (`all`, `llm_judge`, `heuristic`, `user`) |
+| `Targets` | []ProviderFanoutTarget | Providers being dispatched to |
+
+**ProviderFanoutTarget**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Provider` | string | Plugin ID |
+| `Model` | string | Model identifier |
+
+**ProviderFanoutResponse**
+| Field | Type | Description |
+|-------|------|-------------|
+| `FanoutID` | string | Fanout sequence identifier |
+| `Provider` | string | Plugin ID that responded |
+| `Model` | string | Model that responded |
+| `Success` | bool | `false` if provider errored or timed out |
+| `Error` | string | Non-empty on failure |
+
+**ProviderFanoutComplete**
+| Field | Type | Description |
+|-------|------|-------------|
+| `FanoutID` | string | Fanout sequence identifier |
+| `Role` | string | Model role |
+| `Strategy` | string | Selection strategy used |
+| `Succeeded` | int | Number of successful responses |
+| `Failed` | int | Number of errors or timeouts |
 
 ---
 
@@ -241,6 +276,7 @@ Certain metadata keys carry special meaning:
 | `Model` | string | Model that was used |
 | `FinishReason` | string | Why the response ended |
 | `Metadata` | map[string]any | Additional context |
+| `Alternatives` | []LLMResponse | Additional responses from parallel fanout providers (nil for non-fanout) |
 
 **Usage**
 | Field | Type | Description |

--- a/docs/src/plugins/providers/fanout.md
+++ b/docs/src/plugins/providers/fanout.md
@@ -1,0 +1,120 @@
+# Provider Fanout
+
+**Plugin ID**: `nexus.provider.fanout`
+
+Sends a single LLM request to multiple providers in parallel and collects their responses. Supports configurable selection strategies to determine the final response. Agents remain unaware — fanout is transparent at the provider layer.
+
+## Event Subscriptions
+
+| Event | Priority | Purpose |
+|-------|----------|---------|
+| `before:llm.request` | 2 | Detect fanout roles, veto original, dispatch parallel requests |
+| `llm.response` | 1 | Collect individual provider responses |
+| `before:core.error` | 4 | Absorb provider errors within fanout sequences |
+
+## Event Emissions
+
+| Event | Payload | Purpose |
+|-------|---------|---------|
+| `provider.fanout.start` | `ProviderFanoutStart` | Fanout initiated |
+| `provider.fanout.response` | `ProviderFanoutResponse` | Individual provider responded (success or failure) |
+| `provider.fanout.complete` | `ProviderFanoutComplete` | All responses collected or deadline reached |
+| `llm.request` | `LLMRequest` | Per-provider targeted requests (via EmitAsync) |
+| `llm.response` | `LLMResponse` | Combined final response with Alternatives |
+
+## Configuration
+
+```yaml
+core:
+  models:
+    compare:
+      fanout: true
+      providers:
+        - provider: nexus.llm.anthropic
+          model: claude-sonnet-4-20250514
+          max_tokens: 4096
+        - provider: nexus.llm.openai
+          model: gpt-4o
+          max_tokens: 4096
+
+plugins:
+  active:
+    - nexus.llm.anthropic
+    - nexus.llm.openai
+    - nexus.provider.fanout    # required for fanout to work
+
+  nexus.provider.fanout:
+    strategy: all              # selection strategy (default: "all")
+    deadline_ms: 30000         # max wait time in milliseconds (default: 30000)
+```
+
+### Plugin Config
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `strategy` | string | `"all"` | Selection strategy: `all`, `llm_judge`, `heuristic`, `user` |
+| `deadline_ms` | int | `30000` | Maximum time to wait for all providers (milliseconds) |
+
+### Fanout Role Config
+
+Fanout roles are defined in `core.models` as maps with `fanout: true` and a `providers` list:
+
+```yaml
+core:
+  models:
+    compare:
+      fanout: true
+      providers:
+        - provider: nexus.llm.anthropic
+          model: claude-sonnet-4-20250514
+        - provider: nexus.llm.openai
+          model: gpt-4o
+```
+
+This is distinct from fallback chains (which are YAML arrays). Fanout roles dispatch to all providers simultaneously; fallback chains try providers sequentially on error.
+
+## Selection Strategies
+
+| Strategy | Description | Status |
+|----------|-------------|--------|
+| `all` | Return all responses. First response is primary, rest in `Alternatives`. | Implemented |
+| `llm_judge` | Separate LLM call picks best response. | Planned |
+| `heuristic` | Rule-based selection (response length, latency, confidence). | Planned |
+| `user` | Surface all to user, let them pick. | Planned |
+
+## Response Shape
+
+The combined response uses the `Alternatives` field on `LLMResponse`:
+
+- Primary fields (`Content`, `Model`, `ToolCalls`, etc.) contain the first successful response
+- `Alternatives` contains remaining successful responses as full `LLMResponse` structs
+- `Usage` and `CostUSD` are aggregated across all responses
+- `Metadata["_fanout"] = true` indicates this was a fanout response
+- `Metadata["_fanout_id"]` contains the fanout sequence ID
+
+## Deadline Handling
+
+If any provider doesn't respond within `deadline_ms`, the fanout finalizes with whatever responses have arrived. Failed or timed-out providers are counted in `ProviderFanoutComplete.Failed`.
+
+If all providers fail or time out, the plugin emits a `core.error` instead of an `llm.response`.
+
+## Streaming
+
+Fanout disables streaming for individual provider requests (`Stream: false`). Complete responses are required to support selection strategies and the `Alternatives` response shape.
+
+## Request Metadata
+
+The fanout plugin injects tracking metadata into per-provider requests:
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `_fanout_id` | string | Unique ID for this fanout sequence |
+| `_target_provider` | string | Plugin ID of the target provider |
+| `_fanout_provider` | string | Plugin ID that this leg targets |
+| `_source` | string | Set to `nexus.provider.fanout` so agents skip individual responses |
+
+## Interaction with Other Plugins
+
+- **Fallback**: Fanout and fallback serve different purposes. Fallback is sequential error recovery; fanout is parallel dispatch. A fanout leg that fails is simply marked as failed — no per-leg fallback.
+- **Gates**: The initial `before:llm.request` passes through gates normally. Per-provider requests emitted by fanout are direct `llm.request` events (not vetoable).
+- **Mock mode**: Test IO mock responses work with fanout — each fanout leg gets the next mock response in sequence.

--- a/docs/src/plugins/providers/index.md
+++ b/docs/src/plugins/providers/index.md
@@ -9,6 +9,7 @@ LLM provider plugins handle communication with AI model APIs. They receive `llm.
 | [Anthropic](./anthropic.md) | `nexus.llm.anthropic` | Claude (direct HTTP, no SDK) |
 | [OpenAI](./openai.md) | `nexus.llm.openai` | GPT / o-series (direct HTTP, no SDK) |
 | [Fallback](./fallback.md) | `nexus.provider.fallback` | Automatic provider failover coordinator |
+| [Fanout](./fanout.md) | `nexus.provider.fanout` | Parallel multi-provider dispatch |
 
 ## Provider Architecture
 

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -38,6 +38,7 @@ import (
 	// Provider plugins.
 	"github.com/frankbardon/nexus/plugins/providers/anthropic"
 	fallbackplugin "github.com/frankbardon/nexus/plugins/providers/fallback"
+	fanoutplugin "github.com/frankbardon/nexus/plugins/providers/fanout"
 	"github.com/frankbardon/nexus/plugins/providers/openai"
 
 	// Skill plugins.
@@ -103,6 +104,7 @@ func RegisterAll(r *engine.PluginRegistry) {
 	r.Register("nexus.llm.anthropic", anthropic.New)
 	r.Register("nexus.llm.openai", openai.New)
 	r.Register("nexus.provider.fallback", fallbackplugin.New)
+	r.Register("nexus.provider.fanout", fanoutplugin.New)
 
 	// Skills
 	r.Register("nexus.skills", skills.New)

--- a/pkg/engine/bus.go
+++ b/pkg/engine/bus.go
@@ -13,6 +13,10 @@ type EventBus interface {
 	Emit(eventType string, payload any) error
 	// EmitEvent dispatches a pre-built event.
 	EmitEvent(event Event[any]) error
+	// EmitAsync dispatches an event asynchronously, returning immediately.
+	// Handlers run in a separate goroutine. The returned channel receives
+	// nil on success or an error, then is closed.
+	EmitAsync(eventType string, payload any) <-chan error
 	// Subscribe registers a handler for an event type.
 	// Returns an unsubscribe function.
 	Subscribe(eventType string, handler HandlerFunc, opts ...SubscribeOption) (unsubscribe func())
@@ -181,6 +185,15 @@ func (b *eventBus) EmitEvent(event Event[any]) error {
 	}
 
 	return nil
+}
+
+func (b *eventBus) EmitAsync(eventType string, payload any) <-chan error {
+	ch := make(chan error, 1)
+	go func() {
+		ch <- b.Emit(eventType, payload)
+		close(ch)
+	}()
+	return ch
 }
 
 func (b *eventBus) EmitVetoable(eventType string, payload any) (VetoResult, error) {

--- a/pkg/engine/bus_test.go
+++ b/pkg/engine/bus_test.go
@@ -1,7 +1,9 @@
 package engine
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestEmitVetoable_HandlerCanVeto(t *testing.T) {
@@ -158,5 +160,49 @@ func TestEmitVetoable_CanModifyOriginalPayload(t *testing.T) {
 	}
 	if payload.Content != "[REDACTED]" {
 		t.Fatalf("expected redacted content, got %q", payload.Content)
+	}
+}
+
+func TestEmitAsync_RunsHandlerConcurrently(t *testing.T) {
+	bus := NewEventBus()
+
+	var called atomic.Bool
+	bus.Subscribe("test.async", func(e Event[any]) {
+		called.Store(true)
+	})
+
+	ch := bus.EmitAsync("test.async", "hello")
+
+	select {
+	case err := <-ch:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("EmitAsync did not complete in time")
+	}
+
+	if !called.Load() {
+		t.Fatal("handler was not called")
+	}
+}
+
+func TestEmitAsync_ChannelCloses(t *testing.T) {
+	bus := NewEventBus()
+
+	ch := bus.EmitAsync("test.noop", nil)
+
+	select {
+	case _, open := <-ch:
+		// First read gets nil error.
+		if open {
+			// Channel should close after.
+			_, open = <-ch
+			if open {
+				t.Fatal("channel should be closed after result")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("EmitAsync channel did not close in time")
 	}
 }

--- a/pkg/engine/models.go
+++ b/pkg/engine/models.go
@@ -13,8 +13,12 @@ type ModelConfig struct {
 // Each role maps to an ordered chain of ModelConfigs. The first entry is the
 // primary; subsequent entries are fallbacks tried in order when the primary
 // (or prior fallback) fails with a non-retryable error or exhausts retries.
+//
+// Roles with fanout: true send requests to all providers in parallel instead
+// of using sequential fallback.
 type ModelRegistry struct {
 	chains      map[string][]ModelConfig
+	fanoutRoles map[string]bool
 	defaultRole string
 }
 
@@ -42,6 +46,7 @@ func parseModelConfig(m map[string]any) ModelConfig {
 func NewModelRegistry(modelsRaw map[string]any) *ModelRegistry {
 	r := &ModelRegistry{
 		chains:      make(map[string][]ModelConfig),
+		fanoutRoles: make(map[string]bool),
 		defaultRole: "balanced",
 	}
 
@@ -59,8 +64,24 @@ func NewModelRegistry(modelsRaw map[string]any) *ModelRegistry {
 
 		switch v := val.(type) {
 		case map[string]any:
-			// Single model config (backward compatible).
-			r.chains[key] = []ModelConfig{parseModelConfig(v)}
+			// Check for fanout role: map with "fanout: true" + "providers" list.
+			if isFanout, _ := v["fanout"].(bool); isFanout {
+				if providers, ok := v["providers"].([]any); ok {
+					chain := make([]ModelConfig, 0, len(providers))
+					for _, entry := range providers {
+						if m, ok := entry.(map[string]any); ok {
+							chain = append(chain, parseModelConfig(m))
+						}
+					}
+					if len(chain) > 0 {
+						r.chains[key] = chain
+						r.fanoutRoles[key] = true
+					}
+				}
+			} else {
+				// Single model config (backward compatible).
+				r.chains[key] = []ModelConfig{parseModelConfig(v)}
+			}
 
 		case []any:
 			// Ordered fallback chain.
@@ -130,6 +151,27 @@ func (r *ModelRegistry) ChainLen(role string) int {
 func (r *ModelRegistry) Default() ModelConfig {
 	cfg, _ := r.Resolve("")
 	return cfg
+}
+
+// IsFanout returns true if the role is configured for parallel fanout
+// rather than sequential fallback.
+func (r *ModelRegistry) IsFanout(role string) bool {
+	if role == "" {
+		role = r.defaultRole
+	}
+	return r.fanoutRoles[role]
+}
+
+// FanoutProviders returns all provider configs for a fanout role.
+// Returns nil if the role is not a fanout role or doesn't exist.
+func (r *ModelRegistry) FanoutProviders(role string) []ModelConfig {
+	if role == "" {
+		role = r.defaultRole
+	}
+	if !r.fanoutRoles[role] {
+		return nil
+	}
+	return r.chains[role]
 }
 
 // Roles returns the names of all registered roles.

--- a/pkg/engine/models_test.go
+++ b/pkg/engine/models_test.go
@@ -181,3 +181,76 @@ func TestModelRegistry_EmptyChain(t *testing.T) {
 		t.Fatal("expected empty chain to not create a role")
 	}
 }
+
+func TestModelRegistry_FanoutRole(t *testing.T) {
+	r := NewModelRegistry(map[string]any{
+		"compare": map[string]any{
+			"fanout": true,
+			"providers": []any{
+				map[string]any{
+					"provider":   "nexus.llm.anthropic",
+					"model":      "claude-sonnet-4-20250514",
+					"max_tokens": 4096,
+				},
+				map[string]any{
+					"provider":   "nexus.llm.openai",
+					"model":      "gpt-4o",
+					"max_tokens": 4096,
+				},
+			},
+		},
+		"balanced": map[string]any{
+			"provider": "nexus.llm.anthropic",
+			"model":    "claude-sonnet-4-20250514",
+		},
+	})
+
+	// Fanout role detected.
+	if !r.IsFanout("compare") {
+		t.Fatal("expected compare to be fanout role")
+	}
+
+	// Non-fanout role.
+	if r.IsFanout("balanced") {
+		t.Fatal("expected balanced to not be fanout role")
+	}
+
+	// FanoutProviders returns all providers.
+	providers := r.FanoutProviders("compare")
+	if len(providers) != 2 {
+		t.Fatalf("expected 2 fanout providers, got %d", len(providers))
+	}
+	if providers[0].Provider != "nexus.llm.anthropic" {
+		t.Fatalf("expected first provider nexus.llm.anthropic, got %s", providers[0].Provider)
+	}
+	if providers[1].Provider != "nexus.llm.openai" {
+		t.Fatalf("expected second provider nexus.llm.openai, got %s", providers[1].Provider)
+	}
+
+	// FanoutProviders returns nil for non-fanout roles.
+	if r.FanoutProviders("balanced") != nil {
+		t.Fatal("expected nil for non-fanout role")
+	}
+
+	// Resolve still works (returns first provider).
+	cfg, ok := r.Resolve("compare")
+	if !ok {
+		t.Fatal("expected compare role to resolve")
+	}
+	if cfg.Provider != "nexus.llm.anthropic" {
+		t.Fatalf("expected primary provider nexus.llm.anthropic, got %s", cfg.Provider)
+	}
+}
+
+func TestModelRegistry_FanoutEmptyProviders(t *testing.T) {
+	r := NewModelRegistry(map[string]any{
+		"compare": map[string]any{
+			"fanout":    true,
+			"providers": []any{},
+		},
+	})
+
+	if r.IsFanout("compare") {
+		t.Fatal("expected empty fanout to not register")
+	}
+}

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -69,6 +69,12 @@ type LLMResponse struct {
 	Model        string
 	FinishReason string
 	Metadata     map[string]any
+
+	// Alternatives holds additional responses from parallel fanout providers.
+	// Nil for normal (non-fanout) requests. When populated, the primary fields
+	// above contain the first successful response (or selected winner), and
+	// Alternatives contains the remaining responses.
+	Alternatives []LLMResponse
 }
 
 // Usage tracks token consumption for an LLM call.

--- a/pkg/events/provider.go
+++ b/pkg/events/provider.go
@@ -11,3 +11,59 @@ type ProviderFallback struct {
 	NextModel      string // model being tried next
 	Attempt        int    // 0-based index in the fallback chain
 }
+
+// ProviderFanoutTarget describes one provider in a fanout request.
+type ProviderFanoutTarget struct {
+	Provider string // plugin ID
+	Model    string
+}
+
+// ProviderFanoutStart signals that a fanout request has been initiated.
+type ProviderFanoutStart struct {
+	FanoutID string
+	Role     string
+	Strategy string // "all", "llm_judge", "heuristic", "user"
+	Targets  []ProviderFanoutTarget
+}
+
+// ProviderFanoutResponse signals that one provider in a fanout has responded.
+type ProviderFanoutResponse struct {
+	FanoutID string
+	Provider string // plugin ID that responded
+	Model    string
+	Success  bool   // false if provider errored or timed out
+	Error    string // non-empty on failure
+}
+
+// ProviderFanoutComplete signals that all fanout providers have responded
+// (or the deadline was reached) and the final result has been emitted.
+type ProviderFanoutComplete struct {
+	FanoutID  string
+	Role      string
+	Strategy  string
+	Succeeded int // number of providers that responded successfully
+	Failed    int // number of providers that errored or timed out
+}
+
+// ProviderFanoutChoose presents fanout responses for user selection.
+// IO plugins render a picker UI when they receive this event.
+type ProviderFanoutChoose struct {
+	FanoutID  string
+	Role      string
+	Responses []ProviderFanoutOption
+}
+
+// ProviderFanoutOption describes one response available for user selection.
+type ProviderFanoutOption struct {
+	Index    int
+	Provider string
+	Model    string
+	Content  string  // response content preview
+	CostUSD  float64
+}
+
+// ProviderFanoutChosen carries the user's selection from a fanout choice.
+type ProviderFanoutChosen struct {
+	FanoutID    string
+	ChosenIndex int // -1 means user declined to choose (fall back to "all")
+}

--- a/plugins/io/test/plugin.go
+++ b/plugins/io/test/plugin.go
@@ -372,13 +372,9 @@ func (p *Plugin) handleMockLLMRequest(e engine.Event[any]) {
 
 	mock := p.nextMockResponse()
 
-	// Propagate _source metadata so retrier can correlate the response.
-	var metadata map[string]any
-	if src, ok := req.Metadata["_source"]; ok {
-		metadata = map[string]any{"_source": src}
-	}
-
-	_ = p.bus.Emit("llm.response", p.buildMockResponse(mock, metadata))
+	// Propagate full request metadata so downstream plugins (fanout, retrier)
+	// can correlate the response. Matches real provider behavior.
+	_ = p.bus.Emit("llm.response", p.buildMockResponse(mock, req.Metadata))
 }
 
 func (p *Plugin) nextMockResponse() MockResponse {

--- a/plugins/providers/fanout/heuristic.go
+++ b/plugins/providers/fanout/heuristic.go
@@ -1,0 +1,109 @@
+package fanout
+
+import (
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// selectByHeuristic scores responses according to the configured heuristic
+// preference and returns the index of the winning response.
+func (p *Plugin) selectByHeuristic(responses []events.LLMResponse, receivedAt []time.Time) int {
+	candidates := makeIndices(len(responses))
+
+	// Filter by finish reason if configured.
+	if p.cfg.HeuristicRequireFinish {
+		filtered := filterByFinishReason(responses, candidates, "end_turn")
+		if len(filtered) > 0 {
+			candidates = filtered
+		}
+		// If all filtered out, fall back to unfiltered set.
+	}
+
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+
+	switch p.cfg.HeuristicPrefer {
+	case "shortest":
+		return selectShortest(responses, candidates)
+	case "fastest":
+		return selectFastest(receivedAt, candidates)
+	case "cheapest":
+		return selectCheapest(responses, candidates)
+	default: // "longest" is the default
+		return selectLongest(responses, candidates)
+	}
+}
+
+// makeIndices returns a slice [0, 1, 2, ..., n-1].
+func makeIndices(n int) []int {
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i
+	}
+	return idx
+}
+
+// filterByFinishReason returns indices of responses whose FinishReason matches.
+func filterByFinishReason(responses []events.LLMResponse, candidates []int, reason string) []int {
+	var out []int
+	for _, i := range candidates {
+		if responses[i].FinishReason == reason {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// selectLongest returns the index of the response with the longest Content.
+func selectLongest(responses []events.LLMResponse, candidates []int) int {
+	best := candidates[0]
+	bestLen := len(responses[best].Content)
+	for _, i := range candidates[1:] {
+		if l := len(responses[i].Content); l > bestLen {
+			best = i
+			bestLen = l
+		}
+	}
+	return best
+}
+
+// selectShortest returns the index of the response with the shortest Content.
+func selectShortest(responses []events.LLMResponse, candidates []int) int {
+	best := candidates[0]
+	bestLen := len(responses[best].Content)
+	for _, i := range candidates[1:] {
+		if l := len(responses[i].Content); l < bestLen {
+			best = i
+			bestLen = l
+		}
+	}
+	return best
+}
+
+// selectFastest returns the index of the response that arrived first.
+func selectFastest(receivedAt []time.Time, candidates []int) int {
+	best := candidates[0]
+	bestTime := receivedAt[best]
+	for _, i := range candidates[1:] {
+		if receivedAt[i].Before(bestTime) {
+			best = i
+			bestTime = receivedAt[i]
+		}
+	}
+	return best
+}
+
+// selectCheapest returns the index of the response with the lowest CostUSD.
+func selectCheapest(responses []events.LLMResponse, candidates []int) int {
+	best := candidates[0]
+	bestCost := responses[best].CostUSD
+	for _, i := range candidates[1:] {
+		if responses[i].CostUSD < bestCost {
+			best = i
+			bestCost = responses[i].CostUSD
+		}
+	}
+	return best
+}

--- a/plugins/providers/fanout/heuristic_test.go
+++ b/plugins/providers/fanout/heuristic_test.go
@@ -1,0 +1,171 @@
+package fanout
+
+import (
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestSelectByHeuristic_Longest(t *testing.T) {
+	p := &Plugin{cfg: config{HeuristicPrefer: "longest"}}
+	responses := []events.LLMResponse{
+		{Content: "short", Model: "a"},
+		{Content: "this is much longer content", Model: "b"},
+		{Content: "medium length", Model: "c"},
+	}
+	now := time.Now()
+	receivedAt := []time.Time{now, now, now}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	if got != 1 {
+		t.Fatalf("expected index 1 (longest), got %d", got)
+	}
+}
+
+func TestSelectByHeuristic_Shortest(t *testing.T) {
+	p := &Plugin{cfg: config{HeuristicPrefer: "shortest"}}
+	responses := []events.LLMResponse{
+		{Content: "medium length", Model: "a"},
+		{Content: "hi", Model: "b"},
+		{Content: "this is much longer content", Model: "c"},
+	}
+	now := time.Now()
+	receivedAt := []time.Time{now, now, now}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	if got != 1 {
+		t.Fatalf("expected index 1 (shortest), got %d", got)
+	}
+}
+
+func TestSelectByHeuristic_Fastest(t *testing.T) {
+	p := &Plugin{cfg: config{HeuristicPrefer: "fastest"}}
+	responses := []events.LLMResponse{
+		{Content: "a", Model: "a"},
+		{Content: "b", Model: "b"},
+		{Content: "c", Model: "c"},
+	}
+	base := time.Now()
+	receivedAt := []time.Time{
+		base.Add(200 * time.Millisecond), // second
+		base.Add(500 * time.Millisecond), // third
+		base.Add(50 * time.Millisecond),  // first
+	}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	if got != 2 {
+		t.Fatalf("expected index 2 (fastest), got %d", got)
+	}
+}
+
+func TestSelectByHeuristic_Cheapest(t *testing.T) {
+	p := &Plugin{cfg: config{HeuristicPrefer: "cheapest"}}
+	responses := []events.LLMResponse{
+		{Content: "a", CostUSD: 0.05, Model: "a"},
+		{Content: "b", CostUSD: 0.01, Model: "b"},
+		{Content: "c", CostUSD: 0.10, Model: "c"},
+	}
+	now := time.Now()
+	receivedAt := []time.Time{now, now, now}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	if got != 1 {
+		t.Fatalf("expected index 1 (cheapest), got %d", got)
+	}
+}
+
+func TestSelectByHeuristic_RequireFinish(t *testing.T) {
+	p := &Plugin{cfg: config{
+		HeuristicPrefer:        "longest",
+		HeuristicRequireFinish: true,
+	}}
+	responses := []events.LLMResponse{
+		{Content: "this is the longest response by far", FinishReason: "max_tokens", Model: "a"},
+		{Content: "short", FinishReason: "end_turn", Model: "b"},
+		{Content: "medium content here", FinishReason: "end_turn", Model: "c"},
+	}
+	now := time.Now()
+	receivedAt := []time.Time{now, now, now}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	// Index 0 has longest content but finish_reason != "end_turn", so filtered.
+	// Among filtered set [1, 2], index 2 has longest content.
+	if got != 2 {
+		t.Fatalf("expected index 2 (longest among end_turn), got %d", got)
+	}
+}
+
+func TestSelectByHeuristic_RequireFinishFallback(t *testing.T) {
+	p := &Plugin{cfg: config{
+		HeuristicPrefer:        "longest",
+		HeuristicRequireFinish: true,
+	}}
+	responses := []events.LLMResponse{
+		{Content: "short", FinishReason: "max_tokens", Model: "a"},
+		{Content: "this is the longest response", FinishReason: "max_tokens", Model: "b"},
+		{Content: "medium", FinishReason: "stop", Model: "c"},
+	}
+	now := time.Now()
+	receivedAt := []time.Time{now, now, now}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	// All filtered out (none have "end_turn"), so fall back to unfiltered.
+	// Index 1 has longest content.
+	if got != 1 {
+		t.Fatalf("expected index 1 (longest, fallback to unfiltered), got %d", got)
+	}
+}
+
+func TestSelectByHeuristic_DefaultIsLongest(t *testing.T) {
+	p := &Plugin{cfg: config{HeuristicPrefer: ""}}
+	responses := []events.LLMResponse{
+		{Content: "short", Model: "a"},
+		{Content: "this is the longest", Model: "b"},
+	}
+	now := time.Now()
+	receivedAt := []time.Time{now, now}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	if got != 1 {
+		t.Fatalf("expected index 1 (default=longest), got %d", got)
+	}
+}
+
+func TestSelectByHeuristic_SingleResponse(t *testing.T) {
+	p := &Plugin{cfg: config{HeuristicPrefer: "longest"}}
+	responses := []events.LLMResponse{
+		{Content: "only one", Model: "a"},
+	}
+	now := time.Now()
+	receivedAt := []time.Time{now}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	if got != 0 {
+		t.Fatalf("expected index 0 (only response), got %d", got)
+	}
+}
+
+func TestSelectByHeuristic_RequireFinishWithFastest(t *testing.T) {
+	p := &Plugin{cfg: config{
+		HeuristicPrefer:        "fastest",
+		HeuristicRequireFinish: true,
+	}}
+	responses := []events.LLMResponse{
+		{Content: "a", FinishReason: "max_tokens", Model: "a"},
+		{Content: "b", FinishReason: "end_turn", Model: "b"},
+		{Content: "c", FinishReason: "end_turn", Model: "c"},
+	}
+	base := time.Now()
+	receivedAt := []time.Time{
+		base.Add(10 * time.Millisecond),  // fastest but filtered
+		base.Add(300 * time.Millisecond), // slower
+		base.Add(100 * time.Millisecond), // faster among end_turn
+	}
+
+	got := p.selectByHeuristic(responses, receivedAt)
+	// Index 0 is fastest but filtered. Among [1, 2], index 2 arrived first.
+	if got != 2 {
+		t.Fatalf("expected index 2 (fastest among end_turn), got %d", got)
+	}
+}

--- a/plugins/providers/fanout/judge.go
+++ b/plugins/providers/fanout/judge.go
@@ -1,0 +1,186 @@
+package fanout
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// judgeResponse is the expected JSON structure from the judge LLM call.
+type judgeResponse struct {
+	ChosenIndex int    `json:"chosen_index"`
+	Reason      string `json:"reason"`
+}
+
+// judgeResponseSchema is the JSON schema for structured output from the judge.
+var judgeResponseSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"chosen_index": map[string]any{
+			"type":        "integer",
+			"description": "Zero-based index of the best response",
+		},
+		"reason": map[string]any{
+			"type":        "string",
+			"description": "Brief explanation of why this response was chosen",
+		},
+	},
+	"required":             []any{"chosen_index", "reason"},
+	"additionalProperties": false,
+}
+
+// buildJudgePrompt constructs the prompt that asks the judge LLM to pick the
+// best response from the fanout candidates.
+func buildJudgePrompt(responses []events.LLMResponse) string {
+	var b strings.Builder
+	b.WriteString("You are a response quality judge. Below are multiple LLM responses to the same prompt. ")
+	b.WriteString("Evaluate each response for accuracy, completeness, clarity, and helpfulness. ")
+	b.WriteString("Choose the single best response.\n\n")
+
+	for i, r := range responses {
+		provider, _ := r.Metadata["_fanout_provider"].(string)
+		fmt.Fprintf(&b, "--- Response %d (provider: %s, model: %s) ---\n", i, provider, r.Model)
+		b.WriteString(r.Content)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("Return your choice as JSON with chosen_index (zero-based) and reason.")
+	return b.String()
+}
+
+// parseJudgeResponse parses the judge LLM's JSON output into a judgeResponse.
+func parseJudgeResponse(content string, numResponses int) (judgeResponse, error) {
+	// Trim whitespace and try to extract JSON if wrapped in markdown fences.
+	content = strings.TrimSpace(content)
+	if strings.HasPrefix(content, "```") {
+		lines := strings.Split(content, "\n")
+		// Strip first and last lines (fences).
+		if len(lines) >= 3 {
+			content = strings.Join(lines[1:len(lines)-1], "\n")
+			content = strings.TrimSpace(content)
+		}
+	}
+
+	var jr judgeResponse
+	if err := json.Unmarshal([]byte(content), &jr); err != nil {
+		return judgeResponse{}, fmt.Errorf("parse judge JSON: %w", err)
+	}
+
+	if jr.ChosenIndex < 0 || jr.ChosenIndex >= numResponses {
+		return judgeResponse{}, fmt.Errorf("chosen_index %d out of range [0, %d)", jr.ChosenIndex, numResponses)
+	}
+
+	return jr, nil
+}
+
+// selectByJudge makes an LLM call to pick the best response from the fanout
+// candidates, then emits the final combined response with the chosen response
+// as primary. Falls back to "all" strategy (first response = primary) on
+// any failure.
+func (p *Plugin) selectByJudge(fanoutID string, state *fanoutState, responses []events.LLMResponse, origRequest events.LLMRequest) {
+	prompt := buildJudgePrompt(responses)
+
+	// Compute judge deadline: min(deadline/2, 10s).
+	judgeDeadline := p.cfg.deadline / 2
+	if judgeDeadline > 10*time.Second {
+		judgeDeadline = 10 * time.Second
+	}
+	if judgeDeadline < 2*time.Second {
+		judgeDeadline = 2 * time.Second
+	}
+
+	// Channel to receive the judge response.
+	judgeCh := make(chan events.LLMResponse, 1)
+
+	// One-shot subscription for the judge response. Filter by _fanout_judge
+	// metadata. The handleResponse method already skips these, so this sub
+	// is the only consumer.
+	unsub := p.bus.Subscribe("llm.response", func(event engine.Event[any]) {
+		resp, ok := event.Payload.(events.LLMResponse)
+		if !ok {
+			return
+		}
+		if _, isJudge := resp.Metadata["_fanout_judge"]; !isJudge {
+			return
+		}
+		select {
+		case judgeCh <- resp:
+		default:
+		}
+	}, engine.WithPriority(0), engine.WithSource(pluginID))
+	defer unsub()
+
+	// Build and emit the judge LLM request.
+	judgeMeta := map[string]any{
+		"_source":        pluginID,
+		"_fanout_judge":  true,
+		"_fanout_id":     fanoutID,
+	}
+
+	judgeReq := events.LLMRequest{
+		Role: p.cfg.JudgeRole,
+		Messages: []events.Message{
+			{Role: "user", Content: prompt},
+		},
+		Stream:   false,
+		Metadata: judgeMeta,
+		ResponseFormat: &events.ResponseFormat{
+			Type:   "json_schema",
+			Name:   "fanout_judge_selection",
+			Schema: judgeResponseSchema,
+			Strict: true,
+		},
+	}
+
+	p.logger.Info("judge selection started",
+		"fanout_id", fanoutID,
+		"judge_role", p.cfg.JudgeRole,
+		"candidates", len(responses),
+		"deadline_ms", judgeDeadline.Milliseconds(),
+	)
+
+	p.bus.EmitAsync("llm.request", judgeReq)
+
+	// Wait for judge response or timeout.
+	timer := time.NewTimer(judgeDeadline)
+	defer timer.Stop()
+
+	select {
+	case judgeResp := <-judgeCh:
+		jr, err := parseJudgeResponse(judgeResp.Content, len(responses))
+		if err != nil {
+			p.logger.Warn("judge response parse failed, falling back to first response",
+				"fanout_id", fanoutID,
+				"error", err,
+			)
+			p.emitFinalResponse(fanoutID, state, responses)
+			return
+		}
+
+		p.logger.Info("judge selected response",
+			"fanout_id", fanoutID,
+			"chosen_index", jr.ChosenIndex,
+			"reason", jr.Reason,
+		)
+
+		// Reorder: chosen response first, then the rest in original order.
+		reordered := make([]events.LLMResponse, 0, len(responses))
+		reordered = append(reordered, responses[jr.ChosenIndex])
+		for i, r := range responses {
+			if i != jr.ChosenIndex {
+				reordered = append(reordered, r)
+			}
+		}
+		p.emitFinalResponse(fanoutID, state, reordered)
+
+	case <-timer.C:
+		p.logger.Warn("judge deadline reached, falling back to first response",
+			"fanout_id", fanoutID,
+		)
+		p.emitFinalResponse(fanoutID, state, responses)
+	}
+}

--- a/plugins/providers/fanout/judge_test.go
+++ b/plugins/providers/fanout/judge_test.go
@@ -1,0 +1,204 @@
+package fanout
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestBuildJudgePrompt(t *testing.T) {
+	responses := []events.LLMResponse{
+		{
+			Content: "Response from provider A",
+			Model:   "model-a",
+			Metadata: map[string]any{
+				"_fanout_provider": "provider-a",
+			},
+		},
+		{
+			Content: "Response from provider B",
+			Model:   "model-b",
+			Metadata: map[string]any{
+				"_fanout_provider": "provider-b",
+			},
+		},
+		{
+			Content: "Response from provider C",
+			Model:   "model-c",
+			Metadata: map[string]any{
+				"_fanout_provider": "provider-c",
+			},
+		},
+	}
+
+	prompt := buildJudgePrompt(responses)
+
+	// Verify all responses are listed with indices.
+	for i, r := range responses {
+		provider := r.Metadata["_fanout_provider"].(string)
+		indexMarker := strings.Contains(prompt, "Response "+string(rune('0'+i)))
+		if !indexMarker {
+			t.Errorf("prompt missing index marker for response %d", i)
+		}
+		if !strings.Contains(prompt, provider) {
+			t.Errorf("prompt missing provider %q", provider)
+		}
+		if !strings.Contains(prompt, r.Model) {
+			t.Errorf("prompt missing model %q", r.Model)
+		}
+		if !strings.Contains(prompt, r.Content) {
+			t.Errorf("prompt missing content for response %d", i)
+		}
+	}
+
+	// Verify the prompt asks for JSON output.
+	if !strings.Contains(prompt, "chosen_index") {
+		t.Error("prompt missing chosen_index instruction")
+	}
+}
+
+func TestBuildJudgePromptSingleResponse(t *testing.T) {
+	responses := []events.LLMResponse{
+		{
+			Content:  "Only response",
+			Model:    "model-x",
+			Metadata: map[string]any{"_fanout_provider": "prov-x"},
+		},
+	}
+
+	prompt := buildJudgePrompt(responses)
+	if !strings.Contains(prompt, "Response 0") {
+		t.Error("prompt missing index 0 for single response")
+	}
+	if !strings.Contains(prompt, "Only response") {
+		t.Error("prompt missing response content")
+	}
+}
+
+func TestParseJudgeResponse_Valid(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		n       int
+		want    int
+	}{
+		{
+			name:    "index 0",
+			content: `{"chosen_index": 0, "reason": "more complete"}`,
+			n:       3,
+			want:    0,
+		},
+		{
+			name:    "index 2",
+			content: `{"chosen_index": 2, "reason": "better formatting"}`,
+			n:       3,
+			want:    2,
+		},
+		{
+			name:    "with whitespace",
+			content: `  {"chosen_index": 1, "reason": "clearer"}  `,
+			n:       2,
+			want:    1,
+		},
+		{
+			name:    "markdown fenced",
+			content: "```json\n{\"chosen_index\": 0, \"reason\": \"best\"}\n```",
+			n:       2,
+			want:    0,
+		},
+		{
+			name:    "extra fields ignored",
+			content: `{"chosen_index": 1, "reason": "good", "confidence": 0.9}`,
+			n:       3,
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jr, err := parseJudgeResponse(tt.content, tt.n)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if jr.ChosenIndex != tt.want {
+				t.Errorf("got chosen_index=%d, want %d", jr.ChosenIndex, tt.want)
+			}
+			if jr.Reason == "" {
+				t.Error("expected non-empty reason")
+			}
+		})
+	}
+}
+
+func TestParseJudgeResponse_InvalidIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		n       int
+	}{
+		{
+			name:    "index too high",
+			content: `{"chosen_index": 5, "reason": "oops"}`,
+			n:       3,
+		},
+		{
+			name:    "negative index",
+			content: `{"chosen_index": -1, "reason": "oops"}`,
+			n:       3,
+		},
+		{
+			name:    "index equals count",
+			content: `{"chosen_index": 2, "reason": "boundary"}`,
+			n:       2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseJudgeResponse(tt.content, tt.n)
+			if err == nil {
+				t.Fatal("expected error for out-of-range index")
+			}
+			if !strings.Contains(err.Error(), "out of range") {
+				t.Errorf("expected 'out of range' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseJudgeResponse_MalformedJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "empty string",
+			content: "",
+		},
+		{
+			name:    "not json",
+			content: "I choose response 0 because it is better.",
+		},
+		{
+			name:    "incomplete json",
+			content: `{"chosen_index": 1`,
+		},
+		{
+			name:    "array instead of object",
+			content: `[0, "reason"]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseJudgeResponse(tt.content, 3)
+			if err == nil {
+				t.Fatal("expected error for malformed JSON")
+			}
+			if !strings.Contains(err.Error(), "parse judge JSON") {
+				t.Errorf("expected 'parse judge JSON' error, got: %v", err)
+			}
+		})
+	}
+}

--- a/plugins/providers/fanout/plugin.go
+++ b/plugins/providers/fanout/plugin.go
@@ -1,0 +1,580 @@
+// Package fanout sends a single LLM request to multiple providers in parallel
+// and collects their responses. The plugin supports configurable selection
+// strategies to determine the final response returned to the agent.
+//
+// The plugin uses three subscription points:
+//   - before:llm.request (priority 2): detects fanout roles, vetoes the
+//     original request, and dispatches parallel requests via EmitAsync.
+//   - llm.response (priority 1): collects individual provider responses
+//     tagged with _fanout_id metadata, suppressing them from the agent.
+//   - before:core.error (priority 4): captures provider errors within a
+//     fanout sequence so failed legs don't surface as session errors.
+package fanout
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const pluginID = "nexus.provider.fanout"
+
+const (
+	StrategyAll       = "all"
+	StrategyLLMJudge  = "llm_judge"
+	StrategyHeuristic = "heuristic"
+	StrategyUser      = "user"
+)
+
+// config holds plugin configuration.
+type config struct {
+	Strategy       string        `yaml:"strategy"`
+	DeadlineMillis int           `yaml:"deadline_ms"`
+	deadline       time.Duration // parsed from DeadlineMillis
+
+	// Heuristic strategy settings.
+	HeuristicPrefer        string `yaml:"heuristic_prefer"`         // "longest" | "shortest" | "fastest" | "cheapest"
+	HeuristicRequireFinish bool   `yaml:"heuristic_require_finish"` // discard responses with finish_reason != "end_turn"
+
+	// LLM judge strategy settings.
+	JudgeRole string `yaml:"judge_role"` // model role for the judge call
+}
+
+// fanoutState tracks an in-flight fanout sequence.
+type fanoutState struct {
+	mu         sync.Mutex
+	role       string
+	strategy   string
+	targets    []events.ProviderFanoutTarget
+	request    events.LLMRequest
+	responses  []events.LLMResponse
+	receivedAt []time.Time // parallel to responses — when each response arrived
+	errors     []fanoutError
+	done       chan struct{} // closed when all responses collected or deadline hit
+	expected   int
+	received   int
+}
+
+type fanoutError struct {
+	provider string
+	model    string
+	err      string
+}
+
+// Plugin coordinates provider fanout.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+	models *engine.ModelRegistry
+	cfg    config
+	unsubs []func()
+
+	mu             sync.Mutex
+	inflight       map[string]*fanoutState // keyed by fanout ID
+	pendingChoices map[string]chan int      // user strategy: fanoutID -> chosen index
+}
+
+// New creates a new fanout coordinator plugin.
+func New() engine.Plugin {
+	return &Plugin{
+		inflight:       make(map[string]*fanoutState),
+		pendingChoices: make(map[string]chan int),
+	}
+}
+
+func (p *Plugin) ID() string             { return pluginID }
+func (p *Plugin) Name() string           { return "Provider Fanout" }
+func (p *Plugin) Version() string        { return "0.1.0" }
+func (p *Plugin) Dependencies() []string { return nil }
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		// Intercept before gates (priority 2, before fallback at 3, gates at 10).
+		{EventType: "before:llm.request", Priority: 2},
+		// Collect responses before agent handlers (priority 1, agent at 50).
+		{EventType: "llm.response", Priority: 1},
+		// Capture provider errors within fanout sequences.
+		{EventType: "before:core.error", Priority: 4},
+		// User strategy: receive user's choice.
+		{EventType: "provider.fanout.chosen", Priority: 50},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"llm.request",
+		"llm.response",
+		"provider.fanout.start",
+		"provider.fanout.response",
+		"provider.fanout.complete",
+		"provider.fanout.choose",
+	}
+}
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+	p.models = ctx.Models
+
+	// Parse config with defaults.
+	p.cfg = config{
+		Strategy:       StrategyAll,
+		DeadlineMillis: 30000, // 30s default
+	}
+	if v, ok := ctx.Config["strategy"].(string); ok {
+		p.cfg.Strategy = v
+	}
+	if v, ok := ctx.Config["deadline_ms"].(int); ok {
+		p.cfg.DeadlineMillis = v
+	} else if v, ok := ctx.Config["deadline_ms"].(float64); ok {
+		p.cfg.DeadlineMillis = int(v)
+	}
+	p.cfg.deadline = time.Duration(p.cfg.DeadlineMillis) * time.Millisecond
+
+	// Parse heuristic sub-config.
+	p.cfg.HeuristicPrefer = "longest" // default
+	if hm, ok := ctx.Config["heuristic"].(map[string]any); ok {
+		if v, ok := hm["prefer"].(string); ok {
+			p.cfg.HeuristicPrefer = v
+		}
+		if v, ok := hm["require_finish"].(bool); ok {
+			p.cfg.HeuristicRequireFinish = v
+		}
+	}
+
+	// Parse judge config.
+	if v, ok := ctx.Config["judge_role"].(string); ok {
+		p.cfg.JudgeRole = v
+	}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("before:llm.request", p.handleBeforeRequest, engine.WithSource(pluginID)),
+		p.bus.Subscribe("llm.response", p.handleResponse, engine.WithPriority(1), engine.WithSource(pluginID)),
+		p.bus.Subscribe("before:core.error", p.handleBeforeError, engine.WithSource(pluginID)),
+		p.bus.Subscribe("provider.fanout.chosen", p.handleUserChoice, engine.WithSource(pluginID)),
+	)
+
+	p.logger.Info("provider fanout plugin initialized",
+		"strategy", p.cfg.Strategy,
+		"deadline_ms", p.cfg.DeadlineMillis,
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	return nil
+}
+
+// handleBeforeRequest detects fanout roles, vetoes the original request,
+// and dispatches parallel requests to all providers in the fanout group.
+func (p *Plugin) handleBeforeRequest(event engine.Event[any]) {
+	vp, ok := event.Payload.(*engine.VetoablePayload)
+	if !ok {
+		return
+	}
+	req, ok := vp.Original.(*events.LLMRequest)
+	if !ok {
+		return
+	}
+
+	// Skip requests already in a fanout sequence.
+	if req.Metadata != nil {
+		if _, ok := req.Metadata["_fanout_id"]; ok {
+			return
+		}
+	}
+
+	role := req.Role
+	if !p.models.IsFanout(role) {
+		return
+	}
+
+	providers := p.models.FanoutProviders(role)
+	if len(providers) == 0 {
+		return
+	}
+
+	// Veto the original request — we'll re-emit targeted copies.
+	fanoutID := engine.GenerateID()
+	vp.Veto = engine.VetoResult{
+		Vetoed: true,
+		Reason: fmt.Sprintf("fanout: dispatching to %d providers", len(providers)),
+	}
+
+	// Build targets list for the event.
+	targets := make([]events.ProviderFanoutTarget, len(providers))
+	for i, pc := range providers {
+		targets[i] = events.ProviderFanoutTarget{
+			Provider: pc.Provider,
+			Model:    pc.Model,
+		}
+	}
+
+	// Store state.
+	state := &fanoutState{
+		role:     role,
+		strategy: p.cfg.Strategy,
+		targets:  targets,
+		request:  *req,
+		done:     make(chan struct{}),
+		expected: len(providers),
+	}
+
+	p.mu.Lock()
+	p.inflight[fanoutID] = state
+	p.mu.Unlock()
+
+	p.logger.Info("fanout started",
+		"fanout_id", fanoutID,
+		"role", role,
+		"strategy", p.cfg.Strategy,
+		"providers", len(providers),
+	)
+
+	// Notify observers.
+	_ = p.bus.Emit("provider.fanout.start", events.ProviderFanoutStart{
+		FanoutID: fanoutID,
+		Role:     role,
+		Strategy: p.cfg.Strategy,
+		Targets:  targets,
+	})
+
+	// Dispatch parallel requests.
+	for _, pc := range providers {
+		newMeta := make(map[string]any)
+		if req.Metadata != nil {
+			for k, v := range req.Metadata {
+				newMeta[k] = v
+			}
+		}
+		newMeta["_fanout_id"] = fanoutID
+		newMeta["_target_provider"] = pc.Provider
+		newMeta["_fanout_provider"] = pc.Provider
+		// Tag with _source so agent handlers skip individual fanout responses.
+		// The final combined response emitted by finalize() has no _source.
+		newMeta["_source"] = pluginID
+
+		fanReq := *req
+		fanReq.Model = pc.Model
+		fanReq.Metadata = newMeta
+		fanReq.Stream = false // fanout requires complete responses
+		if pc.MaxTokens > 0 && fanReq.MaxTokens == 0 {
+			fanReq.MaxTokens = pc.MaxTokens
+		}
+
+		p.bus.EmitAsync("llm.request", fanReq)
+	}
+
+	// Start deadline watcher.
+	go p.watchDeadline(fanoutID)
+}
+
+// handleResponse intercepts llm.response events tagged with a fanout ID,
+// collects them, and emits the final combined response when all are in.
+func (p *Plugin) handleResponse(event engine.Event[any]) {
+	resp, ok := event.Payload.(events.LLMResponse)
+	if !ok {
+		return
+	}
+
+	// Skip judge responses — they go through the one-shot sub in selectByJudge.
+	if _, isJudge := resp.Metadata["_fanout_judge"]; isJudge {
+		return
+	}
+
+	fanoutID, _ := resp.Metadata["_fanout_id"].(string)
+	if fanoutID == "" {
+		return
+	}
+
+	provider, _ := resp.Metadata["_fanout_provider"].(string)
+
+	p.mu.Lock()
+	state, exists := p.inflight[fanoutID]
+	p.mu.Unlock()
+
+	if !exists {
+		return
+	}
+
+	state.mu.Lock()
+	state.responses = append(state.responses, resp)
+	state.receivedAt = append(state.receivedAt, time.Now())
+	state.received++
+	allDone := state.received >= state.expected
+	state.mu.Unlock()
+
+	p.logger.Info("fanout response received",
+		"fanout_id", fanoutID,
+		"provider", provider,
+		"model", resp.Model,
+		"received", state.received,
+		"expected", state.expected,
+	)
+
+	// Notify per-provider response.
+	_ = p.bus.Emit("provider.fanout.response", events.ProviderFanoutResponse{
+		FanoutID: fanoutID,
+		Provider: provider,
+		Model:    resp.Model,
+		Success:  true,
+	})
+
+	if allDone {
+		p.finalize(fanoutID, state)
+	}
+}
+
+// handleBeforeError captures provider errors for in-flight fanout requests.
+func (p *Plugin) handleBeforeError(event engine.Event[any]) {
+	vp, ok := event.Payload.(*engine.VetoablePayload)
+	if !ok {
+		return
+	}
+	errInfo, ok := vp.Original.(*events.ErrorInfo)
+	if !ok {
+		return
+	}
+
+	meta := errInfo.RequestMeta
+	if meta == nil {
+		return
+	}
+
+	fanoutID, _ := meta["_fanout_id"].(string)
+	if fanoutID == "" {
+		return
+	}
+
+	provider, _ := meta["_fanout_provider"].(string)
+	model, _ := meta["_target_provider"].(string)
+
+	p.mu.Lock()
+	state, exists := p.inflight[fanoutID]
+	p.mu.Unlock()
+
+	if !exists {
+		return
+	}
+
+	// Veto the error — we're handling it within the fanout.
+	vp.Veto = engine.VetoResult{
+		Vetoed: true,
+		Reason: fmt.Sprintf("fanout: absorbing error from %s", provider),
+	}
+
+	state.mu.Lock()
+	state.errors = append(state.errors, fanoutError{
+		provider: provider,
+		model:    model,
+		err:      errInfo.Err.Error(),
+	})
+	state.received++
+	allDone := state.received >= state.expected
+	state.mu.Unlock()
+
+	p.logger.Warn("fanout provider failed",
+		"fanout_id", fanoutID,
+		"provider", provider,
+		"error", errInfo.Err,
+	)
+
+	// Notify per-provider failure.
+	_ = p.bus.Emit("provider.fanout.response", events.ProviderFanoutResponse{
+		FanoutID: fanoutID,
+		Provider: provider,
+		Model:    model,
+		Success:  false,
+		Error:    errInfo.Err.Error(),
+	})
+
+	if allDone {
+		p.finalize(fanoutID, state)
+	}
+}
+
+// handleUserChoice receives the user's selection for the "user" strategy.
+func (p *Plugin) handleUserChoice(event engine.Event[any]) {
+	chosen, ok := event.Payload.(events.ProviderFanoutChosen)
+	if !ok {
+		return
+	}
+
+	p.mu.Lock()
+	ch, exists := p.pendingChoices[chosen.FanoutID]
+	p.mu.Unlock()
+
+	if !exists {
+		return
+	}
+
+	select {
+	case ch <- chosen.ChosenIndex:
+	default:
+	}
+}
+
+// watchDeadline enforces the configured deadline for a fanout sequence.
+func (p *Plugin) watchDeadline(fanoutID string) {
+	timer := time.NewTimer(p.cfg.deadline)
+	defer timer.Stop()
+
+	p.mu.Lock()
+	state, exists := p.inflight[fanoutID]
+	p.mu.Unlock()
+	if !exists {
+		return
+	}
+
+	select {
+	case <-timer.C:
+		state.mu.Lock()
+		remaining := state.expected - state.received
+		state.mu.Unlock()
+
+		if remaining > 0 {
+			p.logger.Warn("fanout deadline reached",
+				"fanout_id", fanoutID,
+				"remaining", remaining,
+			)
+			p.finalize(fanoutID, state)
+		}
+	case <-state.done:
+		// Already finalized.
+	}
+}
+
+// finalize assembles the combined response and emits it.
+func (p *Plugin) finalize(fanoutID string, state *fanoutState) {
+	// Ensure single finalization.
+	select {
+	case <-state.done:
+		return // already finalized
+	default:
+		close(state.done)
+	}
+
+	// Remove from inflight.
+	p.mu.Lock()
+	delete(p.inflight, fanoutID)
+	p.mu.Unlock()
+
+	state.mu.Lock()
+	responses := make([]events.LLMResponse, len(state.responses))
+	copy(responses, state.responses)
+	receivedAt := make([]time.Time, len(state.receivedAt))
+	copy(receivedAt, state.receivedAt)
+	errors := make([]fanoutError, len(state.errors))
+	copy(errors, state.errors)
+	origRequest := state.request
+	state.mu.Unlock()
+
+	if len(responses) == 0 {
+		// All providers failed — emit error.
+		errMsg := "fanout: all providers failed"
+		if len(errors) > 0 {
+			errMsg = fmt.Sprintf("fanout: all %d providers failed, first: %s", len(errors), errors[0].err)
+		}
+		_ = p.bus.Emit("core.error", &events.ErrorInfo{
+			Source:      pluginID,
+			Err:         fmt.Errorf("%s", errMsg),
+			Fatal:       false,
+			RequestMeta: origRequest.Metadata,
+		})
+		return
+	}
+
+	// Apply selection strategy.
+	switch state.strategy {
+	case StrategyHeuristic:
+		if len(responses) > 1 {
+			winner := p.selectByHeuristic(responses, receivedAt)
+			if winner != 0 {
+				responses[0], responses[winner] = responses[winner], responses[0]
+				receivedAt[0], receivedAt[winner] = receivedAt[winner], receivedAt[0]
+			}
+		}
+		p.emitFinalResponse(fanoutID, state, responses)
+
+	case StrategyLLMJudge:
+		if len(responses) > 1 {
+			// Async — judge makes an LLM call then emits the final response.
+			go p.selectByJudge(fanoutID, state, responses, origRequest)
+			return
+		}
+		p.emitFinalResponse(fanoutID, state, responses)
+
+	case StrategyUser:
+		if len(responses) > 1 {
+			// Async — waits for user to pick, then emits the final response.
+			p.presentToUser(fanoutID, state, responses)
+			return
+		}
+		p.emitFinalResponse(fanoutID, state, responses)
+
+	default: // StrategyAll
+		p.emitFinalResponse(fanoutID, state, responses)
+	}
+}
+
+// emitFinalResponse builds the combined response and emits it. First response
+// in the slice is primary, rest become alternatives.
+func (p *Plugin) emitFinalResponse(fanoutID string, state *fanoutState, responses []events.LLMResponse) {
+	primary := responses[0]
+
+	// Strip fanout metadata from primary.
+	cleanMeta := make(map[string]any)
+	for k, v := range primary.Metadata {
+		if k == "_fanout_id" || k == "_fanout_provider" || k == "_target_provider" {
+			continue
+		}
+		cleanMeta[k] = v
+	}
+	cleanMeta["_fanout"] = true
+	cleanMeta["_fanout_id"] = fanoutID
+	primary.Metadata = cleanMeta
+
+	// Remaining responses become alternatives.
+	if len(responses) > 1 {
+		primary.Alternatives = responses[1:]
+	}
+
+	// Aggregate usage across all responses.
+	var totalUsage events.Usage
+	var totalCost float64
+	for _, r := range responses {
+		totalUsage.PromptTokens += r.Usage.PromptTokens
+		totalUsage.CompletionTokens += r.Usage.CompletionTokens
+		totalUsage.TotalTokens += r.Usage.TotalTokens
+		totalCost += r.CostUSD
+	}
+	primary.Usage = totalUsage
+	primary.CostUSD = totalCost
+
+	p.logger.Info("fanout complete",
+		"fanout_id", fanoutID,
+		"succeeded", len(responses),
+		"strategy", state.strategy,
+	)
+
+	// Notify completion.
+	_ = p.bus.Emit("provider.fanout.complete", events.ProviderFanoutComplete{
+		FanoutID:  fanoutID,
+		Role:      state.role,
+		Strategy:  state.strategy,
+		Succeeded: len(responses),
+	})
+
+	// Emit combined response. This goes to the agent as a normal llm.response.
+	_ = p.bus.Emit("llm.response", primary)
+}

--- a/plugins/providers/fanout/user.go
+++ b/plugins/providers/fanout/user.go
@@ -1,0 +1,112 @@
+package fanout
+
+import (
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// newTimer is a package-level variable so tests can replace it with a
+// fast-firing timer to avoid real delays.
+var newTimer = time.NewTimer
+
+// presentToUser emits a provider.fanout.choose event with all responses and
+// waits for the user to pick one via provider.fanout.chosen. On timeout or
+// user declining (index -1), falls back to the "all" strategy behavior.
+func (p *Plugin) presentToUser(fanoutID string, state *fanoutState, responses []events.LLMResponse) {
+	// Build options from responses.
+	options := make([]events.ProviderFanoutOption, len(responses))
+	for i, r := range responses {
+		provider, _ := r.Metadata["_fanout_provider"].(string)
+		options[i] = events.ProviderFanoutOption{
+			Index:    i,
+			Provider: provider,
+			Model:    r.Model,
+			Content:  r.Content,
+			CostUSD:  r.CostUSD,
+		}
+	}
+
+	// Create a buffered channel for the user's choice.
+	choiceCh := make(chan int, 1)
+
+	p.mu.Lock()
+	p.pendingChoices[fanoutID] = choiceCh
+	p.mu.Unlock()
+
+	// Emit the choice event for IO plugins to render.
+	_ = p.bus.Emit("provider.fanout.choose", events.ProviderFanoutChoose{
+		FanoutID:  fanoutID,
+		Role:      state.role,
+		Responses: options,
+	})
+
+	// Wait for user choice or deadline.
+	go p.awaitUserChoice(fanoutID, state, responses, choiceCh)
+}
+
+// awaitUserChoice waits for the user to pick a response or for the deadline
+// to expire, then emits the final response.
+func (p *Plugin) awaitUserChoice(fanoutID string, state *fanoutState, responses []events.LLMResponse, choiceCh chan int) {
+	var chosenIndex int
+	fallback := false
+
+	select {
+	case idx := <-choiceCh:
+		if idx < 0 || idx >= len(responses) {
+			// User declined or invalid index — fall back to "all" behavior.
+			p.logger.Warn("user declined fanout choice, falling back to all strategy",
+				"fanout_id", fanoutID,
+				"chosen_index", idx,
+			)
+			fallback = true
+		} else {
+			chosenIndex = idx
+		}
+	case <-p.deadlineTimer(state):
+		p.logger.Warn("fanout user choice timed out, falling back to all strategy",
+			"fanout_id", fanoutID,
+		)
+		fallback = true
+	}
+
+	// Clean up pending choice.
+	p.mu.Lock()
+	delete(p.pendingChoices, fanoutID)
+	p.mu.Unlock()
+
+	if fallback {
+		// Fall back to "all" strategy: first response as primary.
+		p.emitFinalResponse(fanoutID, state, responses)
+		return
+	}
+
+	// Reorder responses so the chosen one is first.
+	reordered := make([]events.LLMResponse, 0, len(responses))
+	reordered = append(reordered, responses[chosenIndex])
+	for i, r := range responses {
+		if i != chosenIndex {
+			reordered = append(reordered, r)
+		}
+	}
+
+	p.logger.Info("user selected fanout response",
+		"fanout_id", fanoutID,
+		"chosen_index", chosenIndex,
+		"chosen_model", responses[chosenIndex].Model,
+	)
+
+	p.emitFinalResponse(fanoutID, state, reordered)
+}
+
+// deadlineTimer returns a channel that fires after the configured deadline.
+func (p *Plugin) deadlineTimer(state *fanoutState) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		timer := newTimer(p.cfg.deadline)
+		<-timer.C
+		timer.Stop()
+		close(ch)
+	}()
+	return ch
+}

--- a/plugins/providers/fanout/user_test.go
+++ b/plugins/providers/fanout/user_test.go
@@ -1,0 +1,403 @@
+package fanout
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// mockBus is a minimal EventBus implementation for testing.
+type mockBus struct {
+	mu     sync.Mutex
+	events []emittedEvent
+}
+
+type emittedEvent struct {
+	Type    string
+	Payload any
+}
+
+func (b *mockBus) Emit(eventType string, payload any) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = append(b.events, emittedEvent{Type: eventType, Payload: payload})
+	return nil
+}
+
+func (b *mockBus) EmitEvent(_ engine.Event[any]) error { return nil }
+
+func (b *mockBus) EmitAsync(eventType string, payload any) <-chan error {
+	ch := make(chan error, 1)
+	ch <- b.Emit(eventType, payload)
+	close(ch)
+	return ch
+}
+
+func (b *mockBus) Subscribe(_ string, _ engine.HandlerFunc, _ ...engine.SubscribeOption) func() {
+	return func() {}
+}
+
+func (b *mockBus) SubscribeAll(_ engine.HandlerFunc) func() {
+	return func() {}
+}
+
+func (b *mockBus) EmitVetoable(_ string, _ any) (engine.VetoResult, error) {
+	return engine.VetoResult{}, nil
+}
+
+func (b *mockBus) Drain(_ context.Context) error { return nil }
+
+func (b *mockBus) emitted() []emittedEvent {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	cp := make([]emittedEvent, len(b.events))
+	copy(cp, b.events)
+	return cp
+}
+
+// helper to build test responses with fanout metadata.
+func makeResponse(provider, model, content string, cost float64) events.LLMResponse {
+	return events.LLMResponse{
+		Content: content,
+		Model:   model,
+		CostUSD: cost,
+		Usage: events.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 20,
+			TotalTokens:      30,
+		},
+		Metadata: map[string]any{
+			"_fanout_id":       "test-fanout",
+			"_fanout_provider": provider,
+			"_target_provider": provider,
+			"_source":          pluginID,
+		},
+	}
+}
+
+func newTestPlugin() (*Plugin, *mockBus) {
+	bus := &mockBus{}
+	p := &Plugin{
+		bus:            bus,
+		logger:         slog.Default(),
+		cfg:            config{deadline: 5 * time.Second},
+		inflight:       make(map[string]*fanoutState),
+		pendingChoices: make(map[string]chan int),
+	}
+	return p, bus
+}
+
+func TestPresentToUser_BuildsCorrectOptions(t *testing.T) {
+	p, bus := newTestPlugin()
+
+	responses := []events.LLMResponse{
+		makeResponse("nexus.llm.anthropic", "claude-3", "Hello from Claude", 0.01),
+		makeResponse("nexus.llm.openai", "gpt-4", "Hello from GPT", 0.02),
+	}
+
+	state := &fanoutState{
+		role:     "compare",
+		strategy: StrategyUser,
+	}
+
+	// Use a very short deadline so the goroutine cleans up quickly.
+	p.cfg.deadline = 50 * time.Millisecond
+	origNewTimer := newTimer
+	newTimer = func(d time.Duration) *time.Timer { return time.NewTimer(10 * time.Millisecond) }
+	defer func() { newTimer = origNewTimer }()
+
+	p.presentToUser("test-fanout", state, responses)
+
+	// Give the goroutine time to emit the choose event.
+	time.Sleep(5 * time.Millisecond)
+
+	emitted := bus.emitted()
+
+	// Find the provider.fanout.choose event.
+	var chooseEvent *events.ProviderFanoutChoose
+	for _, e := range emitted {
+		if e.Type == "provider.fanout.choose" {
+			if c, ok := e.Payload.(events.ProviderFanoutChoose); ok {
+				chooseEvent = &c
+				break
+			}
+		}
+	}
+
+	if chooseEvent == nil {
+		t.Fatal("expected provider.fanout.choose event to be emitted")
+	}
+
+	if chooseEvent.FanoutID != "test-fanout" {
+		t.Errorf("expected fanoutID %q, got %q", "test-fanout", chooseEvent.FanoutID)
+	}
+	if chooseEvent.Role != "compare" {
+		t.Errorf("expected role %q, got %q", "compare", chooseEvent.Role)
+	}
+	if len(chooseEvent.Responses) != 2 {
+		t.Fatalf("expected 2 options, got %d", len(chooseEvent.Responses))
+	}
+
+	opt0 := chooseEvent.Responses[0]
+	if opt0.Index != 0 || opt0.Provider != "nexus.llm.anthropic" || opt0.Model != "claude-3" {
+		t.Errorf("option 0 mismatch: %+v", opt0)
+	}
+	if opt0.Content != "Hello from Claude" {
+		t.Errorf("option 0 content mismatch: got %q", opt0.Content)
+	}
+	if opt0.CostUSD != 0.01 {
+		t.Errorf("option 0 cost mismatch: got %f", opt0.CostUSD)
+	}
+
+	opt1 := chooseEvent.Responses[1]
+	if opt1.Index != 1 || opt1.Provider != "nexus.llm.openai" || opt1.Model != "gpt-4" {
+		t.Errorf("option 1 mismatch: %+v", opt1)
+	}
+
+	// Wait for timeout fallback to complete.
+	time.Sleep(30 * time.Millisecond)
+}
+
+func TestUserChoice_ValidIndex(t *testing.T) {
+	p, bus := newTestPlugin()
+
+	responses := []events.LLMResponse{
+		makeResponse("nexus.llm.anthropic", "claude-3", "Hello from Claude", 0.01),
+		makeResponse("nexus.llm.openai", "gpt-4", "Hello from GPT", 0.02),
+		makeResponse("nexus.llm.google", "gemini", "Hello from Gemini", 0.005),
+	}
+
+	state := &fanoutState{
+		role:     "compare",
+		strategy: StrategyUser,
+	}
+
+	// Use a long deadline so it doesn't fire during the test.
+	p.cfg.deadline = 10 * time.Second
+	origNewTimer := newTimer
+	newTimer = func(d time.Duration) *time.Timer { return time.NewTimer(d) }
+	defer func() { newTimer = origNewTimer }()
+
+	p.presentToUser("test-fanout", state, responses)
+
+	// Simulate user choosing index 1 (GPT-4).
+	p.mu.Lock()
+	ch, exists := p.pendingChoices["test-fanout"]
+	p.mu.Unlock()
+
+	if !exists {
+		t.Fatal("expected pending choice channel to exist")
+	}
+
+	ch <- 1
+
+	// Wait for the goroutine to process.
+	time.Sleep(20 * time.Millisecond)
+
+	emitted := bus.emitted()
+
+	// Find the llm.response event.
+	var finalResp *events.LLMResponse
+	for _, e := range emitted {
+		if e.Type == "llm.response" {
+			if r, ok := e.Payload.(events.LLMResponse); ok {
+				finalResp = &r
+				break
+			}
+		}
+	}
+
+	if finalResp == nil {
+		t.Fatal("expected llm.response event to be emitted")
+	}
+
+	// The chosen response (index 1, GPT-4) should be primary.
+	if finalResp.Model != "gpt-4" {
+		t.Errorf("expected primary model %q, got %q", "gpt-4", finalResp.Model)
+	}
+	if finalResp.Content != "Hello from GPT" {
+		t.Errorf("expected primary content %q, got %q", "Hello from GPT", finalResp.Content)
+	}
+
+	// Alternatives should contain the other two.
+	if len(finalResp.Alternatives) != 2 {
+		t.Fatalf("expected 2 alternatives, got %d", len(finalResp.Alternatives))
+	}
+	if finalResp.Alternatives[0].Model != "claude-3" {
+		t.Errorf("expected first alternative model %q, got %q", "claude-3", finalResp.Alternatives[0].Model)
+	}
+	if finalResp.Alternatives[1].Model != "gemini" {
+		t.Errorf("expected second alternative model %q, got %q", "gemini", finalResp.Alternatives[1].Model)
+	}
+
+	// Verify pending choice was cleaned up.
+	p.mu.Lock()
+	_, stillPending := p.pendingChoices["test-fanout"]
+	p.mu.Unlock()
+	if stillPending {
+		t.Error("expected pending choice to be cleaned up")
+	}
+}
+
+func TestUserChoice_NegativeIndex_FallsBack(t *testing.T) {
+	p, bus := newTestPlugin()
+
+	responses := []events.LLMResponse{
+		makeResponse("nexus.llm.anthropic", "claude-3", "Hello from Claude", 0.01),
+		makeResponse("nexus.llm.openai", "gpt-4", "Hello from GPT", 0.02),
+	}
+
+	state := &fanoutState{
+		role:     "compare",
+		strategy: StrategyUser,
+	}
+
+	p.cfg.deadline = 10 * time.Second
+	origNewTimer := newTimer
+	newTimer = func(d time.Duration) *time.Timer { return time.NewTimer(d) }
+	defer func() { newTimer = origNewTimer }()
+
+	p.presentToUser("test-fanout", state, responses)
+
+	// Simulate user declining (index -1).
+	p.mu.Lock()
+	ch := p.pendingChoices["test-fanout"]
+	p.mu.Unlock()
+
+	ch <- -1
+
+	// Wait for the goroutine to process.
+	time.Sleep(20 * time.Millisecond)
+
+	emitted := bus.emitted()
+
+	// Find the llm.response event.
+	var finalResp *events.LLMResponse
+	for _, e := range emitted {
+		if e.Type == "llm.response" {
+			if r, ok := e.Payload.(events.LLMResponse); ok {
+				finalResp = &r
+				break
+			}
+		}
+	}
+
+	if finalResp == nil {
+		t.Fatal("expected llm.response event to be emitted")
+	}
+
+	// With fallback to "all" strategy, first response stays primary.
+	if finalResp.Model != "claude-3" {
+		t.Errorf("expected primary model %q (fallback), got %q", "claude-3", finalResp.Model)
+	}
+	if len(finalResp.Alternatives) != 1 {
+		t.Fatalf("expected 1 alternative, got %d", len(finalResp.Alternatives))
+	}
+	if finalResp.Alternatives[0].Model != "gpt-4" {
+		t.Errorf("expected alternative model %q, got %q", "gpt-4", finalResp.Alternatives[0].Model)
+	}
+}
+
+func TestUserChoice_Timeout_FallsBack(t *testing.T) {
+	p, bus := newTestPlugin()
+
+	responses := []events.LLMResponse{
+		makeResponse("nexus.llm.anthropic", "claude-3", "Hello from Claude", 0.01),
+		makeResponse("nexus.llm.openai", "gpt-4", "Hello from GPT", 0.02),
+	}
+
+	state := &fanoutState{
+		role:     "compare",
+		strategy: StrategyUser,
+	}
+
+	// Use a very short deadline to trigger timeout quickly.
+	p.cfg.deadline = 20 * time.Millisecond
+	origNewTimer := newTimer
+	newTimer = func(_ time.Duration) *time.Timer { return time.NewTimer(10 * time.Millisecond) }
+	defer func() { newTimer = origNewTimer }()
+
+	p.presentToUser("test-fanout", state, responses)
+
+	// Don't send any choice — let it time out.
+	time.Sleep(50 * time.Millisecond)
+
+	emitted := bus.emitted()
+
+	// Find the llm.response event.
+	var finalResp *events.LLMResponse
+	for _, e := range emitted {
+		if e.Type == "llm.response" {
+			if r, ok := e.Payload.(events.LLMResponse); ok {
+				finalResp = &r
+				break
+			}
+		}
+	}
+
+	if finalResp == nil {
+		t.Fatal("expected llm.response event after timeout")
+	}
+
+	// Timeout should fall back to "all" strategy — first response is primary.
+	if finalResp.Model != "claude-3" {
+		t.Errorf("expected primary model %q (fallback), got %q", "claude-3", finalResp.Model)
+	}
+	if len(finalResp.Alternatives) != 1 {
+		t.Fatalf("expected 1 alternative, got %d", len(finalResp.Alternatives))
+	}
+
+	// Verify pending choice was cleaned up.
+	p.mu.Lock()
+	_, stillPending := p.pendingChoices["test-fanout"]
+	p.mu.Unlock()
+	if stillPending {
+		t.Error("expected pending choice to be cleaned up after timeout")
+	}
+}
+
+func TestHandleUserChoice_DeliversToChannel(t *testing.T) {
+	p, _ := newTestPlugin()
+
+	// Set up a pending choice.
+	ch := make(chan int, 1)
+	p.mu.Lock()
+	p.pendingChoices["test-fanout"] = ch
+	p.mu.Unlock()
+
+	// Simulate receiving a provider.fanout.chosen event.
+	p.handleUserChoice(engine.Event[any]{
+		Type: "provider.fanout.chosen",
+		Payload: events.ProviderFanoutChosen{
+			FanoutID:    "test-fanout",
+			ChosenIndex: 2,
+		},
+	})
+
+	select {
+	case idx := <-ch:
+		if idx != 2 {
+			t.Errorf("expected chosen index 2, got %d", idx)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for choice delivery")
+	}
+}
+
+func TestHandleUserChoice_UnknownFanoutID(t *testing.T) {
+	p, _ := newTestPlugin()
+
+	// Should not panic when fanout ID is not found.
+	p.handleUserChoice(engine.Event[any]{
+		Type: "provider.fanout.chosen",
+		Payload: events.ProviderFanoutChosen{
+			FanoutID:    "nonexistent",
+			ChosenIndex: 0,
+		},
+	})
+}

--- a/tests/integration/fanout_test.go
+++ b/tests/integration/fanout_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/pkg/testharness"
+)
+
+// TestFanout_Boot validates that the engine boots cleanly with a fanout
+// role config and the fanout coordinator plugin active.
+func TestFanout_Boot(t *testing.T) {
+	h := testharness.New(t, "configs/test-fanout.yaml", testharness.WithTimeout(30*time.Second))
+	h.Run()
+
+	h.AssertBooted(
+		"nexus.io.test",
+		"nexus.llm.anthropic",
+		"nexus.llm.openai",
+		"nexus.provider.fanout",
+		"nexus.agent.react",
+		"nexus.memory.conversation",
+	)
+	h.AssertEventEmitted("io.session.start")
+	h.AssertEventEmitted("io.session.end")
+}
+
+// TestFanout_DispatchesAndCollects validates that the fanout plugin dispatches
+// to multiple providers and collects responses into a single combined response.
+func TestFanout_DispatchesAndCollects(t *testing.T) {
+	h := testharness.New(t, "configs/test-fanout.yaml", testharness.WithTimeout(30*time.Second))
+	h.Run()
+
+	// Fanout lifecycle events.
+	h.AssertEventEmitted("provider.fanout.start")
+	h.AssertEventEmitted("provider.fanout.complete")
+
+	// Two per-provider response events (one per fanout leg).
+	h.AssertEventCount("provider.fanout.response", 2, 2)
+
+	// Agent should still produce output (from combined response).
+	h.AssertEventEmitted("io.output")
+
+	// Verify fanout.start payload has correct targets.
+	for _, e := range h.Events() {
+		if e.Type == "provider.fanout.start" {
+			start, ok := e.Payload.(events.ProviderFanoutStart)
+			if !ok {
+				t.Fatal("provider.fanout.start payload is not ProviderFanoutStart")
+			}
+			if len(start.Targets) != 2 {
+				t.Fatalf("expected 2 fanout targets, got %d", len(start.Targets))
+			}
+			if start.Strategy != "all" {
+				t.Fatalf("expected strategy 'all', got %q", start.Strategy)
+			}
+		}
+	}
+
+	// Verify fanout.complete shows 2 successes.
+	for _, e := range h.Events() {
+		if e.Type == "provider.fanout.complete" {
+			complete, ok := e.Payload.(events.ProviderFanoutComplete)
+			if !ok {
+				t.Fatal("provider.fanout.complete payload is not ProviderFanoutComplete")
+			}
+			if complete.Succeeded != 2 {
+				t.Fatalf("expected 2 succeeded, got %d", complete.Succeeded)
+			}
+			if complete.Failed != 0 {
+				t.Fatalf("expected 0 failed, got %d", complete.Failed)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `nexus.provider.fanout` plugin that sends one LLM request to multiple providers in parallel and collects responses
- Add `EmitAsync` to EventBus for opt-in async event dispatch
- Add `fanout: true` role config in ModelRegistry for parallel provider groups
- Add `Alternatives []LLMResponse` field for multi-response payloads
- Four configurable selection strategies: `all`, `heuristic`, `llm_judge`, `user`
- Configurable deadline timeout for hung providers
- Full fanout lifecycle events (`provider.fanout.start/response/complete/choose/chosen`)

Closes #28

## Test plan

- [x] Unit tests: EmitAsync (2), ModelRegistry fanout parsing (2), heuristic scoring (9), judge prompt/parsing (12), user choice flow (6)
- [x] Integration tests: fanout boot + dispatch/collect with mock providers (2)
- [x] Full project build passes
- [x] Existing engine + integration tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)