### PR TITLE
feat: add system-wide XML prompt organization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,7 @@ Gate tracks `_structured_output` from `llm.response` metadata. Skips validation 
 - **Config**: YAML, loaded at startup. Plugin config passed as `map[string]any` during init.
 - **No direct plugin-to-plugin calls**: All comms via event bus.
 - **Dependencies**: Minimal — only `gopkg.in/yaml.v3` beyond stdlib. Anthropic API called via raw HTTP. JSON schema gate uses `github.com/santhosh-tekuri/jsonschema/v6`. Desktop shell adds `github.com/wailsapp/wails/v2`, `github.com/zalando/go-keyring`, `github.com/fsnotify/fsnotify`.
+- **Prompt construction**: All content injected into LLM prompts must use XML tag boundaries to separate structural sections. Use semantic tags (`<execution_plan>`, `<current_task>`, `<prior_results>`, `<user_request>`, `<skill_context>`, etc.) not markdown headers or bare concatenation. See `plugins/skills/catalog.go` for reference pattern. Shared XML helpers live in `pkg/engine/`.
 
 ## IO Transport Plugins: `nexus.io.browser` ↔ `nexus.io.wails`
 

--- a/docs/src/architecture/prompts.md
+++ b/docs/src/architecture/prompts.md
@@ -6,21 +6,46 @@ The prompt registry allows plugins to inject dynamic sections into the system pr
 
 1. Plugins register **prompt sections** during initialization, each with a name and priority
 2. When the LLM provider builds a request, it calls `prompts.Apply(systemPrompt)` to assemble the final prompt
-3. Each registered section function is called — if it returns a non-empty string, that content is appended
+3. Each registered section function is called — if it returns a non-empty string, that content is wrapped in an XML `<prompt_section>` tag and appended
 4. Sections are appended in priority order (lower priority numbers first)
+5. If a base system prompt is provided, it's wrapped in `<system_instructions>` tags
+
+## XML Structure
+
+All prompt content uses XML tag boundaries for clean structural separation. The assembled prompt looks like:
+
+```xml
+<system_instructions>
+You are a helpful assistant.
+</system_instructions>
+
+<prompt_section name="skill-catalog">
+<available_skills>
+  <skill name="code-review" scope="project">
+    <description>Review code for quality, bugs, security issues, and style.</description>
+  </skill>
+</available_skills>
+</prompt_section>
+
+<prompt_section name="dynvars">
+- Date: 2026-04-08
+- OS: darwin
+- CWD: /Users/frank/projects/myapp
+</prompt_section>
+```
 
 ## Registering a Section
 
 ```go
 func (p *MyPlugin) Init(ctx engine.PluginContext) error {
     ctx.Prompts.Register("my-context", 50, func() string {
-        return "## My Context\nSome dynamic information here."
+        return "Some dynamic information here."
     })
     return nil
 }
 ```
 
-The function is called every time a prompt is assembled, so it can return different content based on current state.
+The function is called every time a prompt is assembled, so it can return different content based on current state. The returned content is automatically wrapped in `<prompt_section name="my-context">` tags by the registry.
 
 ## Built-in Sections
 
@@ -29,6 +54,33 @@ The function is called every time a prompt is assembled, so it can return differ
 | `nexus.system.dynvars` | `dynvars` | 90 | Current date, time, timezone, CWD, OS |
 | `nexus.skills` | `skill-catalog` | 80 | XML-formatted list of available skills |
 
+## Agent-Level Semantic Tags
+
+Beyond the structural `<prompt_section>` wrapping, each agent type uses semantic XML tags for its dynamic content:
+
+| Tag | Content | Agents |
+|-----|---------|--------|
+| `<skill_context>` | Grouped loaded skill bodies | ReAct, PlanExec, Orchestrator |
+| `<execution_plan>` | Plan summary + step list | ReAct |
+| `<current_task>` | Current step instructions | ReAct, PlanExec, Orchestrator workers |
+| `<prior_results>` | Completed step/dependency outputs | PlanExec, Orchestrator workers |
+| `<user_request>` | Original user input (CDATA-wrapped) | PlanExec, Orchestrator |
+| `<subtask_results>` | Worker outputs in synthesis prompts | Orchestrator |
+
+User-provided content and LLM outputs are wrapped in CDATA blocks to prevent parsing conflicts.
+
+## XML Helpers
+
+Shared XML utilities in `pkg/engine/xml.go`:
+
+```go
+engine.XMLWrap("tag", content, "attr", "value")  // wrap content in <tag attr="value">...</tag>
+engine.XMLTag(&builder, "tag", "attr", "value")   // write opening tag
+engine.XMLClose(&builder, "tag")                   // write closing tag
+engine.XMLCDATA(content)                            // wrap in <![CDATA[...]]>
+engine.XMLEscape(s)                                 // escape &, <, >, "
+```
+
 ## API
 
 ```go
@@ -36,30 +88,14 @@ type PromptSectionFunc func() string
 
 type PromptRegistry struct {
     Register(name string, priority int, fn PromptSectionFunc)
+    Unregister(name string)
     Apply(systemPrompt string) string
 }
 ```
 
 - **`Register`** — Adds a named section. If a section with the same name already exists, it is replaced.
-- **`Apply`** — Takes the base system prompt and appends all registered sections that return non-empty strings, separated by newlines.
-
-## Example Output
-
-Given a system prompt of `"You are a helpful assistant."` and two registered sections:
-
-```
-You are a helpful assistant.
-
-## Available Skills
-<skills>
-  <skill name="code-review" scope="project">Review code for quality, bugs, security issues, and style.</skill>
-</skills>
-
-## System Info
-- Date: 2026-04-08
-- OS: darwin
-- CWD: /Users/frank/projects/myapp
-```
+- **`Unregister`** — Removes a named section.
+- **`Apply`** — Takes the base system prompt, wraps it in `<system_instructions>`, and appends all registered sections wrapped in `<prompt_section>` tags, in priority order.
 
 ## Use Cases
 

--- a/pkg/engine/prompt.go
+++ b/pkg/engine/prompt.go
@@ -73,7 +73,7 @@ func (r *PromptRegistry) Apply(systemPrompt string) string {
 	for _, s := range r.sections {
 		content := s.fn()
 		if content != "" {
-			parts = append(parts, content)
+			parts = append(parts, XMLWrap("prompt_section", content, "name", s.name))
 		}
 	}
 
@@ -81,10 +81,17 @@ func (r *PromptRegistry) Apply(systemPrompt string) string {
 		return systemPrompt
 	}
 
-	if systemPrompt == "" {
-		return strings.Join(parts, "\n\n")
+	var result strings.Builder
+	if systemPrompt != "" {
+		result.WriteString(XMLWrap("system_instructions", systemPrompt))
 	}
-	return systemPrompt + "\n\n" + strings.Join(parts, "\n\n")
+	for i, wrapped := range parts {
+		if i > 0 || systemPrompt != "" {
+			result.WriteByte('\n')
+		}
+		result.WriteString(wrapped)
+	}
+	return result.String()
 }
 
 func (r *PromptRegistry) sortLocked() {

--- a/pkg/engine/prompt_test.go
+++ b/pkg/engine/prompt_test.go
@@ -17,8 +17,15 @@ func TestPromptRegistry_ApplyEmptyPrompt(t *testing.T) {
 	r := NewPromptRegistry()
 	r.Register("test", 0, func() string { return "injected" })
 	result := r.Apply("")
-	if result != "injected" {
-		t.Fatalf("expected %q, got %q", "injected", result)
+	if !strings.Contains(result, "<prompt_section name=\"test\">") {
+		t.Fatalf("expected prompt_section tag, got %q", result)
+	}
+	if !strings.Contains(result, "injected") {
+		t.Fatalf("expected content, got %q", result)
+	}
+	// No system_instructions when base prompt is empty.
+	if strings.Contains(result, "<system_instructions>") {
+		t.Fatalf("should not have system_instructions for empty base, got %q", result)
 	}
 }
 
@@ -26,8 +33,17 @@ func TestPromptRegistry_ApplyAppends(t *testing.T) {
 	r := NewPromptRegistry()
 	r.Register("test", 0, func() string { return "section1" })
 	result := r.Apply("base")
-	if result != "base\n\nsection1" {
-		t.Fatalf("expected %q, got %q", "base\n\nsection1", result)
+	if !strings.Contains(result, "<system_instructions>") {
+		t.Fatalf("expected system_instructions wrapper, got %q", result)
+	}
+	if !strings.Contains(result, "base") {
+		t.Fatalf("expected base prompt content, got %q", result)
+	}
+	if !strings.Contains(result, `<prompt_section name="test">`) {
+		t.Fatalf("expected prompt_section tag, got %q", result)
+	}
+	if !strings.Contains(result, "section1") {
+		t.Fatalf("expected section content, got %q", result)
 	}
 }
 
@@ -38,8 +54,14 @@ func TestPromptRegistry_PriorityOrdering(t *testing.T) {
 	r.Register("b", 20, func() string { return "B" })
 
 	result := r.Apply("")
-	if result != "A\n\nB\n\nC" {
-		t.Fatalf("expected priority order A,B,C, got %q", result)
+	idxA := strings.Index(result, `name="a"`)
+	idxB := strings.Index(result, `name="b"`)
+	idxC := strings.Index(result, `name="c"`)
+	if idxA < 0 || idxB < 0 || idxC < 0 {
+		t.Fatalf("expected all three sections, got %q", result)
+	}
+	if !(idxA < idxB && idxB < idxC) {
+		t.Fatalf("expected priority order a < b < c, got %q", result)
 	}
 }
 
@@ -49,8 +71,11 @@ func TestPromptRegistry_SkipsEmptySections(t *testing.T) {
 	r.Register("full", 20, func() string { return "content" })
 
 	result := r.Apply("base")
-	if result != "base\n\ncontent" {
-		t.Fatalf("expected empty section skipped, got %q", result)
+	if strings.Contains(result, `name="empty"`) {
+		t.Fatalf("empty section should be skipped, got %q", result)
+	}
+	if !strings.Contains(result, `name="full"`) {
+		t.Fatalf("full section should be present, got %q", result)
 	}
 }
 
@@ -71,14 +96,16 @@ func TestPromptRegistry_ReplaceDuplicate(t *testing.T) {
 	r.Register("test", 10, func() string { return "new" })
 
 	result := r.Apply("")
-	if result != "new" {
+	if !strings.Contains(result, "new") {
 		t.Fatalf("expected replaced value, got %q", result)
 	}
-
+	if strings.Contains(result, "old") {
+		t.Fatalf("old value should be replaced, got %q", result)
+	}
 	// Should still be one section, not two.
-	count := strings.Count(result, "\n\n")
-	if count != 0 {
-		t.Fatalf("expected single section, got separators: %d", count)
+	count := strings.Count(result, "<prompt_section")
+	if count != 1 {
+		t.Fatalf("expected single section, got %d", count)
 	}
 }
 
@@ -90,8 +117,11 @@ func TestPromptRegistry_Unregister(t *testing.T) {
 	r.Unregister("a")
 
 	result := r.Apply("")
-	if result != "B" {
-		t.Fatalf("expected only B after unregister, got %q", result)
+	if strings.Contains(result, `name="a"`) {
+		t.Fatalf("unregistered section should not appear, got %q", result)
+	}
+	if !strings.Contains(result, `name="b"`) {
+		t.Fatalf("remaining section should appear, got %q", result)
 	}
 }
 
@@ -101,7 +131,7 @@ func TestPromptRegistry_UnregisterNonexistent(t *testing.T) {
 	r.Unregister("nonexistent") // should not panic
 
 	result := r.Apply("")
-	if result != "A" {
+	if !strings.Contains(result, "A") {
 		t.Fatalf("expected A unchanged, got %q", result)
 	}
 }

--- a/pkg/engine/xml.go
+++ b/pkg/engine/xml.go
@@ -1,0 +1,57 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+)
+
+// XMLTag writes an opening XML tag with optional attributes to a strings.Builder.
+// Attributes are written as key="value" pairs.
+func XMLTag(b *strings.Builder, tag string, attrs ...string) {
+	b.WriteByte('<')
+	b.WriteString(tag)
+	for i := 0; i+1 < len(attrs); i += 2 {
+		fmt.Fprintf(b, " %s=%q", attrs[i], attrs[i+1])
+	}
+	b.WriteString(">\n")
+}
+
+// XMLClose writes a closing XML tag to a strings.Builder.
+func XMLClose(b *strings.Builder, tag string) {
+	b.WriteString("</")
+	b.WriteString(tag)
+	b.WriteString(">\n")
+}
+
+// XMLWrap wraps content in an XML element with optional attributes.
+// Returns empty string if content is empty.
+func XMLWrap(tag, content string, attrs ...string) string {
+	if content == "" {
+		return ""
+	}
+	var b strings.Builder
+	XMLTag(&b, tag, attrs...)
+	b.WriteString(content)
+	if !strings.HasSuffix(content, "\n") {
+		b.WriteByte('\n')
+	}
+	XMLClose(&b, tag)
+	return b.String()
+}
+
+// XMLCDATA wraps content in a CDATA section. Use for content that may contain
+// characters that conflict with XML parsing (e.g. user input, LLM output).
+func XMLCDATA(content string) string {
+	// CDATA cannot contain the closing sequence "]]>". If present, split it.
+	content = strings.ReplaceAll(content, "]]>", "]]]]><![CDATA[>")
+	return "<![CDATA[" + content + "]]>"
+}
+
+// XMLEscape escapes XML special characters in a string.
+func XMLEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	return s
+}

--- a/pkg/engine/xml_test.go
+++ b/pkg/engine/xml_test.go
@@ -1,0 +1,83 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestXMLTag(t *testing.T) {
+	var b strings.Builder
+	XMLTag(&b, "section", "name", "test")
+	got := b.String()
+	want := "<section name=\"test\">\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestXMLTag_NoAttrs(t *testing.T) {
+	var b strings.Builder
+	XMLTag(&b, "block")
+	got := b.String()
+	want := "<block>\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestXMLClose(t *testing.T) {
+	var b strings.Builder
+	XMLClose(&b, "section")
+	got := b.String()
+	want := "</section>\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestXMLWrap(t *testing.T) {
+	got := XMLWrap("task", "do something", "id", "1")
+	want := "<task id=\"1\">\ndo something\n</task>\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestXMLWrap_TrailingNewline(t *testing.T) {
+	got := XMLWrap("task", "content\n")
+	want := "<task>\ncontent\n</task>\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestXMLWrap_Empty(t *testing.T) {
+	got := XMLWrap("task", "")
+	if got != "" {
+		t.Fatalf("expected empty string for empty content, got %q", got)
+	}
+}
+
+func TestXMLCDATA(t *testing.T) {
+	got := XMLCDATA("hello <world>")
+	want := "<![CDATA[hello <world>]]>"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestXMLCDATA_NestedClose(t *testing.T) {
+	got := XMLCDATA("data]]>more")
+	want := "<![CDATA[data]]]]><![CDATA[>more]]>"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestXMLEscape(t *testing.T) {
+	got := XMLEscape(`<a & "b">`)
+	want := "&lt;a &amp; &quot;b&quot;&gt;"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/plugins/agents/orchestrator/plugin.go
+++ b/plugins/agents/orchestrator/plugin.go
@@ -324,7 +324,7 @@ func (p *Plugin) handleSkillLoadedEvent(event engine.Event[any]) {
 	if content, ok := event.Payload.(events.SkillContent); ok {
 		p.mu.Lock()
 		defer p.mu.Unlock()
-		p.skillContexts = append(p.skillContexts, fmt.Sprintf("## Skill: %s\n\n%s", content.Name, content.Body))
+		p.skillContexts = append(p.skillContexts, engine.XMLWrap("skill", content.Body, "name", content.Name))
 		p.logger.Info("loaded skill context", "name", content.Name)
 	}
 }
@@ -384,15 +384,15 @@ func (p *Plugin) sendDecomposeRequest() {
 		toolNames[i] = t.Name
 	}
 
-	// Construct system prompt.
+	// Construct system prompt with XML boundaries.
 	var systemPrompt strings.Builder
 	if p.systemPrompt != "" {
 		systemPrompt.WriteString(p.systemPrompt)
 		systemPrompt.WriteString("\n\n")
 	}
 	if len(p.skillContexts) > 0 {
-		systemPrompt.WriteString(strings.Join(p.skillContexts, "\n\n---\n\n"))
-		systemPrompt.WriteString("\n\n")
+		systemPrompt.WriteString(engine.XMLWrap("skill_context", strings.Join(p.skillContexts, "\n")))
+		systemPrompt.WriteString("\n")
 	}
 
 	systemPrompt.WriteString("You are a task decomposition agent. Your role is to break down a user's request " +
@@ -619,7 +619,9 @@ func (p *Plugin) dispatchReadyWorkers() {
 		for _, dep := range p.subtasks[idx].DependsOn {
 			for _, t := range p.subtasks {
 				if t.ID == dep && t.Result != "" {
-					fmt.Fprintf(&depResults, "## Result from %s\n%s\n\n", t.ID, t.Result)
+					depResults.WriteString(engine.XMLWrap("dependency_result",
+						engine.XMLCDATA(t.Result),
+						"task_id", t.ID))
 				}
 			}
 		}
@@ -646,15 +648,15 @@ func (p *Plugin) dispatchReadyWorkers() {
 	// so each spawn blocks until the subagent completes. We emit them and rely
 	// on subagent.complete events to track progress.
 	for _, s := range spawns {
-		// Build a focused system prompt for the worker.
+		// Build a focused system prompt for the worker with XML boundaries.
 		var workerPrompt strings.Builder
 		workerPrompt.WriteString("You are a focused worker agent. Complete the assigned task thoroughly and concisely.\n\n")
-		fmt.Fprintf(&workerPrompt, "**Task:** %s\n\n", s.task)
+		workerPrompt.WriteString(engine.XMLWrap("current_task", s.task))
 		if s.depResults != "" {
-			workerPrompt.WriteString("## Context from Prior Tasks\n\n")
-			workerPrompt.WriteString(s.depResults)
+			workerPrompt.WriteString("\n")
+			workerPrompt.WriteString(engine.XMLWrap("prior_results", s.depResults))
 		}
-		workerPrompt.WriteString("When finished, provide a clear summary of what was accomplished and any relevant results.")
+		workerPrompt.WriteString("\nWhen finished, provide a clear summary of what was accomplished and any relevant results.")
 
 		p.logger.Info("dispatching worker",
 			"spawn_id", s.spawnID,
@@ -756,38 +758,46 @@ func (p *Plugin) sendSynthesizeRequest() {
 		systemPrompt.WriteString("\n\n")
 	}
 	if len(p.skillContexts) > 0 {
-		systemPrompt.WriteString(strings.Join(p.skillContexts, "\n\n---\n\n"))
-		systemPrompt.WriteString("\n\n")
+		systemPrompt.WriteString(engine.XMLWrap("skill_context", strings.Join(p.skillContexts, "\n")))
+		systemPrompt.WriteString("\n")
 	}
 
-	systemPrompt.WriteString("## Synthesis Task\n\n")
 	systemPrompt.WriteString("Multiple worker agents have completed subtasks in parallel. " +
 		"Synthesize their results into a clear, coherent response for the user.\n\n")
-	fmt.Fprintf(&systemPrompt, "**Original request:** %s\n\n", p.originalInput)
+	systemPrompt.WriteString(engine.XMLWrap("user_request", engine.XMLCDATA(p.originalInput)))
+	systemPrompt.WriteString("\n")
 
-	systemPrompt.WriteString("## Worker Results\n\n")
+	var resultsBody strings.Builder
 	for i, t := range p.subtasks {
-		fmt.Fprintf(&systemPrompt, "### Subtask %d: %s [%s]\n", i+1, t.Description, t.Status)
+		var content string
 		switch t.Status {
 		case "completed":
 			if t.Result != "" {
-				systemPrompt.WriteString(t.Result)
+				content = t.Result
+			} else {
+				content = "(no output)"
 			}
 		case "failed":
-			fmt.Fprintf(&systemPrompt, "**Failed:** %s", t.Error)
+			content = "Failed: " + t.Error
 			if t.Result != "" {
-				fmt.Fprintf(&systemPrompt, "\nPartial result: %s", t.Result)
+				content += "\nPartial result: " + t.Result
 			}
 		case "skipped":
-			fmt.Fprintf(&systemPrompt, "**Skipped:** %s", t.Error)
+			content = "Skipped: " + t.Error
+		default:
+			content = "(no output)"
 		}
-		systemPrompt.WriteString("\n\n")
+		resultsBody.WriteString(engine.XMLWrap("subtask_result",
+			engine.XMLCDATA(content),
+			"number", fmt.Sprintf("%d", i+1),
+			"description", t.Description,
+			"status", t.Status))
 	}
-
-	systemPrompt.WriteString("Provide a comprehensive response that addresses the user's original request, " +
-		"incorporating the results from all completed subtasks. " +
-		"If any subtasks failed or were skipped, note what could not be accomplished and why. " +
-		"Be concise but thorough.")
+	systemPrompt.WriteString(engine.XMLWrap("subtask_results", resultsBody.String()))
+	systemPrompt.WriteString("\nProvide a comprehensive response that addresses the user's original request, ")
+	systemPrompt.WriteString("incorporating the results from all completed subtasks. ")
+	systemPrompt.WriteString("If any subtasks failed or were skipped, note what could not be accomplished and why. ")
+	systemPrompt.WriteString("Be concise but thorough.")
 
 	var messages []events.Message
 	messages = append(messages, events.Message{

--- a/plugins/agents/planexec/plugin.go
+++ b/plugins/agents/planexec/plugin.go
@@ -388,7 +388,7 @@ func (p *Plugin) handleSkillLoadedEvent(event engine.Event[any]) {
 	if content, ok := event.Payload.(events.SkillContent); ok {
 		p.mu.Lock()
 		defer p.mu.Unlock()
-		p.skillContexts = append(p.skillContexts, fmt.Sprintf("## Skill: %s\n\n%s", content.Name, content.Body))
+		p.skillContexts = append(p.skillContexts, engine.XMLWrap("skill", content.Body, "name", content.Name))
 		p.logger.Info("loaded skill context", "name", content.Name)
 	}
 }
@@ -577,38 +577,47 @@ func (p *Plugin) sendStepLLMRequest() {
 
 	step := p.plan[p.currentStepIdx]
 
-	// Build system prompt for step execution.
+	// Build system prompt for step execution with XML boundaries.
 	var systemPrompt strings.Builder
 	if p.systemPrompt != "" {
 		systemPrompt.WriteString(p.systemPrompt)
 		systemPrompt.WriteString("\n\n")
 	}
 	if len(p.skillContexts) > 0 {
-		systemPrompt.WriteString(strings.Join(p.skillContexts, "\n\n---\n\n"))
-		systemPrompt.WriteString("\n\n")
+		systemPrompt.WriteString(engine.XMLWrap("skill_context", strings.Join(p.skillContexts, "\n")))
+		systemPrompt.WriteString("\n")
 	}
 
-	systemPrompt.WriteString("## Current Task\n\n")
-	fmt.Fprintf(&systemPrompt, "You are executing step %d of %d in an execution plan.\n\n", p.currentStepIdx+1, len(p.plan))
-	fmt.Fprintf(&systemPrompt, "**Step:** %s\n\n", step.Description)
+	var taskBody strings.Builder
+	fmt.Fprintf(&taskBody, "You are executing step %d of %d in an execution plan.\n\n", p.currentStepIdx+1, len(p.plan))
+	fmt.Fprintf(&taskBody, "Step: %s\n\n", step.Description)
 	if step.Instructions != "" && step.Instructions != step.Description {
-		fmt.Fprintf(&systemPrompt, "**Instructions:** %s\n\n", step.Instructions)
+		fmt.Fprintf(&taskBody, "Instructions: %s\n\n", step.Instructions)
 	}
-	fmt.Fprintf(&systemPrompt, "**Original user request:** %s\n\n", p.originalInput)
+	taskBody.WriteString("Focus on completing this specific step. Use the available tools as needed. ")
+	taskBody.WriteString("When you have completed the step, provide a brief summary of what was accomplished.\n")
+	systemPrompt.WriteString(engine.XMLWrap("current_task", taskBody.String()))
+
+	systemPrompt.WriteString("\n")
+	systemPrompt.WriteString(engine.XMLWrap("user_request", engine.XMLCDATA(p.originalInput)))
 
 	// Include results from prior steps.
 	if len(p.stepResults) > 0 {
-		systemPrompt.WriteString("## Context from Prior Steps\n\n")
+		var priorBody strings.Builder
 		for i := 0; i < p.currentStepIdx; i++ {
 			prevStep := p.plan[i]
 			if result, ok := p.stepResults[prevStep.ID]; ok {
-				fmt.Fprintf(&systemPrompt, "### Step %d: %s\n%s\n\n", i+1, prevStep.Description, result)
+				priorBody.WriteString(engine.XMLWrap("step_result",
+					engine.XMLCDATA(result),
+					"number", fmt.Sprintf("%d", i+1),
+					"description", prevStep.Description))
 			}
 		}
+		if priorBody.Len() > 0 {
+			systemPrompt.WriteString("\n")
+			systemPrompt.WriteString(engine.XMLWrap("prior_results", priorBody.String()))
+		}
 	}
-
-	systemPrompt.WriteString("Focus on completing this specific step. Use the available tools as needed. " +
-		"When you have completed the step, provide a brief summary of what was accomplished.")
 
 	var messages []events.Message
 	messages = append(messages, events.Message{
@@ -861,25 +870,29 @@ func (p *Plugin) sendSynthesisRequest() {
 		systemPrompt.WriteString("\n\n")
 	}
 	if len(p.skillContexts) > 0 {
-		systemPrompt.WriteString(strings.Join(p.skillContexts, "\n\n---\n\n"))
-		systemPrompt.WriteString("\n\n")
+		systemPrompt.WriteString(engine.XMLWrap("skill_context", strings.Join(p.skillContexts, "\n")))
+		systemPrompt.WriteString("\n")
 	}
 
-	systemPrompt.WriteString("## Synthesis Task\n\n")
 	systemPrompt.WriteString("You have completed a multi-step plan. Synthesize the results into a clear, coherent response for the user.\n\n")
-	fmt.Fprintf(&systemPrompt, "**Original request:** %s\n\n", p.originalInput)
+	systemPrompt.WriteString(engine.XMLWrap("user_request", engine.XMLCDATA(p.originalInput)))
+	systemPrompt.WriteString("\n")
 
-	systemPrompt.WriteString("## Step Results\n\n")
+	var resultsBody strings.Builder
 	for i, step := range p.plan {
-		fmt.Fprintf(&systemPrompt, "### Step %d: %s [%s]\n", i+1, step.Description, step.Status)
-		if step.Result != "" {
-			systemPrompt.WriteString(step.Result)
+		content := step.Result
+		if content == "" {
+			content = "(no output)"
 		}
-		systemPrompt.WriteString("\n\n")
+		resultsBody.WriteString(engine.XMLWrap("step_result",
+			engine.XMLCDATA(content),
+			"number", fmt.Sprintf("%d", i+1),
+			"description", step.Description,
+			"status", step.Status))
 	}
-
-	systemPrompt.WriteString("Provide a comprehensive response that addresses the user's original request, " +
-		"incorporating the results from all completed steps. Be concise but thorough.")
+	systemPrompt.WriteString(engine.XMLWrap("prior_results", resultsBody.String()))
+	systemPrompt.WriteString("\nProvide a comprehensive response that addresses the user's original request, ")
+	systemPrompt.WriteString("incorporating the results from all completed steps. Be concise but thorough.")
 
 	var messages []events.Message
 	messages = append(messages, events.Message{

--- a/plugins/agents/react/plugin.go
+++ b/plugins/agents/react/plugin.go
@@ -612,23 +612,24 @@ func (p *Plugin) handleToolResult(result events.ToolResult) {
 func (p *Plugin) handleSkillLoaded(content events.SkillContent) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.skillContexts = append(p.skillContexts, fmt.Sprintf("## Skill: %s\n\n%s", content.Name, content.Body))
+	p.skillContexts = append(p.skillContexts, engine.XMLWrap("skill", content.Body, "name", content.Name))
 	p.logger.Info("loaded skill context", "name", content.Name)
 }
 
 func (p *Plugin) sendLLMRequest() {
 	p.mu.Lock()
 
-	// Build system prompt with skill contexts and plan.
-	systemPrompt := p.systemPrompt
+	// Build system prompt with skill contexts and plan using XML boundaries.
+	var sysBuilder strings.Builder
+	sysBuilder.WriteString(p.systemPrompt)
 	if len(p.skillContexts) > 0 {
-		systemPrompt += "\n\n---\n\n" + strings.Join(p.skillContexts, "\n\n---\n\n")
+		sysBuilder.WriteString("\n\n")
+		sysBuilder.WriteString(engine.XMLWrap("skill_context", strings.Join(p.skillContexts, "\n")))
 	}
 	if p.currentPlan != nil && len(p.currentPlan.Steps) > 0 && p.currentPlanStep >= 0 {
-		var planText strings.Builder
-		planText.WriteString("\n\n## Execution Plan\n\n")
-		planText.WriteString(p.currentPlan.Summary)
-		planText.WriteString("\n\nFull plan:\n")
+		var planBody strings.Builder
+		planBody.WriteString(p.currentPlan.Summary)
+		planBody.WriteString("\n\nFull plan:\n")
 		for i, step := range p.currentPlan.Steps {
 			marker := "  "
 			if i < p.currentPlanStep {
@@ -636,20 +637,25 @@ func (p *Plugin) sendLLMRequest() {
 			} else if i == p.currentPlanStep {
 				marker = "> " // arrow for current
 			}
-			fmt.Fprintf(&planText, "%sStep %d: %s\n", marker, step.Order, step.Description)
+			fmt.Fprintf(&planBody, "%sStep %d: %s\n", marker, step.Order, step.Description)
 		}
+		sysBuilder.WriteString("\n\n")
+		sysBuilder.WriteString(engine.XMLWrap("execution_plan", planBody.String()))
 
 		current := p.currentPlan.Steps[p.currentPlanStep]
 		instructions := current.Instructions
 		if instructions == "" {
 			instructions = current.Description
 		}
-		fmt.Fprintf(&planText, "\n## CURRENT TASK (Step %d of %d)\n\n", current.Order, len(p.currentPlan.Steps))
-		fmt.Fprintf(&planText, "%s\n\n", instructions)
-		planText.WriteString("You MUST focus exclusively on this step. Do not skip ahead or work on other steps. ")
-		planText.WriteString("When this step is complete, respond with your results — do not call any more tools.\n")
-		systemPrompt += planText.String()
+		var taskBody strings.Builder
+		fmt.Fprintf(&taskBody, "Step %d of %d\n\n", current.Order, len(p.currentPlan.Steps))
+		fmt.Fprintf(&taskBody, "%s\n\n", instructions)
+		taskBody.WriteString("You MUST focus exclusively on this step. Do not skip ahead or work on other steps. ")
+		taskBody.WriteString("When this step is complete, respond with your results — do not call any more tools.\n")
+		sysBuilder.WriteString("\n")
+		sysBuilder.WriteString(engine.XMLWrap("current_task", taskBody.String()))
 	}
+	systemPrompt := sysBuilder.String()
 
 	// Build messages: system prompt + conversation history.
 	var messages []events.Message

--- a/plugins/skills/catalog.go
+++ b/plugins/skills/catalog.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/frankbardon/nexus/pkg/engine"
 )
 
 // resourceDirs are the subdirectories within a skill that contain resources.
@@ -72,10 +74,7 @@ func ListResources(baseDir string) ([]string, error) {
 	return resources, nil
 }
 
+// xmlEscape delegates to the shared engine.XMLEscape helper.
 func xmlEscape(s string) string {
-	s = strings.ReplaceAll(s, "&", "&amp;")
-	s = strings.ReplaceAll(s, "<", "&lt;")
-	s = strings.ReplaceAll(s, ">", "&gt;")
-	s = strings.ReplaceAll(s, "\"", "&quot;")
-	return s
+	return engine.XMLEscape(s)
 }


### PR DESCRIPTION
## Summary
- Add shared XML helpers (`XMLWrap`, `XMLTag`, `XMLClose`, `XMLCDATA`, `XMLEscape`) in `pkg/engine/xml.go`
- `PromptRegistry.Apply()` now wraps base prompt in `<system_instructions>` and each section in `<prompt_section name="...">`
- All three agent types (ReAct, PlanExec, Orchestrator) use semantic XML tags (`<skill_context>`, `<execution_plan>`, `<current_task>`, `<prior_results>`, `<user_request>`, `<subtask_results>`) with CDATA blocks for user/LLM content
- Promote `xmlEscape` from skills plugin to shared `engine.XMLEscape`

Closes #30

## Test plan
- [x] All existing unit tests updated and passing
- [x] New XML helper tests (9 cases) passing
- [x] `go build`, `go test ./...`, `go vet ./...` all clean
- [x] Integration test with live LLM to verify agent behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)