### PR TITLE
feat: unify logging via FanoutHandler with ring-buffered replay

### DIFF
--- a/pkg/engine/bus.go
+++ b/pkg/engine/bus.go
@@ -20,8 +20,16 @@ type EventBus interface {
 	// Subscribe registers a handler for an event type.
 	// Returns an unsubscribe function.
 	Subscribe(eventType string, handler HandlerFunc, opts ...SubscribeOption) (unsubscribe func())
-	// SubscribeAll registers a wildcard handler that receives all events.
+	// SubscribeAll registers a wildcard handler that receives all events
+	// emitted from this point forward. Pre-subscription events are not seen.
 	SubscribeAll(handler HandlerFunc) (unsubscribe func())
+	// SubscribeAllReplay is SubscribeAll plus a replay of every event
+	// currently held in the bus's ring buffer. The replay runs before live
+	// dispatch begins for the new subscriber, so observers that init after
+	// other plugins have already emitted still see those events. Replay and
+	// live dispatch are serialized: no event is delivered twice, none is
+	// dropped at the boundary.
+	SubscribeAllReplay(handler HandlerFunc) (unsubscribe func())
 	// EmitVetoable dispatches a before:* event. Handlers may veto by setting
 	// the VetoResult on the payload. Returns the result.
 	EmitVetoable(eventType string, payload any) (VetoResult, error)
@@ -76,12 +84,24 @@ type eventBus struct {
 	wildcards []*subscription
 	nextID    uint64
 	inflight  sync.WaitGroup
+	ring      *eventRing
 }
 
-// NewEventBus creates a new in-process EventBus.
+// NewEventBus creates a new in-process EventBus with a default-sized ring
+// buffer (DefaultLogRingSize). Pass NewEventBusWithRingSize to override.
 func NewEventBus() EventBus {
+	return NewEventBusWithRingSize(DefaultLogRingSize)
+}
+
+// NewEventBusWithRingSize builds a bus whose replay ring holds up to capacity
+// events. capacity <= 0 falls back to DefaultLogRingSize.
+func NewEventBusWithRingSize(capacity int) EventBus {
+	if capacity <= 0 {
+		capacity = DefaultLogRingSize
+	}
 	return &eventBus{
 		handlers: make(map[string][]*subscription),
+		ring:     newEventRing(capacity),
 	}
 }
 
@@ -146,6 +166,39 @@ func (b *eventBus) SubscribeAll(handler HandlerFunc) func() {
 	}
 }
 
+func (b *eventBus) SubscribeAllReplay(handler HandlerFunc) func() {
+	b.mu.Lock()
+	// Snapshot the ring and append the subscription under the same lock so
+	// no event can slip into the gap between snapshot and registration. See
+	// EmitEvent for the matching half of the protocol.
+	replay := b.ring.snapshot()
+	sub := &subscription{
+		id:      b.nextSubID(),
+		handler: handler,
+	}
+	b.wildcards = append(b.wildcards, sub)
+	subID := sub.id
+	b.mu.Unlock()
+
+	// Replay buffered events outside the lock so a slow handler does not
+	// stall concurrent emitters. Live events emitted from this point already
+	// see the new wildcard and are dispatched normally.
+	for _, e := range replay {
+		handler(e)
+	}
+
+	return func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		for i, s := range b.wildcards {
+			if s.id == subID {
+				b.wildcards = append(b.wildcards[:i], b.wildcards[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
 func (b *eventBus) Emit(eventType string, payload any) error {
 	event := Event[any]{
 		Type:      eventType,
@@ -162,13 +215,18 @@ func (b *eventBus) EmitEvent(event Event[any]) error {
 
 	meta := event.Meta()
 
-	b.mu.RLock()
-	// Copy handler slices under read lock to allow concurrent emits.
+	// Append to the replay ring and snapshot handlers under a single write
+	// lock. Serializing this block with SubscribeAllReplay is what guarantees
+	// every event is delivered to every subscriber exactly once — either in
+	// the replay snapshot (if it entered the ring before the subscriber was
+	// added to wildcards) or in live dispatch (if it was emitted after).
+	b.mu.Lock()
+	b.ring.append(event)
 	typed := make([]*subscription, len(b.handlers[event.Type]))
 	copy(typed, b.handlers[event.Type])
 	wilds := make([]*subscription, len(b.wildcards))
 	copy(wilds, b.wildcards)
-	b.mu.RUnlock()
+	b.mu.Unlock()
 
 	for _, sub := range typed {
 		if sub.filter != nil && !sub.filter(meta) {
@@ -212,10 +270,11 @@ func (b *eventBus) EmitVetoable(eventType string, payload any) (VetoResult, erro
 	}
 	meta := event.Meta()
 
-	b.mu.RLock()
+	b.mu.Lock()
+	b.ring.append(event)
 	typed := make([]*subscription, len(b.handlers[eventType]))
 	copy(typed, b.handlers[eventType])
-	b.mu.RUnlock()
+	b.mu.Unlock()
 
 	for _, sub := range typed {
 		if sub.filter != nil && !sub.filter(meta) {
@@ -244,4 +303,39 @@ func (b *eventBus) Drain(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// eventRing is a fixed-capacity ring of Events used to replay pre-subscription
+// events to late-arriving SubscribeAllReplay callers. Not safe for concurrent
+// use; the bus mutex serializes access.
+type eventRing struct {
+	buf  []Event[any]
+	head int
+	size int
+	cap  int
+}
+
+func newEventRing(capacity int) *eventRing {
+	return &eventRing{
+		buf: make([]Event[any], capacity),
+		cap: capacity,
+	}
+}
+
+func (r *eventRing) append(e Event[any]) {
+	if r.size == r.cap {
+		r.head = (r.head + 1) % r.cap
+		r.size--
+	}
+	idx := (r.head + r.size) % r.cap
+	r.buf[idx] = e
+	r.size++
+}
+
+func (r *eventRing) snapshot() []Event[any] {
+	out := make([]Event[any], r.size)
+	for i := 0; i < r.size; i++ {
+		out[i] = r.buf[(r.head+i)%r.cap]
+	}
+	return out
 }

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -21,10 +21,30 @@ type Config struct {
 // CoreConfig holds engine-level settings.
 type CoreConfig struct {
 	LogLevel            string         `yaml:"log_level"`
+	Logging             LoggingConfig  `yaml:"logging"`
 	TickInterval        time.Duration  `yaml:"tick_interval"`
 	MaxConcurrentEvents int            `yaml:"max_concurrent_events"`
 	Sessions            SessionsConfig `yaml:"sessions"`
 	ModelsRaw           map[string]any `yaml:"-"` // Parsed from core.models, used to build ModelRegistry
+}
+
+// LoggingConfig controls the engine-wide logging pipeline.
+//
+// The engine logger is a FanoutHandler with a bounded ring buffer and zero or
+// more dynamically-registered sinks. Absent a sink, records live only in the
+// ring until one registers (typically the logger plugin) or they are evicted.
+// This prevents log output from leaking to stdout/stderr when a visual IO
+// plugin owns the terminal.
+type LoggingConfig struct {
+	// BootstrapStderr, when true, registers a stderr sink at engine
+	// construction time so pre-sink records appear on the terminal. Default
+	// false. Rejected by config validation when a known visual transport
+	// plugin (nexus.io.tui, nexus.io.browser, nexus.io.wails) is active,
+	// because interleaving slog output with the UI corrupts the display.
+	BootstrapStderr bool `yaml:"bootstrap_stderr"`
+	// BufferSize is the capacity of the log and event ring buffers. Values
+	// <= 0 default to DefaultLogRingSize.
+	BufferSize int `yaml:"buffer_size"`
 }
 
 // SessionsConfig controls session workspace behavior.
@@ -115,7 +135,44 @@ func LoadConfigFromBytes(data []byte) (*Config, error) {
 		}
 	}
 
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	return cfg, nil
+}
+
+// visualTransportPlugins are base plugin IDs that own the terminal or a
+// webview when active. Writing slog output to stderr while any of these is
+// active corrupts the UI, so BootstrapStderr is rejected in that case.
+var visualTransportPlugins = map[string]bool{
+	"nexus.io.tui":     true,
+	"nexus.io.browser": true,
+	"nexus.io.wails":   true,
+}
+
+// validate is a post-load check. Keep rules narrow: only flag combinations
+// the engine cannot recover from, not stylistic issues.
+func (c *Config) validate() error {
+	if c.Core.Logging.BootstrapStderr {
+		for _, id := range c.Plugins.Active {
+			base := id
+			if i := len(id); i > 0 {
+				// Strip instance suffix ("foo/bar" -> "foo") without pulling
+				// in PluginBaseID to keep this file free of cross-deps.
+				for j := 0; j < i; j++ {
+					if id[j] == '/' {
+						base = id[:j]
+						break
+					}
+				}
+			}
+			if visualTransportPlugins[base] {
+				return fmt.Errorf("invalid config: core.logging.bootstrap_stderr is true but visual transport plugin %q is active; disable bootstrap_stderr or remove the visual plugin", id)
+			}
+		}
+	}
+	return nil
 }
 
 // extractPluginConfigs pulls per-plugin config maps from the plugins section.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -30,6 +30,10 @@ type Engine struct {
 	Schemas   *SchemaRegistry
 	System    *SystemInfo
 	Logger    *slog.Logger
+	// Logging is the LoggingHost passed to plugins via PluginContext. It is
+	// the same FanoutHandler that backs Logger — exposed here so embedders
+	// can register their own sinks without waiting for a plugin to do it.
+	Logging LoggingHost
 
 	// RecallSessionID, when set, causes Boot to resume an existing session
 	// instead of creating a new one.
@@ -82,17 +86,27 @@ func NewFromBytes(configBytes []byte) (*Engine, error) {
 // drift on logger setup, bus creation, or lifecycle wiring.
 func newFromConfig(cfg *Config) *Engine {
 	level := parseLogLevel(cfg.Core.LogLevel)
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: level,
-	}))
 
-	bus := NewEventBus()
+	// Build the fanout first so every later component (lifecycle, schema
+	// registry, context manager) writes through it from construction time.
+	// Pre-boot records land in the ring until a sink registers.
+	fanout := NewFanoutHandler(cfg.Core.Logging.BufferSize, level)
+	if cfg.Core.Logging.BootstrapStderr {
+		// Config.validate has already rejected the stderr+visual combo, so
+		// it is safe to add the sink here. Callers who want stderr output
+		// during bootstrap (CLI, headless dev) opt in via this flag.
+		fanout.AddLogSink(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+	}
+	logger := slog.New(fanout)
+
+	bus := NewEventBusWithRingSize(cfg.Core.Logging.BufferSize)
 	registry := NewPluginRegistry()
 	models := NewModelRegistry(cfg.Core.ModelsRaw)
 	prompts := NewPromptRegistry()
 	schemas := NewSchemaRegistry(logger)
 	system := DetectSystem()
 	lifecycle := NewLifecycleManager(registry, bus, cfg, logger, models, prompts, schemas, system)
+	lifecycle.logging = fanout
 	ctxMgr := NewContextManager(bus, logger)
 
 	return &Engine{
@@ -106,6 +120,7 @@ func newFromConfig(cfg *Config) *Engine {
 		Schemas:   schemas,
 		System:    system,
 		Logger:    logger,
+		Logging:   fanout,
 	}
 }
 

--- a/pkg/engine/lifecycle.go
+++ b/pkg/engine/lifecycle.go
@@ -26,6 +26,7 @@ type LifecycleManager struct {
 	config   *Config
 	plugins  []Plugin
 	logger   *slog.Logger
+	logging  LoggingHost
 	session  *SessionWorkspace
 	models   *ModelRegistry
 	prompts  *PromptRegistry
@@ -161,6 +162,7 @@ func (lm *LifecycleManager) Boot(ctx context.Context) error {
 			Schemas:      lm.schemas,
 			System:       lm.system,
 			Capabilities: lm.capabilitiesCopy(),
+			Logging:      lm.logging,
 			InstanceID:   instanceIDs[configuredID],
 		}
 
@@ -194,7 +196,10 @@ func (lm *LifecycleManager) Boot(ctx context.Context) error {
 	return nil
 }
 
-// Shutdown tears down plugins in reverse order, drains the bus, and signals completion.
+// Shutdown tears down plugins in reverse order, drains the bus, and signals
+// completion. Plugins that implement LateShutdown and return true are shut
+// down after every non-late plugin, so observers (logger, tracers) can still
+// receive records emitted during peer teardown.
 func (lm *LifecycleManager) Shutdown(ctx context.Context) error {
 	lm.logger.Info("shutting down engine")
 
@@ -204,18 +209,34 @@ func (lm *LifecycleManager) Shutdown(ctx context.Context) error {
 		lm.logger.Warn("drain timed out", "error", err)
 	}
 
-	// Shutdown in reverse dependency order.
+	// Partition plugins into normal and late phases. Preserve init order so
+	// that reverse iteration below mirrors the non-late topological order.
+	normal := make([]Plugin, 0, len(lm.plugins))
+	late := make([]Plugin, 0)
+	for _, p := range lm.plugins {
+		if ls, ok := p.(LateShutdown); ok && ls.LateShutdown() {
+			late = append(late, p)
+			continue
+		}
+		normal = append(normal, p)
+	}
+
 	var firstErr error
-	for i := len(lm.plugins) - 1; i >= 0; i-- {
-		p := lm.plugins[i]
-		lm.logger.Info("shutting down plugin", "plugin", p.ID())
-		if err := p.Shutdown(ctx); err != nil {
-			lm.logger.Error("plugin shutdown error", "plugin", p.ID(), "error", err)
-			if firstErr == nil {
-				firstErr = fmt.Errorf("plugin %q shutdown failed: %w", p.ID(), err)
+	shutdown := func(plugins []Plugin, phase string) {
+		for i := len(plugins) - 1; i >= 0; i-- {
+			p := plugins[i]
+			lm.logger.Info("shutting down plugin", "plugin", p.ID(), "phase", phase)
+			if err := p.Shutdown(ctx); err != nil {
+				lm.logger.Error("plugin shutdown error", "plugin", p.ID(), "phase", phase, "error", err)
+				if firstErr == nil {
+					firstErr = fmt.Errorf("plugin %q shutdown failed: %w", p.ID(), err)
+				}
 			}
 		}
 	}
+
+	shutdown(normal, "normal")
+	shutdown(late, "late")
 
 	lm.logger.Info("engine shutdown complete")
 	return firstErr

--- a/pkg/engine/loghandler.go
+++ b/pkg/engine/loghandler.go
@@ -1,0 +1,211 @@
+package engine
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+)
+
+// DefaultLogRingSize is the default capacity of the in-engine log and event
+// ring buffers.
+const DefaultLogRingSize = 4096
+
+// LoggingHost is the engine-side surface a plugin uses to become a log sink.
+// It is threaded onto PluginContext so the logger plugin (and only the logger
+// plugin, in practice) can register its slog.Handler and receive both the
+// buffered pre-init records and every live record from that point forward.
+//
+// The "capture, not alter" contract: registering a sink does not transform
+// records, strip attrs, or fan out to any implicit sink. The sink sees exactly
+// what the engine logger emits. When no sink is registered, records accumulate
+// in a bounded ring until one registers or they are evicted.
+type LoggingHost interface {
+	// AddLogSink registers a slog.Handler. On registration, every record
+	// currently in the engine's ring buffer is replayed to the sink in
+	// emission order; subsequent records are dispatched live. The returned
+	// function deregisters the sink.
+	AddLogSink(h slog.Handler) (remove func())
+}
+
+// FanoutHandler is the slog.Handler installed as the engine's root logger. It
+// writes every record into a bounded ring buffer and to every currently
+// registered sink. It has no implicit output target — absent a registered
+// sink, records only live in the ring. This keeps log output from leaking to
+// stdout/stderr when a visual IO plugin owns the terminal.
+//
+// FanoutHandler supports WithAttrs for per-plugin scoping (lifecycle attaches
+// a "plugin" attr per plugin logger). WithGroup is not supported and panics
+// if called — no plugin uses it today and proper retroactive grouping across
+// dynamic sinks is not trivial to implement. Revisit if a consumer appears.
+type FanoutHandler struct {
+	core  *fanoutCore
+	attrs []slog.Attr
+}
+
+// fanoutCore is the shared state across all handlers derived via WithAttrs.
+// Every derivation points at the same core so sink changes are observed by
+// every logger.
+type fanoutCore struct {
+	mu       sync.RWMutex
+	sinks    []*sinkEntry
+	ring     *logRing
+	level    slog.Level
+	nextID   uint64
+	overflow atomic.Uint64
+}
+
+type sinkEntry struct {
+	id      uint64
+	handler slog.Handler
+}
+
+// NewFanoutHandler builds a FanoutHandler with a ring buffer of the given
+// capacity. Capacity <= 0 falls back to DefaultLogRingSize. The level gates
+// Enabled for the whole handler; sinks may apply additional filtering.
+func NewFanoutHandler(capacity int, level slog.Level) *FanoutHandler {
+	if capacity <= 0 {
+		capacity = DefaultLogRingSize
+	}
+	return &FanoutHandler{
+		core: &fanoutCore{
+			ring:  newLogRing(capacity),
+			level: level,
+		},
+	}
+}
+
+// Enabled reports whether records at the given level should be processed.
+// Sinks that want stricter filtering should implement their own Enabled.
+func (h *FanoutHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.core.level
+}
+
+// Handle applies any accumulated WithAttrs state to the record, appends it to
+// the ring buffer, and dispatches a clone to every currently-registered sink.
+func (h *FanoutHandler) Handle(ctx context.Context, r slog.Record) error {
+	if len(h.attrs) > 0 {
+		r.AddAttrs(h.attrs...)
+	}
+
+	h.core.mu.Lock()
+	h.core.ring.append(&h.core.overflow, r.Clone())
+	sinks := make([]*sinkEntry, len(h.core.sinks))
+	copy(sinks, h.core.sinks)
+	h.core.mu.Unlock()
+
+	for _, s := range sinks {
+		if !s.handler.Enabled(ctx, r.Level) {
+			continue
+		}
+		_ = s.handler.Handle(ctx, r.Clone())
+	}
+	return nil
+}
+
+// WithAttrs returns a derived handler that appends attrs to every record it
+// processes. The derivation shares the underlying core, so sinks added after
+// derivation still see records flowing through the child.
+func (h *FanoutHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	next := make([]slog.Attr, len(h.attrs)+len(attrs))
+	copy(next, h.attrs)
+	copy(next[len(h.attrs):], attrs)
+	return &FanoutHandler{core: h.core, attrs: next}
+}
+
+// WithGroup is not supported. Nexus plugin code does not use groups today; the
+// retroactive-group semantics across dynamically registered sinks are not
+// worth the complexity until a concrete consumer exists.
+func (h *FanoutHandler) WithGroup(_ string) slog.Handler {
+	panic("engine.FanoutHandler: WithGroup is not supported")
+}
+
+// AddLogSink registers a sink. Records already buffered in the ring are
+// replayed to the sink in emission order before live records flow, so a
+// late-arriving sink never misses pre-init output. The returned remove
+// function is idempotent — calling it more than once is a no-op.
+func (h *FanoutHandler) AddLogSink(sink slog.Handler) (remove func()) {
+	h.core.mu.Lock()
+	h.core.nextID++
+	entry := &sinkEntry{id: h.core.nextID, handler: sink}
+	h.core.sinks = append(h.core.sinks, entry)
+	replay := h.core.ring.snapshot()
+	h.core.mu.Unlock()
+
+	// Replay outside the lock so a slow sink does not stall other emitters.
+	// Records emitted concurrently with this replay will also be dispatched
+	// live — the sink may see a brief window of interleaving at boundary,
+	// but never loses records and never sees them out of emission order
+	// within each class (replay vs. live).
+	ctx := context.Background()
+	for _, r := range replay {
+		if !sink.Enabled(ctx, r.Level) {
+			continue
+		}
+		_ = sink.Handle(ctx, r.Clone())
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			h.core.mu.Lock()
+			defer h.core.mu.Unlock()
+			for i, s := range h.core.sinks {
+				if s.id == entry.id {
+					h.core.sinks = append(h.core.sinks[:i], h.core.sinks[i+1:]...)
+					return
+				}
+			}
+		})
+	}
+}
+
+// RingStats returns the current number of records in the ring and the total
+// count of records evicted since construction. Useful for tests and
+// observability around the bootstrap phase.
+func (h *FanoutHandler) RingStats() (size int, overflow uint64) {
+	h.core.mu.RLock()
+	size = h.core.ring.size
+	h.core.mu.RUnlock()
+	overflow = h.core.overflow.Load()
+	return size, overflow
+}
+
+// logRing is a fixed-capacity ring of slog.Records. append evicts the oldest
+// entry when full and bumps the provided overflow counter. Not safe for
+// concurrent use; callers hold the fanoutCore mutex.
+type logRing struct {
+	buf  []slog.Record
+	head int
+	size int
+	cap  int
+}
+
+func newLogRing(capacity int) *logRing {
+	return &logRing{
+		buf: make([]slog.Record, capacity),
+		cap: capacity,
+	}
+}
+
+func (r *logRing) append(overflow *atomic.Uint64, rec slog.Record) {
+	if r.size == r.cap {
+		overflow.Add(1)
+		r.head = (r.head + 1) % r.cap
+		r.size--
+	}
+	idx := (r.head + r.size) % r.cap
+	r.buf[idx] = rec
+	r.size++
+}
+
+func (r *logRing) snapshot() []slog.Record {
+	out := make([]slog.Record, r.size)
+	for i := 0; i < r.size; i++ {
+		out[i] = r.buf[(r.head+i)%r.cap]
+	}
+	return out
+}

--- a/pkg/engine/plugin.go
+++ b/pkg/engine/plugin.go
@@ -115,9 +115,28 @@ type PluginContext struct {
 	// specific plugin IDs.
 	Capabilities map[string][]string
 
+	// Logging lets a plugin register itself as a sink for the engine's
+	// structured logger. Intended for the logger plugin (or equivalents);
+	// most plugins should ignore this field. Registration replays buffered
+	// pre-init records, then dispatches live records. See LoggingHost.
+	Logging LoggingHost
+
 	// InstanceID is set when a plugin is activated with an instance suffix
 	// (e.g. "nexus.agent.subagent/researcher"). It contains the full ID
 	// including the suffix. Plugins that support multiple instances should
 	// use this as their identity instead of their hardcoded ID.
 	InstanceID string
+}
+
+// LateShutdown is an optional marker interface. A plugin that implements it
+// and returns true is shut down after every non-late plugin, regardless of
+// its position in dependency order. Late shutdown is intended for observers
+// (loggers, tracers) that must stay active through peer plugins' Shutdown
+// calls so the records emitted during teardown still reach their sink.
+//
+// A late plugin is still initialized in dependency order; only shutdown
+// ordering shifts. Late plugins are shut down among themselves in reverse
+// init order, just like the normal phase.
+type LateShutdown interface {
+	LateShutdown() bool
 }

--- a/plugins/discovery/progressive/plugin_test.go
+++ b/plugins/discovery/progressive/plugin_test.go
@@ -31,6 +31,8 @@ func (b *testBus) Subscribe(eventType string, handler engine.HandlerFunc, _ ...e
 
 func (b *testBus) SubscribeAll(handler engine.HandlerFunc) func() { return func() {} }
 
+func (b *testBus) SubscribeAllReplay(handler engine.HandlerFunc) func() { return func() {} }
+
 func (b *testBus) Emit(eventType string, payload any) error {
 	b.emitted = append(b.emitted, emittedEvent{eventType, payload})
 	return nil

--- a/plugins/observe/logger/plugin.go
+++ b/plugins/observe/logger/plugin.go
@@ -3,8 +3,12 @@ package logger
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/frankbardon/nexus/pkg/engine"
@@ -12,37 +16,58 @@ import (
 
 const pluginID = "nexus.observe.logger"
 
-// Plugin observes all events and logs them in structured JSON format.
+// Plugin is the unified observer for the engine: it registers as a sink on
+// the engine's LoggingHost so every slog record — including those emitted
+// before this plugin booted — is captured, and it subscribes to the bus with
+// replay so every event since construction is captured too. Both streams
+// write JSONL into the session workspace.
+//
+// Messages and events go to separate files so they can be tailed and filtered
+// independently. Records from the main Go logger land in messages.jsonl;
+// every bus event lands in events.jsonl. Paths may be overridden to absolute
+// locations outside the session dir — useful for dev or centralized log
+// collection — but by default everything lives under
+// <session>/plugins/nexus.observe.logger/.
 type Plugin struct {
 	bus     engine.EventBus
 	logger  *slog.Logger
 	session *engine.SessionWorkspace
+	logging engine.LoggingHost
 
-	output   string // "stdout" or "file"
-	filePath string
-	level    slog.Level
-	unsub    func()
+	logMessages bool
+	logEvents   bool
+	level       slog.Level
 
-	eventLogger *slog.Logger
+	messagesPath string // absolute override; empty = session default
+	eventsPath   string // absolute override; empty = session default
+
+	// Resolved at Init; held for Shutdown.
+	messagesFile   *os.File
+	messagesMu     sync.Mutex // guards messagesFile writes; file handles are not safe for concurrent use
+	removeLogSink  func()
+	unsubEvents    func()
+	eventsFile     *os.File
+	eventsMu       sync.Mutex
 }
 
-// New creates a new observer/logger plugin.
+// New creates a new observer/logger plugin with defaults.
 func New() engine.Plugin {
 	return &Plugin{
-		output: "stdout",
-		level:  slog.LevelInfo,
+		logMessages: true,
+		logEvents:   true,
+		level:       slog.LevelInfo,
 	}
 }
 
 func (p *Plugin) ID() string                        { return pluginID }
 func (p *Plugin) Name() string                      { return "Event Logger" }
-func (p *Plugin) Version() string                   { return "0.1.0" }
+func (p *Plugin) Version() string                   { return "0.2.0" }
 func (p *Plugin) Dependencies() []string            { return nil }
 func (p *Plugin) Requires() []engine.Requirement    { return nil }
 func (p *Plugin) Capabilities() []engine.Capability { return nil }
 
 func (p *Plugin) Subscriptions() []engine.EventSubscription {
-	// No specific subscriptions; uses SubscribeAll.
+	// Uses SubscribeAllReplay via PluginContext.Bus.
 	return nil
 }
 
@@ -50,23 +75,80 @@ func (p *Plugin) Emissions() []string {
 	return nil
 }
 
+// LateShutdown returns true so this plugin is torn down after every non-late
+// plugin. Peer Shutdown methods that emit slog records during teardown still
+// reach the messages sink this plugin owns.
+func (p *Plugin) LateShutdown() bool { return true }
+
 func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.bus = ctx.Bus
 	p.logger = ctx.Logger
 	p.session = ctx.Session
+	p.logging = ctx.Logging
 
-	// Read config.
-	if v, ok := ctx.Config["output"]; ok {
-		if s, ok := v.(string); ok {
-			p.output = s
+	p.applyConfig(ctx.Config)
+
+	if p.logMessages {
+		if err := p.startMessagesSink(); err != nil {
+			return fmt.Errorf("starting messages sink: %w", err)
 		}
 	}
-	if v, ok := ctx.Config["file_path"]; ok {
-		if s, ok := v.(string); ok {
-			p.filePath = s
+	if p.logEvents {
+		if err := p.startEventsSink(); err != nil {
+			return fmt.Errorf("starting events sink: %w", err)
 		}
 	}
-	if v, ok := ctx.Config["level"]; ok {
+
+	p.logger.Info("event logger plugin initialized",
+		"log_messages", p.logMessages,
+		"log_events", p.logEvents,
+		"level", p.level.String())
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+// Shutdown deregisters the log sink, unsubscribes from the bus, and closes
+// the output files. Runs in the late phase so teardown records still land.
+func (p *Plugin) Shutdown(_ context.Context) error {
+	if p.removeLogSink != nil {
+		p.removeLogSink()
+		p.removeLogSink = nil
+	}
+	if p.unsubEvents != nil {
+		p.unsubEvents()
+		p.unsubEvents = nil
+	}
+
+	p.messagesMu.Lock()
+	if p.messagesFile != nil {
+		_ = p.messagesFile.Close()
+		p.messagesFile = nil
+	}
+	p.messagesMu.Unlock()
+
+	p.eventsMu.Lock()
+	if p.eventsFile != nil {
+		_ = p.eventsFile.Close()
+		p.eventsFile = nil
+	}
+	p.eventsMu.Unlock()
+
+	return nil
+}
+
+func (p *Plugin) applyConfig(cfg map[string]any) {
+	if v, ok := cfg["log_messages"]; ok {
+		if b, ok := v.(bool); ok {
+			p.logMessages = b
+		}
+	}
+	if v, ok := cfg["log_events"]; ok {
+		if b, ok := v.(bool); ok {
+			p.logEvents = b
+		}
+	}
+	if v, ok := cfg["level"]; ok {
 		if s, ok := v.(string); ok {
 			switch s {
 			case "debug":
@@ -80,75 +162,128 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 			}
 		}
 	}
+	if v, ok := cfg["messages_file_path"]; ok {
+		if s, ok := v.(string); ok {
+			p.messagesPath = s
+		}
+	}
+	if v, ok := cfg["events_file_path"]; ok {
+		if s, ok := v.(string); ok {
+			p.eventsPath = s
+		}
+	}
+}
 
-	// Create the event logger based on output config.
-	p.eventLogger = p.createEventLogger()
+func (p *Plugin) startMessagesSink() error {
+	if p.logging == nil {
+		// No host means the engine was constructed without a LoggingHost
+		// wired. That shouldn't happen for plugin-managed boots, but fall
+		// back gracefully so embedders who skip the field still boot.
+		p.logger.Warn("no LoggingHost on PluginContext; messages sink disabled")
+		return nil
+	}
 
-	// Subscribe to all events.
-	p.unsub = p.bus.SubscribeAll(p.handleEvent)
+	path := p.messagesPath
+	if path == "" {
+		if p.session == nil {
+			p.logger.Warn("no session workspace; messages sink disabled (set messages_file_path to override)")
+			return nil
+		}
+		path = filepath.Join(p.session.PluginDir(pluginID), "messages.jsonl")
+	}
 
-	p.logger.Info("event logger plugin initialized", "output", p.output, "level", p.level.String())
+	f, err := openAppend(path)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", path, err)
+	}
+	p.messagesFile = f
+
+	// Wrap the file in a mutex-serialized writer so concurrent Handle calls
+	// from the fanout do not interleave partial JSON lines. slog's JSON
+	// handler issues a single Write per record, but we still serialize to
+	// guard against torn writes when multiple sinks share a process.
+	sink := slog.NewJSONHandler(&lockedWriter{mu: &p.messagesMu, w: f}, &slog.HandlerOptions{
+		Level: p.level,
+	})
+	p.removeLogSink = p.logging.AddLogSink(sink)
 	return nil
 }
 
-func (p *Plugin) Ready() error { return nil }
-
-func (p *Plugin) Shutdown(_ context.Context) error {
-	if p.unsub != nil {
-		p.unsub()
+func (p *Plugin) startEventsSink() error {
+	if p.bus == nil {
+		return nil
 	}
+
+	path := p.eventsPath
+	if path == "" {
+		if p.session == nil {
+			p.logger.Warn("no session workspace; events sink disabled (set events_file_path to override)")
+			return nil
+		}
+		path = filepath.Join(p.session.PluginDir(pluginID), "events.jsonl")
+	}
+
+	f, err := openAppend(path)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", path, err)
+	}
+	p.eventsFile = f
+
+	p.unsubEvents = p.bus.SubscribeAllReplay(p.handleEvent)
 	return nil
 }
 
 func (p *Plugin) handleEvent(e engine.Event[any]) {
-	p.eventLogger.LogAttrs(context.Background(), slog.LevelDebug, "event",
-		slog.String("event_type", e.Type),
-		slog.String("event_id", e.ID),
-		slog.String("source", e.Source),
-		slog.Time("timestamp", e.Timestamp),
-	)
-
-	// If session workspace is available, also append to the plugin's event log.
-	if p.session != nil {
-		entry := eventLogEntry{
-			Type:      e.Type,
-			ID:        e.ID,
-			Source:    e.Source,
-			Timestamp: e.Timestamp,
-		}
-		data, err := json.Marshal(entry)
-		if err != nil {
-			return
-		}
-		data = append(data, '\n')
-		subpath := "plugins/" + pluginID + "/events.jsonl"
-		_ = p.session.AppendFile(subpath, data)
+	entry := eventLogEntry{
+		Type:      e.Type,
+		ID:        e.ID,
+		Source:    e.Source,
+		Timestamp: e.Timestamp,
 	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+
+	p.eventsMu.Lock()
+	defer p.eventsMu.Unlock()
+	if p.eventsFile == nil {
+		return
+	}
+	_, _ = p.eventsFile.Write(data)
 }
 
-func (p *Plugin) createEventLogger() *slog.Logger {
-	opts := &slog.HandlerOptions{Level: p.level}
-
-	switch p.output {
-	case "file":
-		if p.filePath != "" {
-			f, err := os.OpenFile(p.filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-			if err != nil {
-				p.logger.Error("failed to open log file, falling back to stderr", "path", p.filePath, "error", err)
-				return slog.New(slog.NewJSONHandler(os.Stderr, opts))
-			}
-			return slog.New(slog.NewJSONHandler(f, opts))
-		}
-		return slog.New(slog.NewJSONHandler(os.Stdout, opts))
-	default:
-		return slog.New(slog.NewJSONHandler(os.Stderr, opts))
-	}
-}
-
-// eventLogEntry is the JSON structure written to the session event log.
+// eventLogEntry is the JSON shape written to events.jsonl. Keep this struct
+// stable — external tools tail this file for observability.
 type eventLogEntry struct {
 	Type      string    `json:"type"`
 	ID        string    `json:"id"`
 	Source    string    `json:"source"`
 	Timestamp time.Time `json:"timestamp"`
+}
+
+// lockedWriter serializes Write calls to an underlying writer. The fanout
+// handler can dispatch records from multiple goroutines; slog.JSONHandler
+// itself is safe, but the io.Writer contract does not guarantee atomicity
+// across concurrent Writes, so we mediate.
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.w == nil {
+		return 0, nil
+	}
+	return l.w.Write(p)
+}
+
+func openAppend(path string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 }

--- a/plugins/providers/fanout/user_test.go
+++ b/plugins/providers/fanout/user_test.go
@@ -46,6 +46,10 @@ func (b *mockBus) SubscribeAll(_ engine.HandlerFunc) func() {
 	return func() {}
 }
 
+func (b *mockBus) SubscribeAllReplay(_ engine.HandlerFunc) func() {
+	return func() {}
+}
+
 func (b *mockBus) EmitVetoable(_ string, _ any) (engine.VetoResult, error) {
 	return engine.VetoResult{}, nil
 }


### PR DESCRIPTION
## Summary

- Engine logger is now a `FanoutHandler` (bounded ring + dynamically registered sinks) with no implicit stderr target. `nexus.observe.logger` registers as a sink via new `PluginContext.Logging` (LoggingHost) and replays the ring on registration, so every pre-init slog record is captured.
- Bus gains a parallel event ring and `SubscribeAllReplay`; the logger subscribes through it so pre-init events (`core.boot`, `io.session.start`, etc.) also make it into `events.jsonl`.
- New `LateShutdown` marker keeps the logger alive through peer teardown — its own shutdown record lands in the log.
- Stdout/stderr output is off by default, killing the UI-corruption leak when a visual IO plugin is active. `core.logging.bootstrap_stderr` opts back in for headless/dev; config validation rejects the combination with `nexus.io.tui`, `nexus.io.browser`, or `nexus.io.wails`.
- Default ring size 4096 records for both logs and events (configurable via `core.logging.buffer_size`).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages green
- [x] End-to-end smoke: boot nexus with only `nexus.observe.logger` active → `stdout`/`stderr` empty; `messages.jsonl` contains pre-init `"session started"` and `"booting engine"`; `events.jsonl` contains pre-subscription `session.file.created`, `io.session.start`, `core.boot`; plugin's own late-shutdown record captured.
- [x] Manual verify with a TUI/browser profile that no slog output corrupts the UI (follow-up — not exercised by automated tests).

## Follow-ups (not in this PR)

- 30 existing configs still carry the old `output:` / `file_path:` keys on `nexus.observe.logger` — silently ignored now; should be stripped and replaced with the new `log_messages` / `log_events` flags in a docs-and-config pass.
- Docs under `docs/` reference the old logger config shape and need a refresh.
- `EmitEvent` now takes the bus write lock (was `RLock`) so the event ring append and wildcard snapshot are atomic with `SubscribeAllReplay`. If benchmarks show contention, split the ring onto its own mutex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)