### PR TITLE
feat: Gemini LLM provider + Gemini-native search plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ plugins/
   apps/helloworld/       # Built-in hello-world placeholder agent
   providers/anthropic/   # Claude LLM provider (direct HTTP, no SDK; supports api_key config or api_key_env env var)
   providers/openai/      # OpenAI LLM provider (direct HTTP, no SDK; supports api_key config, api_key_env env var, base_url override)
+  providers/gemini/      # Google Gemini LLM provider (direct HTTP, no SDK; api-key + Vertex AI auth, thinking, code execution, multimodal, prompt caching)
   providers/fallback/    # Automatic provider failover coordinator (config-driven fallback chains in core.models)
   providers/fanout/      # Parallel multi-provider dispatch (config-driven fanout roles in core.models)
   tools/shell/           # Sandboxed shell execution (supports working_dir, allowed_commands, timeout, sandbox config)
@@ -74,6 +75,7 @@ plugins/
   search/brave/          # search.provider adapter: Brave Search REST API
   search/anthropic_native/ # search.provider adapter: Anthropic's server-side web_search tool (direct HTTP)
   search/openai_native/  # search.provider adapter: OpenAI's server-side web_search via Responses API
+  search/gemini_native/  # search.provider adapter: Gemini's google_search grounding tool
   io/tui/                # Terminal UI
   io/browser/            # Browser IO (HTTP/WS transport for the Nexus web UI)
   io/test/               # Non-interactive test IO (scripted inputs, event collection, auto-approvals)

--- a/configs/test-gemini-thinking.yaml
+++ b/configs/test-gemini-thinking.yaml
@@ -1,0 +1,53 @@
+# Test: Gemini 2.5 thinking (reasoning) parts
+# Validates: thinkingConfig request shape, thought-part filtering from Content,
+#            thinking.step events feeding nexus.observe.thinking JSONL.
+#
+# Run:
+#   bin/nexus -config configs/test-gemini-thinking.yaml
+#
+# What to watch for:
+#   - Session dir contains plugins/nexus.observe.thinking/thinking.jsonl with
+#     entries authored by Source=nexus.llm.gemini, Phase=reasoning.
+#   - Final response Content is the answer only — no chain-of-thought leakage.
+#   - usage.ReasoningTokens > 0 for non-trivial prompts.
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: reasoning
+    reasoning:
+      provider: nexus.llm.gemini
+      model: gemini-2.5-pro
+      max_tokens: 16384
+
+plugins:
+  active:
+    - nexus.io.tui
+    - nexus.llm.gemini
+    - nexus.agent.react
+    - nexus.gate.endless_loop
+    - nexus.memory.capped
+    - nexus.observe.logger
+    - nexus.observe.thinking
+
+  nexus.llm.gemini:
+    api_key_env: GEMINI_API_KEY
+    thinking:
+      enabled: true
+      budget_tokens: 8192
+      include_thoughts: true
+
+  nexus.agent.react:
+    system_prompt_file: ./prompts/conversationalist.md
+
+  nexus.gate.endless_loop:
+    max_iterations: 5
+
+  nexus.memory.capped:
+    max_messages: 50
+    persist: true
+
+  nexus.observe.logger:
+    output: stderr
+    level: info

--- a/configs/test-gemini-vertex.yaml
+++ b/configs/test-gemini-vertex.yaml
@@ -1,0 +1,54 @@
+# Test: Gemini provider via Vertex AI (service-account auth)
+#
+# Run:
+#   bin/nexus -config configs/test-gemini-vertex.yaml
+#
+# Prerequisites:
+#   - GOOGLE_CLOUD_PROJECT set, or override project_id below.
+#   - GOOGLE_APPLICATION_CREDENTIALS pointing to a service-account JSON key,
+#     or override service_account_json below. The key must have roles/aiplatform.user.
+#
+# What to test:
+#   1. Boot: provider mints OAuth2 token via signed JWT exchange. Watch logs
+#      for the first request — token cache should keep subsequent calls fast.
+#   2. URL routing: requests go to {location}-aiplatform.googleapis.com, NOT
+#      generativelanguage.googleapis.com.
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: balanced
+    balanced:
+      provider: nexus.llm.gemini
+      model: gemini-2.5-flash
+      max_tokens: 8192
+
+plugins:
+  active:
+    - nexus.io.tui
+    - nexus.llm.gemini
+    - nexus.agent.react
+    - nexus.gate.endless_loop
+    - nexus.memory.capped
+    - nexus.observe.logger
+
+  nexus.llm.gemini:
+    auth: vertex
+    location: us-central1
+    # project_id: your-project        # falls back to GOOGLE_CLOUD_PROJECT
+    # service_account_json: /path/to/sa.json  # falls back to GOOGLE_APPLICATION_CREDENTIALS
+
+  nexus.agent.react:
+    system_prompt_file: ./prompts/conversationalist.md
+
+  nexus.gate.endless_loop:
+    max_iterations: 10
+
+  nexus.memory.capped:
+    max_messages: 100
+    persist: true
+
+  nexus.observe.logger:
+    output: stderr
+    level: info

--- a/configs/test-gemini.yaml
+++ b/configs/test-gemini.yaml
@@ -1,0 +1,69 @@
+# Test: Gemini provider (api-key auth)
+# Validates: gemini sync + streaming, tool calls, role-mapping (assistant→model)
+#
+# Run:
+#   bin/nexus -config configs/test-gemini.yaml
+#
+# Prerequisites:
+#   - GEMINI_API_KEY (or GOOGLE_API_KEY) set in env or .env
+#
+# What to test:
+#   1. Boot: engine starts with Gemini provider, no Anthropic / OpenAI in logs.
+#   2. Streaming: response streams token-by-token in TUI.
+#   3. Tool calls: ask the model to read a file — exercises functionDeclarations
+#      round-trip (synthetic tool-call IDs, functionResponse parts).
+#   4. Multi-turn: ask a follow-up; assistant→model role mapping must be correct.
+#   5. Cancel: hit Ctrl-C mid-stream — should abort the in-flight HTTP request.
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: balanced
+    reasoning:
+      provider: nexus.llm.gemini
+      model: gemini-2.5-pro
+      max_tokens: 16384
+    balanced:
+      provider: nexus.llm.gemini
+      model: gemini-2.5-flash
+      max_tokens: 8192
+    quick:
+      provider: nexus.llm.gemini
+      model: gemini-2.5-flash-lite
+      max_tokens: 4096
+  sessions:
+    root: ~/.nexus/test-sessions
+    retention: 30d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.tui
+    - nexus.llm.gemini
+    - nexus.agent.react
+    - nexus.tool.file
+    - nexus.tool.shell
+    - nexus.gate.endless_loop
+    - nexus.memory.capped
+    - nexus.observe.logger
+
+  nexus.llm.gemini:
+    api_key_env: GEMINI_API_KEY
+
+  nexus.agent.react:
+    system_prompt_file: ./prompts/conversationalist.md
+
+  nexus.tool.shell:
+    allowed_commands: [ls, pwd, cat, echo]
+
+  nexus.gate.endless_loop:
+    max_iterations: 10
+
+  nexus.memory.capped:
+    max_messages: 100
+    persist: true
+
+  nexus.observe.logger:
+    output: stderr
+    level: info

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [LLM Providers](./plugins/providers/index.md)
   - [Anthropic (Claude)](./plugins/providers/anthropic.md)
   - [OpenAI](./plugins/providers/openai.md)
+  - [Gemini (Google)](./plugins/providers/gemini.md)
   - [Fallback](./plugins/providers/fallback.md)
   - [Fanout](./plugins/providers/fanout.md)
 - [Tools](./plugins/tools/index.md)

--- a/docs/src/plugins/providers/gemini.md
+++ b/docs/src/plugins/providers/gemini.md
@@ -1,0 +1,180 @@
+# Gemini Provider
+
+The Gemini provider calls Google's Gemini API via direct HTTP — no SDK dependency. It supports both the public Generative Language API (api-key auth) and Vertex AI (service-account JWT auth) and ships feature parity with the OpenAI and Anthropic providers (sync + streaming, tool use, structured output, retry, cancellation, debug logs, fallback hooks). On top of that it adds Gemini-only features: thinking ("reasoning") parts, multimodal inputs, the built-in code execution tool, and prompt caching via the `cachedContents` API.
+
+## Details
+
+|  |  |
+|---|---|
+| **ID** | `nexus.llm.gemini` |
+| **Dependencies** | None |
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `auth` | string | `api_key` | `api_key` for the public endpoint, `vertex` for Vertex AI |
+| `api_key` | string | — | Direct API key (overrides `api_key_env`) |
+| `api_key_env` | string | `GEMINI_API_KEY`, then `GOOGLE_API_KEY` | Env var holding the API key |
+| `project_id` | string | `$GOOGLE_CLOUD_PROJECT` | (Vertex) GCP project id |
+| `location` | string | `us-central1` | (Vertex) GCP region for the AI Platform endpoint |
+| `service_account_json` | string | — | (Vertex) Path to a service-account JSON key |
+| `service_account_json_env` | string | `GOOGLE_APPLICATION_CREDENTIALS` | (Vertex) Env var holding the service-account path |
+| `debug` | bool | `false` | Log raw request/response bodies into the session plugin directory |
+| `pricing` | map | embedded defaults | Per-model pricing overrides; see **Cost Tracking** below |
+| `retry` | map | disabled | Retry/backoff config; see **Retry Logic** |
+| `thinking` | map | disabled | Reasoning config for Gemini 2.5; see **Thinking** |
+| `code_execution` | bool | `false` | Enable Gemini's built-in code execution tool |
+| `cache` | map | disabled | Prompt cache config; see **Prompt Caching** |
+
+## Events
+
+### Subscribes To
+
+| Event | Priority | Purpose |
+|-------|----------|---------|
+| `llm.request` | 10 | LLM requests from agents |
+| `cancel.active` | 5 | Cancels in-flight API requests |
+
+### Emits
+
+| Event | When |
+|-------|------|
+| `llm.response` | Non-streaming response received (also after a stream completes) |
+| `llm.stream.chunk` | Each chunk of a streaming response |
+| `llm.stream.end` | Streaming response complete |
+| `thinking.step` | A `thought: true` part is observed (sync or stream) |
+| `tool.invoke` / `tool.result` | When the built-in code execution tool is used |
+| `before:core.error` / `core.error` | API errors (vetoable so fallback can intercept) |
+
+## Features
+
+### Auth Modes
+
+- **`api_key`** (default) — Sends `x-goog-api-key` header. URL: `https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`.
+- **`vertex`** — Mints an OAuth2 access token via signed JWT exchange against `https://oauth2.googleapis.com/token`, caches the token until expiry minus 60s, and routes requests to `https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent`. JWT signing uses RS256 from the stdlib `crypto/rsa`; no third-party dependencies are added.
+
+### Streaming
+
+When `llm.request.Stream` is `true`, the provider uses `:streamGenerateContent?alt=sse` and parses SSE `data:` lines. Text deltas are emitted as `llm.stream.chunk` (Content), function calls as `llm.stream.chunk` (ToolCall), and a final `llm.stream.end` carries `usageMetadata`.
+
+### Tool Calling
+
+Nexus tool definitions are translated into Gemini `functionDeclarations`. Because Gemini matches tool calls and tool responses by **function name** (not an opaque ID), the provider synthesises stable IDs (`call_{seq}_{name}`) on outbound responses and resolves trailing `tool` messages back to the function name when serializing `functionResponse` parts.
+
+### Tool Choice
+
+`ToolChoice.Mode` maps to `toolConfig.function_calling_config`:
+
+- `auto` → `mode: AUTO`
+- `required` → `mode: ANY`
+- `none` → `mode: NONE`
+- `tool` (with `Name`) → `mode: ANY` plus `allowed_function_names: [name]`
+
+### Structured Output (Native)
+
+When `ResponseFormat.Type` is `json_object` or `json_schema`, the provider sets `generationConfig.responseMimeType: application/json` and (for `json_schema`) `generationConfig.responseSchema`. JSON Schema fields Gemini doesn't accept (`$schema`, `$id`, `additionalProperties`, `$ref`, `definitions`, `$defs`) are stripped recursively. `LLMResponse.Metadata["_structured_output"]` is set to `true`.
+
+### Thinking (Gemini 2.5)
+
+When `thinking.enabled: true`, the provider sends `generationConfig.thinkingConfig`:
+
+```yaml
+nexus.llm.gemini:
+  thinking:
+    enabled: true
+    budget_tokens: 8192      # 0 = disabled, -1 = dynamic budget
+    include_thoughts: true   # surface thought parts to the bus
+```
+
+Response parts with `thought: true` are emitted as `thinking.step` events (`Source: nexus.llm.gemini`, `Phase: reasoning`) and are excluded from `LLMResponse.Content`. The `nexus.observe.thinking` plugin persists them to `plugins/nexus.observe.thinking/thinking.jsonl` automatically. `usageMetadata.thoughtsTokenCount` is mirrored into `events.Usage.ReasoningTokens`.
+
+### Multimodal
+
+`events.Message.Parts` (text, image, audio, video, file) is serialized into Gemini parts. Inline payloads up to 18 MB use `inlineData` with base64 bytes; larger payloads must be uploaded via the Files API and referenced by URI (`fileData.fileUri`). Provider falls back to `Content` only when `Parts` is empty, so existing text-only callers are unaffected.
+
+### Code Execution
+
+Set `code_execution: true` to advertise Gemini's built-in code execution tool. Response parts of type `executableCode` and `codeExecutionResult` are dual-emitted: appended to `Content` as fenced markdown blocks for any UI, and emitted as `tool.invoke` / `tool.result` events under the synthetic name `_gemini_code_execution` so observers see them as ordinary tool activity.
+
+### Prompt Caching
+
+```yaml
+nexus.llm.gemini:
+  cache:
+    enabled: true
+    min_tokens: 32768
+    ttl: "1h"
+    max_entries: 64
+```
+
+The provider computes a deterministic hash of the cache-eligible prefix (model + system instruction + tool declarations + the leading run of contents up to the first tool exchange). When a hit is present in the in-memory LRU, `cachedContent` is set on the request and only the trailing delta is sent. Cache entries are populated explicitly via `Plugin.createCachedContent`; the auto-populate path is intentionally read-only in this initial release. `usageMetadata.cachedContentTokenCount` flows into `events.Usage.CachedTokens` and the cost calculation applies the cached-input discount (default 25%, override via `pricing.<model>.cached_ratio`).
+
+### Cost Tracking
+
+Embedded defaults cover the 1.5, 2.0, and 2.5 model lines (single tier — the 2.5-pro >200k tier is **not** modeled; override via config when high-context billing matters):
+
+```yaml
+nexus.llm.gemini:
+  pricing:
+    gemini-2.5-pro:
+      input_per_million: 2.50      # >200k tier
+      output_per_million: 15.0
+      cached_ratio: 0.25
+```
+
+`ReasoningTokens` are billed at the output rate. `CachedTokens` are billed at `input_per_million * cached_ratio`; remaining prompt tokens at the standard input rate.
+
+### Retry Logic
+
+Same retry surface as the OpenAI / Anthropic providers (`constant`, `linear`, `exponential`, `exponential_jitter`). Defaults retry 429 / 500 / 502 / 503 / 504. Honors `Retry-After` on 429 responses.
+
+### Request Cancellation
+
+Subscribes to `cancel.active` at priority 5. When a cancellation arrives, the in-flight HTTP request context is cancelled.
+
+### Fallback Hook
+
+Errors are emitted on the vetoable `before:core.error` event before the terminal `core.error`, letting `nexus.provider.fallback` swap to another provider in the chain.
+
+## Example: api-key
+
+```yaml
+core:
+  models:
+    default: balanced
+    balanced:
+      provider: nexus.llm.gemini
+      model: gemini-2.5-flash
+      max_tokens: 8192
+
+plugins:
+  active:
+    - nexus.io.tui
+    - nexus.llm.gemini
+    - nexus.agent.react
+
+  nexus.llm.gemini:
+    api_key_env: GEMINI_API_KEY
+```
+
+## Example: Vertex AI
+
+```yaml
+plugins:
+  nexus.llm.gemini:
+    auth: vertex
+    location: us-central1
+    project_id: my-gcp-project
+    service_account_json: ~/.config/gcloud/keys/nexus-sa.json
+```
+
+## HTTP Configuration
+
+- **Timeout**: 5 minutes per request
+- **Public endpoint**: `https://generativelanguage.googleapis.com/v1beta`
+- **Vertex endpoint**: `https://{location}-aiplatform.googleapis.com/v1`
+
+## Search Grounding
+
+A separate plugin, `nexus.search.gemini_native`, advertises the `search.provider` capability and answers `search.request` events using Gemini's `google_search` tool. Use it independently of the LLM provider — for example, run Anthropic for chat and Gemini for grounded search lookups.

--- a/docs/src/plugins/providers/index.md
+++ b/docs/src/plugins/providers/index.md
@@ -8,6 +8,7 @@ LLM provider plugins handle communication with AI model APIs. They receive `llm.
 |--------|----|---------|
 | [Anthropic](./anthropic.md) | `nexus.llm.anthropic` | Claude (direct HTTP, no SDK) |
 | [OpenAI](./openai.md) | `nexus.llm.openai` | GPT / o-series (direct HTTP, no SDK) |
+| [Gemini](./gemini.md) | `nexus.llm.gemini` | Google Gemini — public api-key + Vertex AI; thinking, multimodal, code execution, prompt caching |
 | [Fallback](./fallback.md) | `nexus.provider.fallback` | Automatic provider failover coordinator |
 | [Fanout](./fanout.md) | `nexus.provider.fanout` | Parallel multi-provider dispatch |
 
@@ -33,6 +34,7 @@ When `ResponseFormat` is set on an `LLMRequest`, providers map it to their nativ
 |----------|---------------|----------|
 | **OpenAI** | Yes | Maps directly to `response_format` in the API payload |
 | **Anthropic** | No | Simulates via tool-use-as-schema: injects synthetic tool, forces tool choice, unwraps tool call arguments as structured response |
+| **Gemini** | Yes | Maps to `generationConfig.responseMimeType` + `responseSchema` (incompatible JSON Schema keywords stripped) |
 | **Other/unknown** | No | Ignores the field; `json_schema` gate handles validation downstream |
 
 ### Metadata Flag

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -42,11 +42,13 @@ import (
 	"github.com/frankbardon/nexus/plugins/providers/anthropic"
 	fallbackplugin "github.com/frankbardon/nexus/plugins/providers/fallback"
 	fanoutplugin "github.com/frankbardon/nexus/plugins/providers/fanout"
+	"github.com/frankbardon/nexus/plugins/providers/gemini"
 	"github.com/frankbardon/nexus/plugins/providers/openai"
 
 	// Search provider plugins (advertise the "search.provider" capability).
 	anthropicnativesearch "github.com/frankbardon/nexus/plugins/search/anthropic_native"
 	bravesearch "github.com/frankbardon/nexus/plugins/search/brave"
+	geminativesearch "github.com/frankbardon/nexus/plugins/search/gemini_native"
 	openainativesearch "github.com/frankbardon/nexus/plugins/search/openai_native"
 
 	// Embeddings provider plugins (advertise the "embeddings.provider" capability).
@@ -131,6 +133,7 @@ func RegisterAll(r *engine.PluginRegistry) {
 	// Providers
 	r.Register("nexus.llm.anthropic", anthropic.New)
 	r.Register("nexus.llm.openai", openai.New)
+	r.Register("nexus.llm.gemini", gemini.New)
 	r.Register("nexus.provider.fallback", fallbackplugin.New)
 	r.Register("nexus.provider.fanout", fanoutplugin.New)
 
@@ -138,6 +141,7 @@ func RegisterAll(r *engine.PluginRegistry) {
 	r.Register("nexus.search.brave", bravesearch.New)
 	r.Register("nexus.search.anthropic_native", anthropicnativesearch.New)
 	r.Register("nexus.search.openai_native", openainativesearch.New)
+	r.Register("nexus.search.gemini_native", geminativesearch.New)
 
 	// Embeddings providers (capability: embeddings.provider)
 	r.Register("nexus.embeddings.openai", openaiembeddings.New)

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -40,10 +40,26 @@ type LLMRequest struct {
 
 // Message represents a single message in an LLM conversation.
 type Message struct {
-	Role       string // "system", "user", "assistant", "tool"
-	Content    string
+	Role    string // "system", "user", "assistant", "tool"
+	Content string
+	Parts   []MessagePart // optional multimodal parts; when non-empty, providers
+	// that support multimodal serialize these alongside or instead of Content.
+	// Providers without multimodal support fall back to Content (text-only path).
 	ToolCallID string            // for tool result messages
 	ToolCalls  []ToolCallRequest // for assistant messages with tool calls
+}
+
+// MessagePart carries a single piece of multimodal content. Providers that
+// don't support a given Type should skip the part (or concatenate Text parts).
+// Either Data (inline bytes) or URI (provider-hosted reference) is set, never
+// both. Inline payloads beyond a provider-specific size limit are uploaded by
+// the provider and replaced with a URI on send.
+type MessagePart struct {
+	Type     string // "text" | "image" | "audio" | "video" | "file"
+	Text     string // when Type == "text"
+	MimeType string // e.g. "image/png", "application/pdf"; required when Data or URI set
+	Data     []byte // inline bytes
+	URI      string // provider-hosted reference (e.g. Gemini Files API URI)
 }
 
 // ToolCallRequest represents a tool invocation requested by the LLM.
@@ -89,6 +105,8 @@ type Usage struct {
 	PromptTokens     int
 	CompletionTokens int
 	TotalTokens      int
+	ReasoningTokens  int // thinking/reasoning tokens (Gemini 2.5 thoughtTokenCount, etc.)
+	CachedTokens     int // tokens served from a prompt cache (billed at a discount)
 }
 
 // StreamChunk is a single chunk from a streaming LLM response.

--- a/plugins/providers/gemini/auth.go
+++ b/plugins/providers/gemini/auth.go
@@ -1,0 +1,307 @@
+package gemini
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// authMode determines how requests are authenticated and routed.
+type authMode string
+
+const (
+	authModeAPIKey authMode = "api_key" // public Gemini Generative Language API
+	authModeVertex authMode = "vertex"  // Vertex AI on Google Cloud
+)
+
+// authState holds resolved auth configuration and cached credentials.
+type authState struct {
+	mode authMode
+
+	// API-key path.
+	apiKey string
+
+	// Vertex path.
+	saEmail   string
+	saKey     *rsa.PrivateKey
+	projectID string
+	location  string // e.g. "us-central1"
+
+	mu          sync.Mutex
+	tokenCache  string
+	tokenExpiry time.Time
+}
+
+// resolveAuth reads auth config and returns a configured authState.
+func resolveAuth(cfg map[string]any) (*authState, error) {
+	mode := authModeAPIKey
+	if v, ok := cfg["auth"].(string); ok {
+		switch authMode(v) {
+		case authModeAPIKey, authModeVertex:
+			mode = authMode(v)
+		default:
+			return nil, fmt.Errorf("gemini: unknown auth mode %q (expected api_key or vertex)", v)
+		}
+	}
+
+	a := &authState{mode: mode}
+
+	switch mode {
+	case authModeAPIKey:
+		if key, ok := cfg["api_key"].(string); ok && key != "" {
+			a.apiKey = key
+		} else {
+			envVar, _ := cfg["api_key_env"].(string)
+			if envVar != "" {
+				a.apiKey = os.Getenv(envVar)
+			} else {
+				if v := os.Getenv("GEMINI_API_KEY"); v != "" {
+					a.apiKey = v
+				} else if v := os.Getenv("GOOGLE_API_KEY"); v != "" {
+					a.apiKey = v
+				}
+			}
+		}
+		if a.apiKey == "" {
+			return nil, fmt.Errorf("gemini: no API key configured (set api_key in config or GEMINI_API_KEY / GOOGLE_API_KEY env var)")
+		}
+
+	case authModeVertex:
+		project, _ := cfg["project_id"].(string)
+		if project == "" {
+			project = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		}
+		if project == "" {
+			return nil, fmt.Errorf("gemini: vertex auth requires project_id config or GOOGLE_CLOUD_PROJECT env var")
+		}
+		a.projectID = project
+
+		loc, _ := cfg["location"].(string)
+		if loc == "" {
+			loc = "us-central1"
+		}
+		a.location = loc
+
+		var saJSON []byte
+		if path, ok := cfg["service_account_json"].(string); ok && path != "" {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("gemini: read service_account_json: %w", err)
+			}
+			saJSON = data
+		} else {
+			envVar, _ := cfg["service_account_json_env"].(string)
+			if envVar == "" {
+				envVar = "GOOGLE_APPLICATION_CREDENTIALS"
+			}
+			if path := os.Getenv(envVar); path != "" {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					return nil, fmt.Errorf("gemini: read %s=%s: %w", envVar, path, err)
+				}
+				saJSON = data
+			}
+		}
+		if saJSON == nil {
+			return nil, fmt.Errorf("gemini: vertex auth requires service_account_json or service_account_json_env")
+		}
+
+		email, key, err := parseServiceAccountJSON(saJSON)
+		if err != nil {
+			return nil, fmt.Errorf("gemini: parse service account: %w", err)
+		}
+		a.saEmail = email
+		a.saKey = key
+	}
+
+	return a, nil
+}
+
+// apiURL builds the request URL for a model + operation.
+// op is "generateContent" or "streamGenerateContent". For streaming, alt=sse
+// is appended.
+func (a *authState) apiURL(model, op string) string {
+	switch a.mode {
+	case authModeVertex:
+		base := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:%s",
+			a.location, a.projectID, a.location, model, op)
+		if op == "streamGenerateContent" {
+			base += "?alt=sse"
+		}
+		return base
+	default:
+		base := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:%s", model, op)
+		if op == "streamGenerateContent" {
+			base += "?alt=sse"
+		}
+		return base
+	}
+}
+
+// applyAuth attaches credentials to an outgoing request. For Vertex it may
+// fetch and cache a fresh OAuth2 token.
+func (a *authState) applyAuth(ctx context.Context, req *http.Request, httpClient *http.Client) error {
+	switch a.mode {
+	case authModeAPIKey:
+		req.Header.Set("x-goog-api-key", a.apiKey)
+		return nil
+	case authModeVertex:
+		token, err := a.vertexToken(ctx, httpClient)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+	return fmt.Errorf("gemini: unknown auth mode")
+}
+
+// filesAPIBaseURL returns the base URL for the Files API. Files API is only
+// available on the public endpoint; in Vertex mode an empty string is returned
+// to signal callers to use inline data.
+func (a *authState) filesAPIBaseURL() string {
+	if a.mode == authModeVertex {
+		return ""
+	}
+	return "https://generativelanguage.googleapis.com"
+}
+
+// cachedContentsURL returns the base URL for the cachedContents resource.
+func (a *authState) cachedContentsURL() string {
+	switch a.mode {
+	case authModeVertex:
+		return fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/cachedContents",
+			a.location, a.projectID, a.location)
+	default:
+		return "https://generativelanguage.googleapis.com/v1beta/cachedContents"
+	}
+}
+
+// vertexToken returns a valid OAuth2 access token, minting a new one if
+// needed. Tokens are cached in-memory until expiry minus 60s skew.
+func (a *authState) vertexToken(ctx context.Context, client *http.Client) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.tokenCache != "" && time.Now().Before(a.tokenExpiry) {
+		return a.tokenCache, nil
+	}
+
+	jwt, err := a.signJWT()
+	if err != nil {
+		return "", fmt.Errorf("sign JWT: %w", err)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+	form.Set("assertion", jwt)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://oauth2.googleapis.com/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token exchange failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var tr struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return "", fmt.Errorf("empty access_token in response: %s", string(body))
+	}
+
+	a.tokenCache = tr.AccessToken
+	expiresIn := time.Duration(tr.ExpiresIn) * time.Second
+	if expiresIn <= 0 {
+		expiresIn = 1 * time.Hour
+	}
+	a.tokenExpiry = time.Now().Add(expiresIn - 60*time.Second)
+
+	return a.tokenCache, nil
+}
+
+// signJWT mints an RS256-signed JWT bearer assertion for Google's token endpoint.
+func (a *authState) signJWT() (string, error) {
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	headerJSON, _ := json.Marshal(header)
+
+	now := time.Now().Unix()
+	claims := map[string]any{
+		"iss":   a.saEmail,
+		"scope": "https://www.googleapis.com/auth/cloud-platform",
+		"aud":   "https://oauth2.googleapis.com/token",
+		"exp":   now + 3600,
+		"iat":   now,
+	}
+	claimsJSON, _ := json.Marshal(claims)
+
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON)
+
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, a.saKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// parseServiceAccountJSON extracts client_email and the private RSA key.
+func parseServiceAccountJSON(data []byte) (string, *rsa.PrivateKey, error) {
+	var sa struct {
+		ClientEmail string `json:"client_email"`
+		PrivateKey  string `json:"private_key"`
+	}
+	if err := json.Unmarshal(data, &sa); err != nil {
+		return "", nil, fmt.Errorf("decode JSON: %w", err)
+	}
+	if sa.ClientEmail == "" || sa.PrivateKey == "" {
+		return "", nil, fmt.Errorf("missing client_email or private_key")
+	}
+
+	block, _ := pem.Decode([]byte(sa.PrivateKey))
+	if block == nil {
+		return "", nil, fmt.Errorf("invalid PEM in private_key")
+	}
+
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return sa.ClientEmail, k, nil
+	}
+	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse private_key: %w", err)
+	}
+	rsaKey, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return "", nil, fmt.Errorf("private_key is not RSA")
+	}
+	return sa.ClientEmail, rsaKey, nil
+}

--- a/plugins/providers/gemini/auth_test.go
+++ b/plugins/providers/gemini/auth_test.go
@@ -1,0 +1,156 @@
+package gemini
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+func TestResolveAuth_APIKey(t *testing.T) {
+	a, err := resolveAuth(map[string]any{"api_key": "test-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.mode != authModeAPIKey {
+		t.Fatalf("expected api_key mode, got %s", a.mode)
+	}
+	if a.apiKey != "test-key" {
+		t.Fatalf("expected api_key=test-key, got %q", a.apiKey)
+	}
+}
+
+func TestResolveAuth_APIKey_FromEnv(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "env-key")
+	a, err := resolveAuth(map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.apiKey != "env-key" {
+		t.Fatalf("expected env fallback, got %q", a.apiKey)
+	}
+}
+
+func TestResolveAuth_APIKey_FallsBackToGoogleAPIKey(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "google-fallback")
+	a, err := resolveAuth(map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.apiKey != "google-fallback" {
+		t.Fatalf("expected GOOGLE_API_KEY fallback, got %q", a.apiKey)
+	}
+}
+
+func TestResolveAuth_NoCreds(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	if _, err := resolveAuth(map[string]any{}); err == nil {
+		t.Fatal("expected error when no API key set")
+	}
+}
+
+func TestAPIURL_PublicEndpoint(t *testing.T) {
+	a := &authState{mode: authModeAPIKey}
+	got := a.apiURL("gemini-2.5-flash", "generateContent")
+	want := "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+
+	got = a.apiURL("gemini-2.5-flash", "streamGenerateContent")
+	if !strings.HasSuffix(got, "?alt=sse") {
+		t.Fatalf("streaming URL should append ?alt=sse, got %q", got)
+	}
+}
+
+func TestAPIURL_VertexEndpoint(t *testing.T) {
+	a := &authState{mode: authModeVertex, projectID: "myproj", location: "us-central1"}
+	got := a.apiURL("gemini-2.5-flash", "generateContent")
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/myproj/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
+	if got != want {
+		t.Fatalf("vertex URL: got %q want %q", got, want)
+	}
+}
+
+func TestSignJWT_RoundTrip(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &authState{mode: authModeVertex, saEmail: "sa@proj.iam.gserviceaccount.com", saKey: key}
+
+	jwt, err := a.signJWT()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3-segment JWT, got %d", len(parts))
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	var header map[string]string
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatalf("parse header: %v", err)
+	}
+	if header["alg"] != "RS256" {
+		t.Fatalf("alg=%s, want RS256", header["alg"])
+	}
+
+	claimsJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		t.Fatal(err)
+	}
+	if claims["iss"] != a.saEmail {
+		t.Fatalf("iss mismatch: %v", claims["iss"])
+	}
+	if claims["aud"] != "https://oauth2.googleapis.com/token" {
+		t.Fatalf("aud mismatch: %v", claims["aud"])
+	}
+}
+
+func TestParseServiceAccountJSON(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der})
+
+	sa := map[string]string{
+		"client_email": "test@proj.iam.gserviceaccount.com",
+		"private_key":  string(pemBytes),
+	}
+	saJSON, _ := json.Marshal(sa)
+
+	email, parsedKey, err := parseServiceAccountJSON(saJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if email != sa["client_email"] {
+		t.Fatalf("email mismatch: %s", email)
+	}
+	if parsedKey.N.Cmp(key.N) != 0 {
+		t.Fatal("parsed key modulus mismatch")
+	}
+}
+
+func TestParseServiceAccountJSON_InvalidPEM(t *testing.T) {
+	saJSON := []byte(`{"client_email":"x","private_key":"not a pem"}`)
+	if _, _, err := parseServiceAccountJSON(saJSON); err == nil {
+		t.Fatal("expected error on bad PEM")
+	}
+}

--- a/plugins/providers/gemini/cache.go
+++ b/plugins/providers/gemini/cache.go
@@ -1,0 +1,305 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// cacheState holds prompt-cache configuration and the in-memory key map.
+//
+//	cache:
+//	  enabled: true
+//	  min_tokens: 32768
+//	  ttl: "1h"
+//	  max_entries: 64
+//
+// Caching is conservative: only the stable prefix (system instruction + tool
+// declarations + initial user/model turns up to the first tool exchange) is
+// hashed and cached. The trailing delta is sent on every request.
+type cacheState struct {
+	enabled    bool
+	minTokens  int
+	ttl        time.Duration
+	maxEntries int
+	logger     *slog.Logger
+
+	mu      sync.Mutex
+	entries map[string]*cacheEntry // prefix-hash -> entry
+	order   []string               // LRU eviction order, oldest first
+}
+
+type cacheEntry struct {
+	name    string // resource name returned by cachedContents.create
+	expires time.Time
+}
+
+func newCacheState(cfg map[string]any, logger *slog.Logger) *cacheState {
+	cs := &cacheState{
+		minTokens:  32768,
+		ttl:        time.Hour,
+		maxEntries: 64,
+		logger:     logger,
+		entries:    make(map[string]*cacheEntry),
+	}
+
+	raw, ok := cfg["cache"].(map[string]any)
+	if !ok {
+		return cs
+	}
+
+	if v, ok := raw["enabled"].(bool); ok {
+		cs.enabled = v
+	}
+	if v, ok := raw["min_tokens"].(int); ok && v > 0 {
+		cs.minTokens = v
+	}
+	if v, ok := raw["max_entries"].(int); ok && v > 0 {
+		cs.maxEntries = v
+	}
+	if v, ok := raw["ttl"].(string); ok {
+		if d, err := time.ParseDuration(v); err == nil {
+			cs.ttl = d
+		}
+	}
+
+	return cs
+}
+
+// lookup returns a cached_content resource name when the request prefix
+// matches a live cache entry. Returns "" when no cache should be applied.
+//
+// This is a pure-read lookup; population happens out-of-band via populate().
+// The current implementation is a stub: it computes the prefix hash and
+// returns a hit when present, but never auto-populates (auto-population
+// requires a token-count probe and a synchronous create call). Callers can
+// pre-populate via a future explicit API; for now this preserves the engine
+// hook so cached prompts work when the user manually wires them.
+func (cs *cacheState) lookup(model, system string, tools []events.ToolDef, contents []map[string]any) string {
+	if cs == nil || !cs.enabled {
+		return ""
+	}
+
+	hash := cs.prefixHash(model, system, tools, contents)
+
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	entry, ok := cs.entries[hash]
+	if !ok {
+		return ""
+	}
+	if time.Now().After(entry.expires) {
+		delete(cs.entries, hash)
+		cs.removeOrder(hash)
+		return ""
+	}
+	return entry.name
+}
+
+// populate stores a cachedContents resource name against a prefix hash. Called
+// by integrations that explicitly create a cache entry (e.g. a future
+// admin tool or the cache plugin itself).
+func (cs *cacheState) populate(model, system string, tools []events.ToolDef, contents []map[string]any, name string, ttl time.Duration) {
+	if cs == nil || !cs.enabled {
+		return
+	}
+	hash := cs.prefixHash(model, system, tools, contents)
+	if ttl == 0 {
+		ttl = cs.ttl
+	}
+
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	cs.entries[hash] = &cacheEntry{name: name, expires: time.Now().Add(ttl)}
+	cs.order = append(cs.order, hash)
+	for len(cs.order) > cs.maxEntries {
+		oldest := cs.order[0]
+		cs.order = cs.order[1:]
+		delete(cs.entries, oldest)
+	}
+}
+
+// invalidate removes a cache entry by name (used when a 404 indicates Google-
+// side expiry).
+func (cs *cacheState) invalidate(name string) {
+	if cs == nil {
+		return
+	}
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	for hash, entry := range cs.entries {
+		if entry.name == name {
+			delete(cs.entries, hash)
+			cs.removeOrder(hash)
+			return
+		}
+	}
+}
+
+func (cs *cacheState) removeOrder(hash string) {
+	for i, h := range cs.order {
+		if h == hash {
+			cs.order = append(cs.order[:i], cs.order[i+1:]...)
+			return
+		}
+	}
+}
+
+// prefixHash hashes the request prefix that would be cached. Order: model,
+// system, tool declarations (sorted by name), and the leading run of contents
+// up to (but not including) any functionResponse turn (those represent the
+// dynamic tail).
+func (cs *cacheState) prefixHash(model, system string, tools []events.ToolDef, contents []map[string]any) string {
+	type toolKey struct {
+		Name        string
+		Description string
+		Params      map[string]any
+	}
+
+	keys := make([]toolKey, 0, len(tools))
+	for _, t := range tools {
+		keys = append(keys, toolKey{Name: t.Name, Description: t.Description, Params: t.Parameters})
+	}
+	// Stable order: same input set produces the same hash even if tool slice
+	// order varies between calls.
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1].Name > keys[j].Name; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+
+	prefixContents := make([]map[string]any, 0, len(contents))
+	for _, c := range contents {
+		if hasFunctionResponsePart(c) {
+			break
+		}
+		prefixContents = append(prefixContents, c)
+	}
+
+	payload := struct {
+		Model    string
+		System   string
+		Tools    []toolKey
+		Contents []map[string]any
+	}{
+		Model:    model,
+		System:   system,
+		Tools:    keys,
+		Contents: prefixContents,
+	}
+
+	data, _ := json.Marshal(payload)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func hasFunctionResponsePart(c map[string]any) bool {
+	parts, ok := c["parts"].([]map[string]any)
+	if !ok {
+		// Json round-trip might normalize to []any.
+		if alt, ok := c["parts"].([]any); ok {
+			for _, p := range alt {
+				if pm, ok := p.(map[string]any); ok {
+					if _, ok := pm["functionResponse"]; ok {
+						return true
+					}
+				}
+			}
+			return false
+		}
+		return false
+	}
+	for _, p := range parts {
+		if _, ok := p["functionResponse"]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// createCachedContent calls the cachedContents API to create a new cache
+// entry. Exposed for callers that want to pre-populate the cache; not used
+// by the auto-cache path (which stays read-only — see lookup()).
+func (p *Plugin) createCachedContent(ctx context.Context, model, system string, tools []events.ToolDef, contents []map[string]any, ttl time.Duration) (string, error) {
+	if !p.cache.enabled {
+		return "", fmt.Errorf("cache disabled")
+	}
+	return p.createCachedContentAt(ctx, p.auth.cachedContentsURL(), model, system, tools, contents, ttl)
+}
+
+// createCachedContentAt is the test-friendly variant: it posts to an explicit
+// URL rather than the one resolved from authState.
+func (p *Plugin) createCachedContentAt(ctx context.Context, url, model, system string, tools []events.ToolDef, contents []map[string]any, ttl time.Duration) (string, error) {
+	body := map[string]any{
+		"model": fmt.Sprintf("models/%s", model),
+	}
+	if system != "" {
+		body["systemInstruction"] = map[string]any{
+			"parts": []map[string]any{{"text": system}},
+		}
+	}
+	if len(tools) > 0 {
+		decls := make([]map[string]any, 0, len(tools))
+		for _, t := range tools {
+			decls = append(decls, map[string]any{
+				"name":        t.Name,
+				"description": t.Description,
+				"parameters":  sanitizeSchemaForGemini(t.Parameters),
+			})
+		}
+		body["tools"] = []map[string]any{{"functionDeclarations": decls}}
+	}
+	if len(contents) > 0 {
+		body["contents"] = contents
+	}
+	if ttl > 0 {
+		body["ttl"] = fmt.Sprintf("%ds", int(ttl.Seconds()))
+	}
+
+	bodyJSON, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyJSON))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if err := p.auth.applyAuth(ctx, req, p.client); err != nil {
+		return "", err
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cachedContents.create failed (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var out struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return "", fmt.Errorf("parse cachedContents response: %w", err)
+	}
+	if out.Name == "" {
+		return "", fmt.Errorf("empty cache name in response: %s", string(respBody))
+	}
+
+	p.cache.populate(model, system, tools, contents, out.Name, ttl)
+	return out.Name, nil
+}

--- a/plugins/providers/gemini/cache_test.go
+++ b/plugins/providers/gemini/cache_test.go
@@ -1,0 +1,188 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestNewCacheState_Defaults(t *testing.T) {
+	cs := newCacheState(map[string]any{}, slog.Default())
+	if cs.enabled {
+		t.Fatal("expected disabled by default")
+	}
+	if cs.minTokens != 32768 {
+		t.Fatalf("minTokens default %d", cs.minTokens)
+	}
+	if cs.ttl != time.Hour {
+		t.Fatalf("ttl default %v", cs.ttl)
+	}
+}
+
+func TestNewCacheState_FromConfig(t *testing.T) {
+	cs := newCacheState(map[string]any{
+		"cache": map[string]any{
+			"enabled":     true,
+			"min_tokens":  10000,
+			"ttl":         "30m",
+			"max_entries": 8,
+		},
+	}, slog.Default())
+	if !cs.enabled {
+		t.Fatal("enabled should be true")
+	}
+	if cs.minTokens != 10000 {
+		t.Fatalf("minTokens %d", cs.minTokens)
+	}
+	if cs.ttl != 30*time.Minute {
+		t.Fatalf("ttl %v", cs.ttl)
+	}
+	if cs.maxEntries != 8 {
+		t.Fatalf("maxEntries %d", cs.maxEntries)
+	}
+}
+
+func TestPrefixHash_StableAcrossToolOrder(t *testing.T) {
+	cs := newCacheState(map[string]any{"cache": map[string]any{"enabled": true}}, slog.Default())
+
+	t1 := []events.ToolDef{{Name: "b", Description: "B"}, {Name: "a", Description: "A"}}
+	t2 := []events.ToolDef{{Name: "a", Description: "A"}, {Name: "b", Description: "B"}}
+
+	h1 := cs.prefixHash("gemini-2.5-flash", "system", t1, nil)
+	h2 := cs.prefixHash("gemini-2.5-flash", "system", t2, nil)
+
+	if h1 != h2 {
+		t.Fatalf("hash should be tool-order-stable: %s vs %s", h1, h2)
+	}
+}
+
+func TestPrefixHash_StopsAtFunctionResponse(t *testing.T) {
+	cs := newCacheState(map[string]any{"cache": map[string]any{"enabled": true}}, slog.Default())
+
+	stableContents := []map[string]any{
+		{"role": "user", "parts": []map[string]any{{"text": "stable"}}},
+	}
+	withTool := append([]map[string]any{}, stableContents...)
+	withTool = append(withTool,
+		map[string]any{"role": "user", "parts": []map[string]any{{"functionResponse": map[string]any{"name": "x"}}}},
+		map[string]any{"role": "user", "parts": []map[string]any{{"text": "different tail"}}},
+	)
+
+	h1 := cs.prefixHash("model", "sys", nil, stableContents)
+	h2 := cs.prefixHash("model", "sys", nil, withTool)
+
+	if h1 != h2 {
+		t.Fatalf("trailing functionResponse turn must not affect prefix hash: %s vs %s", h1, h2)
+	}
+}
+
+func TestCachePopulateLookup(t *testing.T) {
+	cs := newCacheState(map[string]any{"cache": map[string]any{"enabled": true, "ttl": "1h"}}, slog.Default())
+	contents := []map[string]any{{"role": "user", "parts": []map[string]any{{"text": "hi"}}}}
+
+	if got := cs.lookup("m", "s", nil, contents); got != "" {
+		t.Fatalf("expected empty before populate, got %q", got)
+	}
+
+	cs.populate("m", "s", nil, contents, "cachedContents/abc", time.Hour)
+
+	got := cs.lookup("m", "s", nil, contents)
+	if got != "cachedContents/abc" {
+		t.Fatalf("expected hit, got %q", got)
+	}
+}
+
+func TestCacheExpiry(t *testing.T) {
+	cs := newCacheState(map[string]any{"cache": map[string]any{"enabled": true}}, slog.Default())
+	contents := []map[string]any{{"role": "user", "parts": []map[string]any{{"text": "hi"}}}}
+
+	cs.populate("m", "s", nil, contents, "cachedContents/expired", -1*time.Second)
+
+	if got := cs.lookup("m", "s", nil, contents); got != "" {
+		t.Fatalf("expected expired entry to miss, got %q", got)
+	}
+}
+
+func TestCacheInvalidate(t *testing.T) {
+	cs := newCacheState(map[string]any{"cache": map[string]any{"enabled": true}}, slog.Default())
+	contents := []map[string]any{{"role": "user", "parts": []map[string]any{{"text": "hi"}}}}
+
+	cs.populate("m", "s", nil, contents, "cachedContents/abc", time.Hour)
+	cs.invalidate("cachedContents/abc")
+
+	if got := cs.lookup("m", "s", nil, contents); got != "" {
+		t.Fatalf("expected miss after invalidate, got %q", got)
+	}
+}
+
+func TestCreateCachedContent_Disabled(t *testing.T) {
+	p := &Plugin{
+		client: http.DefaultClient,
+		logger: slog.Default(),
+		auth:   &authState{mode: authModeAPIKey, apiKey: "k"},
+		cache:  newCacheState(map[string]any{}, slog.Default()),
+	}
+	if _, err := p.createCachedContent(context.Background(), "m", "s", nil, nil, time.Hour); err == nil {
+		t.Fatal("expected error when cache disabled")
+	}
+}
+
+func TestCreateCachedContentAt_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["model"] != "models/gemini-2.5-flash" {
+			t.Errorf("unexpected model: %v", body["model"])
+		}
+		if body["ttl"] != "60s" {
+			t.Errorf("unexpected ttl: %v", body["ttl"])
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "cachedContents/xyz",
+		})
+	}))
+	defer srv.Close()
+
+	p := &Plugin{
+		client: srv.Client(),
+		logger: slog.Default(),
+		auth:   &authState{mode: authModeAPIKey, apiKey: "k"},
+		cache: newCacheState(map[string]any{
+			"cache": map[string]any{"enabled": true, "ttl": "1h"},
+		}, slog.Default()),
+	}
+
+	contents := []map[string]any{{"role": "user", "parts": []map[string]any{{"text": "hello"}}}}
+	name, err := p.createCachedContentAt(context.Background(), srv.URL, "gemini-2.5-flash", "sys", nil, contents, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "cachedContents/xyz" {
+		t.Fatalf("unexpected cache name: %s", name)
+	}
+
+	// Cache should now contain the entry under the prefix hash.
+	if got := p.cache.lookup("gemini-2.5-flash", "sys", nil, contents); got != "cachedContents/xyz" {
+		t.Fatalf("expected cache hit after create, got %q", got)
+	}
+}
+
+func TestCachedContentsURL(t *testing.T) {
+	a := &authState{mode: authModeAPIKey}
+	want := "https://generativelanguage.googleapis.com/v1beta/cachedContents"
+	if got := a.cachedContentsURL(); got != want {
+		t.Fatalf("api-key URL: got %q want %q", got, want)
+	}
+
+	v := &authState{mode: authModeVertex, projectID: "myproj", location: "us-central1"}
+	wantV := "https://us-central1-aiplatform.googleapis.com/v1/projects/myproj/locations/us-central1/cachedContents"
+	if got := v.cachedContentsURL(); got != wantV {
+		t.Fatalf("vertex URL: got %q want %q", got, wantV)
+	}
+}

--- a/plugins/providers/gemini/files.go
+++ b/plugins/providers/gemini/files.go
@@ -1,0 +1,146 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// preuploadParts walks msgs and replaces any oversize multimodal Data with a
+// Files API URI. Inputs already carrying a URI are left alone. Returns a fresh
+// slice so the caller's messages are not mutated.
+func (p *Plugin) preuploadParts(ctx context.Context, msgs []events.Message) ([]events.Message, error) {
+	if p.auth.filesAPIBaseURL() == "" {
+		// Vertex mode — Files API unavailable; surface an error if any part is
+		// oversize so the user gets a clear message rather than a 4xx.
+		for _, m := range msgs {
+			for _, part := range m.Parts {
+				if len(part.Data) > inlineDataLimit && part.URI == "" {
+					return nil, fmt.Errorf("gemini: %s part (%d bytes) exceeds inline limit and Files API is unavailable in Vertex mode; upload to Cloud Storage and set URI", part.Type, len(part.Data))
+				}
+			}
+		}
+		return msgs, nil
+	}
+
+	out := make([]events.Message, len(msgs))
+	for i, m := range msgs {
+		out[i] = m
+		if len(m.Parts) == 0 {
+			continue
+		}
+		newParts := make([]events.MessagePart, len(m.Parts))
+		for j, part := range m.Parts {
+			newParts[j] = part
+			if len(part.Data) > inlineDataLimit && part.URI == "" {
+				if part.MimeType == "" {
+					return nil, fmt.Errorf("gemini: oversize %s part requires mime_type", part.Type)
+				}
+				p.logger.Info("uploading oversize part via Files API", "type", part.Type, "bytes", len(part.Data), "mime", part.MimeType)
+				uri, err := p.uploadFile(ctx, part.Data, part.MimeType, fmt.Sprintf("nexus-%s-%d", part.Type, i))
+				if err != nil {
+					return nil, fmt.Errorf("gemini: Files API upload: %w", err)
+				}
+				newParts[j].URI = uri
+				newParts[j].Data = nil
+			}
+		}
+		out[i].Parts = newParts
+	}
+	return out, nil
+}
+
+// uploadFile uploads bytes to the Gemini Files API and returns the resulting
+// file resource. Used for multimodal payloads above the inline limit.
+//
+// Files API is only available on the public api-key endpoint; in Vertex mode
+// callers should use Cloud Storage URIs instead (not implemented here — see
+// authState.filesAPIBaseURL).
+func (p *Plugin) uploadFile(ctx context.Context, data []byte, mimeType, displayName string) (uri string, err error) {
+	base := p.auth.filesAPIBaseURL()
+	if base == "" {
+		return "", fmt.Errorf("gemini: files API unavailable in Vertex mode")
+	}
+	if p.auth.mode != authModeAPIKey {
+		return "", fmt.Errorf("gemini: files API requires api_key auth")
+	}
+	return p.uploadFileTo(ctx, base, data, mimeType, displayName)
+}
+
+// uploadFileTo is the test-friendly variant: it uploads to an explicit base
+// URL rather than the one resolved from authState. Production code uses
+// uploadFile; tests inject a fake base URL.
+func (p *Plugin) uploadFileTo(ctx context.Context, base string, data []byte, mimeType, displayName string) (string, error) {
+	startURL := base + "/upload/v1beta/files"
+
+	meta := map[string]any{
+		"file": map[string]any{
+			"display_name": displayName,
+		},
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	startReq, err := http.NewRequestWithContext(ctx, "POST", startURL, bytes.NewReader(metaJSON))
+	if err != nil {
+		return "", err
+	}
+	startReq.Header.Set("X-Goog-Upload-Protocol", "resumable")
+	startReq.Header.Set("X-Goog-Upload-Command", "start")
+	startReq.Header.Set("X-Goog-Upload-Header-Content-Length", strconv.Itoa(len(data)))
+	startReq.Header.Set("X-Goog-Upload-Header-Content-Type", mimeType)
+	startReq.Header.Set("Content-Type", "application/json")
+	startReq.Header.Set("x-goog-api-key", p.auth.apiKey)
+
+	startResp, err := p.client.Do(startReq)
+	if err != nil {
+		return "", err
+	}
+	defer startResp.Body.Close()
+	if startResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(startResp.Body)
+		return "", fmt.Errorf("files API start failed (%d): %s", startResp.StatusCode, string(body))
+	}
+
+	uploadURL := startResp.Header.Get("X-Goog-Upload-URL")
+	if uploadURL == "" {
+		return "", fmt.Errorf("files API: missing X-Goog-Upload-URL header")
+	}
+
+	// Phase 2: upload bytes + finalize.
+	upReq, err := http.NewRequestWithContext(ctx, "POST", uploadURL, bytes.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+	upReq.Header.Set("Content-Length", strconv.Itoa(len(data)))
+	upReq.Header.Set("X-Goog-Upload-Offset", "0")
+	upReq.Header.Set("X-Goog-Upload-Command", "upload, finalize")
+
+	upResp, err := p.client.Do(upReq)
+	if err != nil {
+		return "", err
+	}
+	defer upResp.Body.Close()
+	body, _ := io.ReadAll(upResp.Body)
+	if upResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("files API upload failed (%d): %s", upResp.StatusCode, string(body))
+	}
+
+	var fileResp struct {
+		File struct {
+			URI string `json:"uri"`
+		} `json:"file"`
+	}
+	if err := json.Unmarshal(body, &fileResp); err != nil {
+		return "", fmt.Errorf("parse files API response: %w", err)
+	}
+	if fileResp.File.URI == "" {
+		return "", fmt.Errorf("files API: empty URI in response: %s", string(body))
+	}
+	return fileResp.File.URI, nil
+}

--- a/plugins/providers/gemini/files_test.go
+++ b/plugins/providers/gemini/files_test.go
@@ -1,0 +1,101 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestUploadFile_HappyPath(t *testing.T) {
+	var seenBody []byte
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/upload/v1beta/files":
+			// Phase 1: respond with an upload URL pointing back to this server.
+			w.Header().Set("X-Goog-Upload-URL", srv.URL+"/_upload-bytes")
+			w.WriteHeader(http.StatusOK)
+		case "/_upload-bytes":
+			seenBody, _ = io.ReadAll(r.Body)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"file": map[string]any{
+					"uri": "https://generativelanguage.googleapis.com/v1beta/files/abc",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Plugin{
+		client: srv.Client(),
+		logger: slog.Default(),
+		auth:   &authState{mode: authModeAPIKey, apiKey: "test"},
+	}
+
+	uri, err := p.uploadFileTo(context.Background(), srv.URL, []byte("hello"), "text/plain", "name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(uri, "/files/abc") {
+		t.Fatalf("unexpected URI: %s", uri)
+	}
+	if string(seenBody) != "hello" {
+		t.Fatalf("server saw body %q want %q", string(seenBody), "hello")
+	}
+}
+
+func TestUploadFile_VertexBlocked(t *testing.T) {
+	p := &Plugin{
+		logger: slog.Default(),
+		auth:   &authState{mode: authModeVertex, projectID: "p", location: "us-central1"},
+	}
+	if _, err := p.uploadFile(context.Background(), []byte("x"), "text/plain", "n"); err == nil {
+		t.Fatal("expected error in Vertex mode")
+	}
+}
+
+func TestPreuploadParts_VertexBlocked(t *testing.T) {
+	p := &Plugin{
+		logger: slog.Default(),
+		auth:   &authState{mode: authModeVertex, projectID: "p", location: "us-central1"},
+	}
+	big := make([]byte, inlineDataLimit+1)
+	_, err := p.preuploadParts(context.Background(), []events.Message{{
+		Role: "user",
+		Parts: []events.MessagePart{{Type: "image", MimeType: "image/png", Data: big}},
+	}})
+	if err == nil {
+		t.Fatal("expected vertex-mode oversize error")
+	}
+	if !strings.Contains(err.Error(), "Vertex") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreuploadParts_NoChangeForSmall(t *testing.T) {
+	p := &Plugin{
+		logger: slog.Default(),
+		auth:   &authState{mode: authModeAPIKey, apiKey: "k"},
+	}
+	small := []byte("tiny")
+	out, err := p.preuploadParts(context.Background(), []events.Message{{
+		Role: "user",
+		Parts: []events.MessagePart{{Type: "image", MimeType: "image/png", Data: small}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out[0].Parts[0].Data) == 0 || out[0].Parts[0].URI != "" {
+		t.Fatalf("small part should be unchanged, got %+v", out[0].Parts[0])
+	}
+}

--- a/plugins/providers/gemini/multimodal.go
+++ b/plugins/providers/gemini/multimodal.go
@@ -1,0 +1,74 @@
+package gemini
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// inlineDataLimit is the byte ceiling above which Gemini recommends using the
+// Files API instead of inline_data. Set conservatively at 18 MB; the real cap
+// is ~20 MB for the entire request.
+const inlineDataLimit = 18 * 1024 * 1024
+
+// buildParts converts an events.Message into Gemini "parts" entries. Falls back
+// to a single text part when Parts is empty (text-only path used by all
+// existing providers). Multimodal parts (image/audio/video/file) are encoded
+// inline when small or referenced via URI when the caller has already uploaded
+// to the Files API.
+func buildParts(msg events.Message) ([]map[string]any, error) {
+	if len(msg.Parts) == 0 {
+		// Text-only path. An empty message with no parts is unusual but
+		// harmless — emit an empty text part to satisfy the schema.
+		return []map[string]any{{"text": msg.Content}}, nil
+	}
+
+	out := make([]map[string]any, 0, len(msg.Parts)+1)
+	if msg.Content != "" {
+		out = append(out, map[string]any{"text": msg.Content})
+	}
+
+	for _, part := range msg.Parts {
+		switch part.Type {
+		case "text":
+			out = append(out, map[string]any{"text": part.Text})
+
+		case "image", "audio", "video", "file":
+			if part.URI != "" {
+				if part.MimeType == "" {
+					return nil, fmt.Errorf("gemini: part with URI requires mime_type (type=%s)", part.Type)
+				}
+				out = append(out, map[string]any{
+					"fileData": map[string]any{
+						"mimeType": part.MimeType,
+						"fileUri":  part.URI,
+					},
+				})
+				continue
+			}
+			if len(part.Data) == 0 {
+				return nil, fmt.Errorf("gemini: %s part has neither URI nor Data", part.Type)
+			}
+			if part.MimeType == "" {
+				return nil, fmt.Errorf("gemini: %s part requires mime_type", part.Type)
+			}
+			if len(part.Data) > inlineDataLimit {
+				// Caller should have uploaded via Files API and set URI. Surface
+				// a clear error so the issue is obvious.
+				return nil, fmt.Errorf("gemini: %s part (%d bytes) exceeds inline limit; upload via Files API and set URI", part.Type, len(part.Data))
+			}
+			out = append(out, map[string]any{
+				"inlineData": map[string]any{
+					"mimeType": part.MimeType,
+					"data":     base64.StdEncoding.EncodeToString(part.Data),
+				},
+			})
+
+		default:
+			return nil, fmt.Errorf("gemini: unsupported part type %q", part.Type)
+		}
+	}
+
+	return out, nil
+}

--- a/plugins/providers/gemini/multimodal_test.go
+++ b/plugins/providers/gemini/multimodal_test.go
@@ -1,0 +1,132 @@
+package gemini
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestBuildParts_TextOnly(t *testing.T) {
+	got, err := buildParts(events.Message{Role: "user", Content: "hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0]["text"] != "hello" {
+		t.Fatalf("unexpected: %+v", got)
+	}
+}
+
+func TestBuildParts_InlineImage(t *testing.T) {
+	data := []byte("PNGDATA")
+	got, err := buildParts(events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{{
+			Type:     "image",
+			MimeType: "image/png",
+			Data:     data,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(got))
+	}
+	inline, ok := got[0]["inlineData"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inlineData, got %+v", got[0])
+	}
+	if inline["mimeType"] != "image/png" {
+		t.Fatalf("mime: %v", inline["mimeType"])
+	}
+	if inline["data"] != base64.StdEncoding.EncodeToString(data) {
+		t.Fatalf("data not base64-encoded")
+	}
+}
+
+func TestBuildParts_FileURI(t *testing.T) {
+	got, err := buildParts(events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{{
+			Type:     "file",
+			MimeType: "application/pdf",
+			URI:      "https://generativelanguage.googleapis.com/v1beta/files/abc",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(got))
+	}
+	fd, ok := got[0]["fileData"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fileData, got %+v", got[0])
+	}
+	if fd["fileUri"] != "https://generativelanguage.googleapis.com/v1beta/files/abc" {
+		t.Fatalf("uri mismatch: %v", fd)
+	}
+}
+
+func TestBuildParts_TextPlusImage(t *testing.T) {
+	got, err := buildParts(events.Message{
+		Role:    "user",
+		Content: "describe this:",
+		Parts: []events.MessagePart{{
+			Type:     "image",
+			MimeType: "image/jpeg",
+			Data:     []byte("JPEG"),
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 parts (text + image), got %d", len(got))
+	}
+	if got[0]["text"] != "describe this:" {
+		t.Fatalf("first part should be content text")
+	}
+	if _, ok := got[1]["inlineData"]; !ok {
+		t.Fatalf("second part should be inlineData")
+	}
+}
+
+func TestBuildParts_MissingMime(t *testing.T) {
+	_, err := buildParts(events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{{
+			Type: "image",
+			Data: []byte("X"),
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing mime_type")
+	}
+}
+
+func TestBuildParts_OversizeInline(t *testing.T) {
+	big := make([]byte, inlineDataLimit+1)
+	_, err := buildParts(events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{{
+			Type:     "image",
+			MimeType: "image/png",
+			Data:     big,
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected error for oversize inline data")
+	}
+}
+
+func TestBuildParts_UnsupportedType(t *testing.T) {
+	_, err := buildParts(events.Message{
+		Role:  "user",
+		Parts: []events.MessagePart{{Type: "weird"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown part type")
+	}
+}

--- a/plugins/providers/gemini/plugin.go
+++ b/plugins/providers/gemini/plugin.go
@@ -1,0 +1,946 @@
+// Package gemini implements the Google Gemini LLM provider for Nexus.
+//
+// Supports both the public Generative Language API (api-key auth) and Vertex
+// AI (service-account JWT auth). Feature parity with the OpenAI and Anthropic
+// providers (sync + streaming, tool use, structured output, retry, cancel,
+// debug logs, fallback hooks) plus Gemini-specific features: thinking parts
+// (2.5 models), multimodal inputs (inline + Files API), code execution, and
+// prompt caching via the cachedContents API.
+package gemini
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID   = "nexus.llm.gemini"
+	pluginName = "Google Gemini LLM Provider"
+	version    = "0.1.0"
+)
+
+// Plugin implements the Gemini LLM provider.
+type Plugin struct {
+	bus     engine.EventBus
+	logger  *slog.Logger
+	models  *engine.ModelRegistry
+	session *engine.SessionWorkspace
+
+	auth    *authState
+	client  *http.Client
+	prompts *engine.PromptRegistry
+	unsubs  []func()
+	debug   bool
+	retry   retryConfig
+	pricing map[string]modelPricing
+
+	thinking      thinkingConfig
+	codeExecution bool
+	cache         *cacheState
+
+	mu                 sync.Mutex
+	currentRequestMeta map[string]any
+	cancelFunc         context.CancelFunc
+	requestSeq         int
+}
+
+// New creates a new Gemini provider plugin.
+func New() engine.Plugin {
+	return &Plugin{}
+}
+
+func (p *Plugin) ID() string                        { return pluginID }
+func (p *Plugin) Name() string                      { return pluginName }
+func (p *Plugin) Version() string                   { return version }
+func (p *Plugin) Dependencies() []string            { return nil }
+func (p *Plugin) Requires() []engine.Requirement    { return nil }
+func (p *Plugin) Capabilities() []engine.Capability { return nil }
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+	p.models = ctx.Models
+	p.session = ctx.Session
+	p.prompts = ctx.Prompts
+
+	if debug, ok := ctx.Config["debug"].(bool); ok {
+		p.debug = debug
+	}
+
+	auth, err := resolveAuth(ctx.Config)
+	if err != nil {
+		return err
+	}
+	p.auth = auth
+
+	p.client = &http.Client{Timeout: 5 * time.Minute}
+
+	p.pricing = parsePricingConfig(ctx.Config)
+	p.retry = parseRetryConfig(ctx.Config)
+	p.thinking = parseThinkingConfig(ctx.Config)
+
+	if v, ok := ctx.Config["code_execution"].(bool); ok {
+		p.codeExecution = v
+	}
+
+	p.cache = newCacheState(ctx.Config, p.logger)
+
+	if p.retry.Enabled {
+		p.logger.Info("retry enabled",
+			"max_retries", p.retry.MaxRetries,
+			"backoff", string(p.retry.Backoff),
+			"initial_delay", p.retry.InitialDelay,
+			"max_delay", p.retry.MaxDelay,
+		)
+	}
+	if p.thinking.Enabled {
+		p.logger.Info("thinking enabled",
+			"budget_tokens", p.thinking.BudgetTokens,
+			"include_thoughts", p.thinking.IncludeThoughts,
+		)
+	}
+	if p.codeExecution {
+		p.logger.Info("code_execution tool enabled")
+	}
+	if p.cache.enabled {
+		p.logger.Info("prompt caching enabled",
+			"min_tokens", p.cache.minTokens,
+			"ttl", p.cache.ttl,
+		)
+	}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("llm.request", p.handleEvent,
+			engine.WithPriority(10),
+			engine.WithSource(pluginID),
+		),
+		p.bus.Subscribe("cancel.active", p.handleCancel,
+			engine.WithPriority(5),
+			engine.WithSource(pluginID),
+		),
+	)
+
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	p.client.CloseIdleConnections()
+	return nil
+}
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "llm.request", Priority: 10},
+		{EventType: "cancel.active", Priority: 5},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"llm.response",
+		"llm.stream.chunk",
+		"llm.stream.end",
+		"thinking.step",
+		"tool.invoke",
+		"tool.result",
+		"before:core.error",
+		"core.error",
+	}
+}
+
+func (p *Plugin) handleEvent(event engine.Event[any]) {
+	if event.Type != "llm.request" {
+		return
+	}
+	req, ok := event.Payload.(events.LLMRequest)
+	if !ok {
+		p.emitError(fmt.Errorf("gemini: invalid llm.request payload type: %T", event.Payload))
+		return
+	}
+	p.handleRequest(req)
+}
+
+func (p *Plugin) handleCancel(_ engine.Event[any]) {
+	p.mu.Lock()
+	cancel := p.cancelFunc
+	p.cancelFunc = nil
+	p.mu.Unlock()
+
+	if cancel != nil {
+		p.logger.Info("cancelling in-flight LLM request")
+		cancel()
+	}
+}
+
+func (p *Plugin) handleRequest(req events.LLMRequest) {
+	if target, ok := req.Metadata["_target_provider"].(string); ok && target != pluginID {
+		return
+	}
+
+	model := req.Model
+	maxTokens := req.MaxTokens
+
+	if model == "" && p.models != nil {
+		if cfg, ok := p.models.Resolve(req.Role); ok {
+			if cfg.Provider != "" && cfg.Provider != pluginID {
+				return
+			}
+			if cfg.Model != "" {
+				model = cfg.Model
+			}
+			if maxTokens == 0 && cfg.MaxTokens > 0 {
+				maxTokens = cfg.MaxTokens
+			}
+		}
+	}
+
+	if model == "" && p.models != nil {
+		def := p.models.Default()
+		if def.Provider == "" || def.Provider == pluginID {
+			model = def.Model
+			if maxTokens == 0 {
+				maxTokens = def.MaxTokens
+			}
+		}
+	}
+
+	if model == "" {
+		p.emitError(fmt.Errorf("gemini: no model resolved for role %q", req.Role))
+		return
+	}
+
+	p.logger.Debug("resolving LLM request", "role", req.Role, "model", model, "max_tokens", maxTokens)
+
+	body, err := p.buildRequestBody(model, maxTokens, req)
+	if err != nil {
+		p.emitError(fmt.Errorf("gemini: build request: %w", err))
+		return
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		p.emitError(fmt.Errorf("gemini: marshal request: %w", err))
+		return
+	}
+
+	if p.debug {
+		p.mu.Lock()
+		p.requestSeq++
+		p.mu.Unlock()
+		p.debugLog("request", jsonBody)
+	}
+
+	op := "generateContent"
+	if req.Stream {
+		op = "streamGenerateContent"
+	}
+	url := p.auth.apiURL(model, op)
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	p.mu.Lock()
+	p.cancelFunc = cancel
+	p.mu.Unlock()
+
+	makeReq := func() (*http.Request, error) {
+		httpReq, err := http.NewRequestWithContext(reqCtx, "POST", url, bytes.NewReader(jsonBody))
+		if err != nil {
+			return nil, err
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		if err := p.auth.applyAuth(reqCtx, httpReq, p.client); err != nil {
+			return nil, fmt.Errorf("apply auth: %w", err)
+		}
+		return httpReq, nil
+	}
+
+	resp, err := p.doWithRetry(reqCtx, makeReq)
+	if err != nil {
+		p.mu.Lock()
+		p.cancelFunc = nil
+		p.mu.Unlock()
+		if reqCtx.Err() == context.Canceled {
+			p.logger.Info("LLM request cancelled")
+			return
+		}
+		p.emitErrorInfo(events.ErrorInfo{
+			Err:              fmt.Errorf("gemini: HTTP request failed: %w", err),
+			Retryable:        true,
+			RetriesExhausted: true,
+			RequestMeta:      req.Metadata,
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		p.emitErrorInfo(events.ErrorInfo{
+			Err:         fmt.Errorf("gemini: API returned status %d: %s", resp.StatusCode, string(respBody)),
+			Retryable:   false,
+			RequestMeta: req.Metadata,
+		})
+		return
+	}
+
+	meta := req.Metadata
+	if req.ResponseFormat != nil && req.ResponseFormat.Type != "text" {
+		if meta == nil {
+			meta = make(map[string]any)
+		}
+		meta["_structured_output"] = true
+	}
+	p.mu.Lock()
+	p.currentRequestMeta = meta
+	p.mu.Unlock()
+
+	var responseBody io.Reader = resp.Body
+	var debugBuf *bytes.Buffer
+	if p.debug {
+		debugBuf = new(bytes.Buffer)
+		responseBody = io.TeeReader(resp.Body, debugBuf)
+	}
+
+	if req.Stream {
+		p.handleStreamResponse(responseBody)
+	} else {
+		p.handleSyncResponse(responseBody)
+	}
+
+	if debugBuf != nil {
+		p.debugLog("response", debugBuf.Bytes())
+	}
+
+	p.mu.Lock()
+	p.cancelFunc = nil
+	p.mu.Unlock()
+}
+
+// buildRequestBody constructs a Gemini generateContent request body.
+func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMRequest) (map[string]any, error) {
+	body := map[string]any{}
+
+	// generationConfig.
+	gen := map[string]any{}
+	if maxTokens > 0 {
+		gen["maxOutputTokens"] = maxTokens
+	}
+	if req.Temperature != nil {
+		gen["temperature"] = *req.Temperature
+	}
+
+	// Structured output: native response_schema.
+	if rf := req.ResponseFormat; rf != nil {
+		switch rf.Type {
+		case "json_object":
+			gen["responseMimeType"] = "application/json"
+		case "json_schema":
+			gen["responseMimeType"] = "application/json"
+			if rf.Schema != nil {
+				gen["responseSchema"] = sanitizeSchemaForGemini(rf.Schema)
+			}
+		}
+	}
+
+	// Thinking config.
+	if p.thinking.Enabled {
+		tc := map[string]any{}
+		if p.thinking.IncludeThoughts {
+			tc["includeThoughts"] = true
+		}
+		if p.thinking.BudgetTokens > 0 {
+			tc["thinkingBudget"] = p.thinking.BudgetTokens
+		}
+		if len(tc) > 0 {
+			gen["thinkingConfig"] = tc
+		}
+	}
+
+	if len(gen) > 0 {
+		body["generationConfig"] = gen
+	}
+
+	// Pre-upload any oversize multimodal parts via the Files API so the rest of
+	// the request can stay in a single HTTP call.
+	preparedMsgs, err := p.preuploadParts(context.Background(), req.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	// System instruction + contents.
+	systemPrompt, contents, err := p.convertMessages(preparedMsgs)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.prompts != nil {
+		systemPrompt = p.prompts.Apply(systemPrompt)
+	}
+	if systemPrompt != "" {
+		body["systemInstruction"] = map[string]any{
+			"parts": []map[string]any{{"text": systemPrompt}},
+		}
+	}
+	body["contents"] = contents
+
+	// Tool filtering.
+	filteredTools := applyToolFilter(req.Tools, req.ToolFilter)
+	if req.ToolChoice != nil && req.ToolChoice.Mode == "none" {
+		// Gemini's NONE mode keeps tools listed but disabled. To match the
+		// other providers' "strip everything" behavior we drop them entirely.
+		filteredTools = nil
+	}
+
+	var toolGroups []map[string]any
+	if len(filteredTools) > 0 {
+		decls := make([]map[string]any, 0, len(filteredTools))
+		for _, t := range filteredTools {
+			decls = append(decls, map[string]any{
+				"name":        t.Name,
+				"description": t.Description,
+				"parameters":  sanitizeSchemaForGemini(t.Parameters),
+			})
+		}
+		toolGroups = append(toolGroups, map[string]any{
+			"functionDeclarations": decls,
+		})
+	}
+	if p.codeExecution {
+		toolGroups = append(toolGroups, map[string]any{"codeExecution": map[string]any{}})
+	}
+	if len(toolGroups) > 0 {
+		body["tools"] = toolGroups
+	}
+
+	if tc := resolveToolChoice(req.ToolChoice, filteredTools); tc != nil {
+		body["toolConfig"] = tc
+	}
+
+	// Prompt caching: replace the stable prefix with cached_content reference
+	// when eligible.
+	if p.cache.enabled {
+		if cachedName := p.cache.lookup(model, systemPrompt, filteredTools, contents); cachedName != "" {
+			body["cachedContent"] = cachedName
+			// Caller's contents already includes only the trailing delta; the
+			// cache plugin stripped what's covered by the cache. See cache.go.
+		}
+	}
+
+	return body, nil
+}
+
+// convertMessages walks the message list, extracts the system prompt, and
+// converts the rest into Gemini "contents" entries. Tool results are folded
+// into user-role entries with functionResponse parts.
+func (p *Plugin) convertMessages(msgs []events.Message) (string, []map[string]any, error) {
+	var systemPrompt strings.Builder
+	var out []map[string]any
+
+	// Maintain a name→toolCallID lookup so we can correlate tool results back
+	// to the function name (Gemini's functionResponse needs a name, not an ID).
+	toolCallNames := make(map[string]string)
+
+	for _, msg := range msgs {
+		switch msg.Role {
+		case "system":
+			if systemPrompt.Len() > 0 {
+				systemPrompt.WriteString("\n\n")
+			}
+			systemPrompt.WriteString(msg.Content)
+
+		case "user":
+			parts, err := buildParts(msg)
+			if err != nil {
+				return "", nil, err
+			}
+			out = append(out, map[string]any{
+				"role":  "user",
+				"parts": parts,
+			})
+
+		case "assistant":
+			var parts []map[string]any
+			if msg.Content != "" {
+				parts = append(parts, map[string]any{"text": msg.Content})
+			}
+			for _, tc := range msg.ToolCalls {
+				var args any
+				if tc.Arguments != "" {
+					if err := json.Unmarshal([]byte(tc.Arguments), &args); err != nil {
+						args = map[string]any{}
+					}
+				} else {
+					args = map[string]any{}
+				}
+				parts = append(parts, map[string]any{
+					"functionCall": map[string]any{
+						"name": tc.Name,
+						"args": args,
+					},
+				})
+				toolCallNames[tc.ID] = tc.Name
+			}
+			if len(parts) == 0 {
+				continue
+			}
+			out = append(out, map[string]any{
+				"role":  "model",
+				"parts": parts,
+			})
+
+		case "tool":
+			name := toolCallNames[msg.ToolCallID]
+			if name == "" {
+				// Best effort: use ToolCallID as the function name. Engine
+				// callers may emit synthetic IDs equal to the tool name.
+				name = msg.ToolCallID
+			}
+			// Gemini expects response.content to be a structured object. Wrap
+			// raw text in {output: ...} for round-trip safety.
+			var responseObj any
+			if err := json.Unmarshal([]byte(msg.Content), &responseObj); err != nil {
+				responseObj = map[string]any{"output": msg.Content}
+			}
+			out = append(out, map[string]any{
+				"role": "user",
+				"parts": []map[string]any{{
+					"functionResponse": map[string]any{
+						"name":     name,
+						"response": responseObj,
+					},
+				}},
+			})
+
+		default:
+			// Unknown role: pass through as user text.
+			out = append(out, map[string]any{
+				"role":  "user",
+				"parts": []map[string]any{{"text": msg.Content}},
+			})
+		}
+	}
+
+	return systemPrompt.String(), out, nil
+}
+
+// sanitizeSchemaForGemini strips JSON Schema keywords Gemini's schema dialect
+// doesn't accept (e.g. additionalProperties, $schema, $id). Walks recursively.
+func sanitizeSchemaForGemini(schema map[string]any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	out := make(map[string]any, len(schema))
+	for k, v := range schema {
+		switch k {
+		case "$schema", "$id", "$ref", "additionalProperties", "definitions", "$defs":
+			continue
+		}
+		switch vv := v.(type) {
+		case map[string]any:
+			out[k] = sanitizeSchemaForGemini(vv)
+		case []any:
+			arr := make([]any, len(vv))
+			for i, item := range vv {
+				if m, ok := item.(map[string]any); ok {
+					arr[i] = sanitizeSchemaForGemini(m)
+				} else {
+					arr[i] = item
+				}
+			}
+			out[k] = arr
+		default:
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// API response shapes.
+
+type apiResponse struct {
+	Candidates    []apiCandidate    `json:"candidates"`
+	UsageMetadata *apiUsageMetadata `json:"usageMetadata,omitempty"`
+	ModelVersion  string            `json:"modelVersion,omitempty"`
+}
+
+type apiCandidate struct {
+	Content      apiContent `json:"content"`
+	FinishReason string     `json:"finishReason"`
+	Index        int        `json:"index"`
+}
+
+type apiContent struct {
+	Parts []apiPart `json:"parts"`
+	Role  string    `json:"role"`
+}
+
+type apiPart struct {
+	Text                string             `json:"text,omitempty"`
+	Thought             bool               `json:"thought,omitempty"`
+	FunctionCall        *apiFunctionCall   `json:"functionCall,omitempty"`
+	ExecutableCode      *apiExecutableCode `json:"executableCode,omitempty"`
+	CodeExecutionResult *apiCodeExecResult `json:"codeExecutionResult,omitempty"`
+	InlineData          *apiInlineData     `json:"inlineData,omitempty"`
+	FileData            map[string]any     `json:"fileData,omitempty"`
+}
+
+type apiFunctionCall struct {
+	Name string         `json:"name"`
+	Args map[string]any `json:"args"`
+}
+
+type apiExecutableCode struct {
+	Language string `json:"language"`
+	Code     string `json:"code"`
+}
+
+type apiCodeExecResult struct {
+	Outcome string `json:"outcome"`
+	Output  string `json:"output"`
+}
+
+type apiInlineData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"` // base64
+}
+
+type apiUsageMetadata struct {
+	PromptTokenCount        int `json:"promptTokenCount"`
+	CandidatesTokenCount    int `json:"candidatesTokenCount"`
+	TotalTokenCount         int `json:"totalTokenCount"`
+	ThoughtsTokenCount      int `json:"thoughtsTokenCount"`
+	CachedContentTokenCount int `json:"cachedContentTokenCount"`
+}
+
+func (p *Plugin) handleSyncResponse(body io.Reader) {
+	var apiResp apiResponse
+	if err := json.NewDecoder(body).Decode(&apiResp); err != nil {
+		p.emitError(fmt.Errorf("gemini: decode response: %w", err))
+		return
+	}
+
+	resp := p.convertAPIResponse(apiResp, generateTurnID())
+
+	p.mu.Lock()
+	resp.Metadata = p.currentRequestMeta
+	p.mu.Unlock()
+
+	if err := p.bus.Emit("llm.response", resp); err != nil {
+		p.logger.Error("failed to emit llm.response", "error", err)
+	}
+}
+
+// convertAPIResponse normalizes a Gemini response into events.LLMResponse.
+// Thinking parts are emitted as thinking.step events (when turnID is non-empty)
+// or skipped from Content. Code execution parts are dual-emitted as content
+// and tool.invoke / tool.result events.
+func (p *Plugin) convertAPIResponse(apiResp apiResponse, turnID string) events.LLMResponse {
+	var content strings.Builder
+	var toolCalls []events.ToolCallRequest
+	var finishReason string
+	model := apiResp.ModelVersion
+
+	if len(apiResp.Candidates) > 0 {
+		cand := apiResp.Candidates[0]
+		finishReason = cand.FinishReason
+
+		toolCallSeq := 0
+		for _, part := range cand.Content.Parts {
+			switch {
+			case part.Thought && part.Text != "":
+				_ = p.bus.Emit("thinking.step", events.ThinkingStep{
+					TurnID:    turnID,
+					Source:    pluginID,
+					Content:   part.Text,
+					Phase:     "reasoning",
+					Timestamp: time.Now(),
+				})
+
+			case part.Text != "":
+				content.WriteString(part.Text)
+
+			case part.FunctionCall != nil:
+				args, _ := json.Marshal(part.FunctionCall.Args)
+				id := fmt.Sprintf("call_%d_%s", toolCallSeq, part.FunctionCall.Name)
+				toolCalls = append(toolCalls, events.ToolCallRequest{
+					ID:        id,
+					Name:      part.FunctionCall.Name,
+					Arguments: string(args),
+				})
+				toolCallSeq++
+
+			case part.ExecutableCode != nil:
+				code := part.ExecutableCode.Code
+				lang := part.ExecutableCode.Language
+				content.WriteString(fmt.Sprintf("\n```%s\n%s\n```\n", strings.ToLower(lang), code))
+				_ = p.bus.Emit("tool.invoke", events.ToolCall{
+					Name:      "_gemini_code_execution",
+					Arguments: map[string]any{"language": lang, "code": code},
+				})
+
+			case part.CodeExecutionResult != nil:
+				out := part.CodeExecutionResult.Output
+				outcome := part.CodeExecutionResult.Outcome
+				content.WriteString(fmt.Sprintf("\n```output\n%s\n```\n", out))
+				toolResult := events.ToolResult{
+					Name:   "_gemini_code_execution",
+					Output: out,
+				}
+				if outcome != "OUTCOME_OK" {
+					toolResult.Error = outcome
+				}
+				_ = p.bus.Emit("tool.result", toolResult)
+			}
+		}
+	}
+
+	usage := events.Usage{}
+	if apiResp.UsageMetadata != nil {
+		usage.PromptTokens = apiResp.UsageMetadata.PromptTokenCount
+		usage.CompletionTokens = apiResp.UsageMetadata.CandidatesTokenCount
+		usage.TotalTokens = apiResp.UsageMetadata.TotalTokenCount
+		usage.ReasoningTokens = apiResp.UsageMetadata.ThoughtsTokenCount
+		usage.CachedTokens = apiResp.UsageMetadata.CachedContentTokenCount
+	}
+
+	return events.LLMResponse{
+		Content:      content.String(),
+		ToolCalls:    toolCalls,
+		Usage:        usage,
+		CostUSD:      p.costForModel(model, usage),
+		Model:        model,
+		FinishReason: finishReason,
+	}
+}
+
+// generateTurnID returns a synthetic per-stream identifier. Gemini's API does
+// not assign one and the engine relies on a stable TurnID to associate
+// streaming chunks with the bubble they belong to.
+func generateTurnID() string {
+	return fmt.Sprintf("gemini_%d", time.Now().UnixNano())
+}
+
+// SSE streaming.
+
+func (p *Plugin) handleStreamResponse(body io.Reader) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var fullContent strings.Builder
+	var toolCalls []events.ToolCallRequest
+	var finishReason string
+	var model string
+	var totalUsage apiUsageMetadata
+	// Gemini's stream payloads have no native turn ID, so we synthesize one
+	// per stream. TUI keys streaming bubbles on TurnID; an empty value would
+	// collapse all turns into a single bubble.
+	turnID := generateTurnID()
+	chunkIndex := 0
+	toolCallSeq := 0
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+
+		var chunk apiResponse
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			p.logger.Warn("gemini: parse stream chunk", "error", err)
+			continue
+		}
+
+		if chunk.ModelVersion != "" {
+			model = chunk.ModelVersion
+		}
+		if chunk.UsageMetadata != nil {
+			// Each chunk carries a cumulative usage snapshot; keep latest.
+			totalUsage = *chunk.UsageMetadata
+		}
+
+		if len(chunk.Candidates) == 0 {
+			continue
+		}
+		cand := chunk.Candidates[0]
+		if cand.FinishReason != "" {
+			finishReason = cand.FinishReason
+		}
+
+		for _, part := range cand.Content.Parts {
+			switch {
+			case part.Thought && part.Text != "":
+				_ = p.bus.Emit("thinking.step", events.ThinkingStep{
+					TurnID:    turnID,
+					Source:    pluginID,
+					Content:   part.Text,
+					Phase:     "reasoning",
+					Timestamp: time.Now(),
+				})
+
+			case part.Text != "":
+				fullContent.WriteString(part.Text)
+				_ = p.bus.Emit("llm.stream.chunk", events.StreamChunk{
+					Content: part.Text,
+					Index:   chunkIndex,
+					TurnID:  turnID,
+				})
+				chunkIndex++
+
+			case part.FunctionCall != nil:
+				args, _ := json.Marshal(part.FunctionCall.Args)
+				tc := events.ToolCallRequest{
+					ID:        fmt.Sprintf("call_%d_%s", toolCallSeq, part.FunctionCall.Name),
+					Name:      part.FunctionCall.Name,
+					Arguments: string(args),
+				}
+				toolCalls = append(toolCalls, tc)
+				_ = p.bus.Emit("llm.stream.chunk", events.StreamChunk{
+					ToolCall: &tc,
+					Index:    chunkIndex,
+					TurnID:   turnID,
+				})
+				chunkIndex++
+				toolCallSeq++
+
+			case part.ExecutableCode != nil:
+				code := part.ExecutableCode.Code
+				lang := part.ExecutableCode.Language
+				snippet := fmt.Sprintf("\n```%s\n%s\n```\n", strings.ToLower(lang), code)
+				fullContent.WriteString(snippet)
+				_ = p.bus.Emit("llm.stream.chunk", events.StreamChunk{
+					Content: snippet,
+					Index:   chunkIndex,
+					TurnID:  turnID,
+				})
+				chunkIndex++
+				_ = p.bus.Emit("tool.invoke", events.ToolCall{
+					Name:      "_gemini_code_execution",
+					Arguments: map[string]any{"language": lang, "code": code},
+				})
+
+			case part.CodeExecutionResult != nil:
+				out := part.CodeExecutionResult.Output
+				outcome := part.CodeExecutionResult.Outcome
+				snippet := fmt.Sprintf("\n```output\n%s\n```\n", out)
+				fullContent.WriteString(snippet)
+				_ = p.bus.Emit("llm.stream.chunk", events.StreamChunk{
+					Content: snippet,
+					Index:   chunkIndex,
+					TurnID:  turnID,
+				})
+				chunkIndex++
+				toolResult := events.ToolResult{
+					Name:   "_gemini_code_execution",
+					Output: out,
+				}
+				if outcome != "OUTCOME_OK" {
+					toolResult.Error = outcome
+				}
+				_ = p.bus.Emit("tool.result", toolResult)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		p.emitError(fmt.Errorf("gemini: stream read error: %w", err))
+	}
+
+	finalUsage := events.Usage{
+		PromptTokens:     totalUsage.PromptTokenCount,
+		CompletionTokens: totalUsage.CandidatesTokenCount,
+		TotalTokens:      totalUsage.TotalTokenCount,
+		ReasoningTokens:  totalUsage.ThoughtsTokenCount,
+		CachedTokens:     totalUsage.CachedContentTokenCount,
+	}
+
+	_ = p.bus.Emit("llm.stream.end", events.StreamEnd{
+		TurnID:       turnID,
+		FinishReason: finishReason,
+		Usage:        finalUsage,
+	})
+
+	p.mu.Lock()
+	meta := p.currentRequestMeta
+	p.mu.Unlock()
+
+	_ = p.bus.Emit("llm.response", events.LLMResponse{
+		Content:      fullContent.String(),
+		ToolCalls:    toolCalls,
+		Usage:        finalUsage,
+		CostUSD:      p.costForModel(model, finalUsage),
+		Model:        model,
+		FinishReason: finishReason,
+		Metadata:     meta,
+	})
+}
+
+// costForModel returns the USD cost for a response from the given model.
+func (p *Plugin) costForModel(model string, usage events.Usage) float64 {
+	if rates, ok := p.pricing[model]; ok {
+		return calculateCost(usage, rates)
+	}
+	// Try a prefix match (Google appends "-001" / "-latest" suffixes).
+	for prefix, rates := range p.pricing {
+		if strings.HasPrefix(model, prefix) {
+			return calculateCost(usage, rates)
+		}
+	}
+	return 0
+}
+
+func (p *Plugin) debugLog(label string, data []byte) {
+	if !p.debug || p.session == nil {
+		return
+	}
+	p.mu.Lock()
+	seq := p.requestSeq
+	p.mu.Unlock()
+
+	filename := fmt.Sprintf("plugins/%s/%04d_%s.json", pluginID, seq, label)
+	if err := p.session.WriteFile(filename, data); err != nil {
+		p.logger.Error("failed to write debug log", "file", filename, "error", err)
+	}
+}
+
+func (p *Plugin) emitError(err error) {
+	p.emitErrorInfo(events.ErrorInfo{
+		Source: pluginID,
+		Err:    err,
+		Fatal:  false,
+	})
+}
+
+func (p *Plugin) emitErrorInfo(info events.ErrorInfo) {
+	info.Source = pluginID
+	p.logger.Error(info.Err.Error())
+
+	result, vErr := p.bus.EmitVetoable("before:core.error", &info)
+	if vErr != nil {
+		p.logger.Error("failed to emit before:core.error", "error", vErr)
+		return
+	}
+	if result.Vetoed {
+		return
+	}
+	_ = p.bus.Emit("core.error", info)
+}

--- a/plugins/providers/gemini/pricing.go
+++ b/plugins/providers/gemini/pricing.go
@@ -1,0 +1,88 @@
+package gemini
+
+import "github.com/frankbardon/nexus/pkg/events"
+
+// modelPricing holds per-model token rates in USD per million tokens.
+// CachedRatio multiplies InputPerMillion to derive the cost of cached prompt
+// tokens (Google bills cached input at ~25% of standard input rate).
+type modelPricing struct {
+	InputPerMillion  float64
+	OutputPerMillion float64
+	CachedRatio      float64 // 0 disables; defaults to 0.25 if unset on lookup
+}
+
+// defaultPricing is the embedded fallback pricing table. Single tier; the
+// 2.5-pro >200k tier (2.50 / 15.00) is not modeled here. Override via config
+// when high-context billing matters.
+var defaultPricing = map[string]modelPricing{
+	"gemini-2.5-pro":        {InputPerMillion: 1.25, OutputPerMillion: 10.00, CachedRatio: 0.25},
+	"gemini-2.5-flash":      {InputPerMillion: 0.30, OutputPerMillion: 2.50, CachedRatio: 0.25},
+	"gemini-2.5-flash-lite": {InputPerMillion: 0.10, OutputPerMillion: 0.40, CachedRatio: 0.25},
+	"gemini-2.0-flash":      {InputPerMillion: 0.10, OutputPerMillion: 0.40, CachedRatio: 0.25},
+	"gemini-2.0-flash-lite": {InputPerMillion: 0.075, OutputPerMillion: 0.30, CachedRatio: 0.25},
+	"gemini-1.5-pro":        {InputPerMillion: 1.25, OutputPerMillion: 5.00, CachedRatio: 0.25},
+	"gemini-1.5-flash":      {InputPerMillion: 0.075, OutputPerMillion: 0.30, CachedRatio: 0.25},
+	"gemini-1.5-flash-8b":   {InputPerMillion: 0.0375, OutputPerMillion: 0.15, CachedRatio: 0.25},
+}
+
+// calculateCost computes the USD cost for a single LLM call. CachedTokens are
+// billed at the discounted rate; remaining prompt tokens at full input rate.
+// ReasoningTokens (Gemini thoughtTokenCount) are billed at the output rate per
+// Google's policy.
+func calculateCost(usage events.Usage, rates modelPricing) float64 {
+	cachedRatio := rates.CachedRatio
+	if cachedRatio == 0 {
+		cachedRatio = 0.25
+	}
+
+	cachedCost := float64(usage.CachedTokens) / 1_000_000 * rates.InputPerMillion * cachedRatio
+
+	uncachedPrompt := usage.PromptTokens - usage.CachedTokens
+	if uncachedPrompt < 0 {
+		uncachedPrompt = 0
+	}
+	promptCost := float64(uncachedPrompt) / 1_000_000 * rates.InputPerMillion
+
+	outputCost := float64(usage.CompletionTokens+usage.ReasoningTokens) / 1_000_000 * rates.OutputPerMillion
+
+	return cachedCost + promptCost + outputCost
+}
+
+// parsePricingConfig merges embedded defaults with optional config overrides.
+//
+//	pricing:
+//	  gemini-2.5-pro:
+//	    input_per_million: 2.50    # >200k tier
+//	    output_per_million: 15.0
+//	    cached_ratio: 0.25
+func parsePricingConfig(cfg map[string]any) map[string]modelPricing {
+	merged := make(map[string]modelPricing, len(defaultPricing))
+	for k, v := range defaultPricing {
+		merged[k] = v
+	}
+
+	raw, ok := cfg["pricing"].(map[string]any)
+	if !ok {
+		return merged
+	}
+
+	for model, val := range raw {
+		entry, ok := val.(map[string]any)
+		if !ok {
+			continue
+		}
+		p := merged[model]
+		if v, ok := entry["input_per_million"].(float64); ok {
+			p.InputPerMillion = v
+		}
+		if v, ok := entry["output_per_million"].(float64); ok {
+			p.OutputPerMillion = v
+		}
+		if v, ok := entry["cached_ratio"].(float64); ok {
+			p.CachedRatio = v
+		}
+		merged[model] = p
+	}
+
+	return merged
+}

--- a/plugins/providers/gemini/retry.go
+++ b/plugins/providers/gemini/retry.go
@@ -1,0 +1,199 @@
+package gemini
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// BackoffStrategy defines how delays increase between retries.
+type BackoffStrategy string
+
+const (
+	BackoffConstant    BackoffStrategy = "constant"
+	BackoffLinear      BackoffStrategy = "linear"
+	BackoffExponential BackoffStrategy = "exponential"
+	BackoffJitter      BackoffStrategy = "exponential_jitter"
+)
+
+// retryConfig controls automatic retry behavior for API requests.
+type retryConfig struct {
+	Enabled           bool
+	MaxRetries        int
+	InitialDelay      time.Duration
+	MaxDelay          time.Duration
+	Backoff           BackoffStrategy
+	Multiplier        float64
+	RetryableStatuses map[int]bool
+}
+
+func defaultRetryConfig() retryConfig {
+	return retryConfig{
+		Enabled:      false,
+		MaxRetries:   3,
+		InitialDelay: 1 * time.Second,
+		MaxDelay:     60 * time.Second,
+		Backoff:      BackoffJitter,
+		Multiplier:   2.0,
+		RetryableStatuses: map[int]bool{
+			429: true,
+			500: true,
+			502: true,
+			503: true,
+			504: true,
+		},
+	}
+}
+
+// parseRetryConfig reads retry settings from the plugin config map.
+func parseRetryConfig(cfg map[string]any) retryConfig {
+	rc := defaultRetryConfig()
+
+	retryCfg, ok := cfg["retry"].(map[string]any)
+	if !ok {
+		return rc
+	}
+
+	rc.Enabled = true
+
+	if v, ok := retryCfg["max_retries"].(int); ok {
+		rc.MaxRetries = v
+	}
+	if v, ok := retryCfg["initial_delay"].(string); ok {
+		if d, err := time.ParseDuration(v); err == nil {
+			rc.InitialDelay = d
+		}
+	}
+	if v, ok := retryCfg["max_delay"].(string); ok {
+		if d, err := time.ParseDuration(v); err == nil {
+			rc.MaxDelay = d
+		}
+	}
+	if v, ok := retryCfg["backoff"].(string); ok {
+		switch BackoffStrategy(v) {
+		case BackoffConstant, BackoffLinear, BackoffExponential, BackoffJitter:
+			rc.Backoff = BackoffStrategy(v)
+		}
+	}
+	if v, ok := retryCfg["multiplier"].(float64); ok && v > 0 {
+		rc.Multiplier = v
+	}
+	if v, ok := retryCfg["statuses"].([]any); ok {
+		rc.RetryableStatuses = make(map[int]bool, len(v))
+		for _, s := range v {
+			if code, ok := s.(int); ok {
+				rc.RetryableStatuses[code] = true
+			}
+		}
+	}
+
+	return rc
+}
+
+// doWithRetry executes an HTTP request with retry logic. The caller must close
+// the response body on success. The makeFn creates a fresh *http.Request for
+// each attempt (request bodies are consumed on send).
+func (p *Plugin) doWithRetry(ctx context.Context, makeFn func() (*http.Request, error)) (*http.Response, error) {
+	rc := p.retry
+
+	if !rc.Enabled {
+		req, err := makeFn()
+		if err != nil {
+			return nil, err
+		}
+		return p.client.Do(req)
+	}
+
+	var lastErr error
+
+	for attempt := 0; attempt <= rc.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := p.backoffDelay(attempt-1, rc)
+			p.logger.Info("retrying API request",
+				"attempt", attempt,
+				"max_retries", rc.MaxRetries,
+				"delay", delay,
+			)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		req, err := makeFn()
+		if err != nil {
+			return nil, fmt.Errorf("gemini: failed to create HTTP request: %w", err)
+		}
+
+		resp, err := p.client.Do(req)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			lastErr = err
+			continue
+		}
+
+		if !rc.RetryableStatuses[resp.StatusCode] {
+			return resp, nil
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if secs, err := strconv.Atoi(ra); err == nil {
+					delay := time.Duration(secs) * time.Second
+					if delay > rc.MaxDelay {
+						delay = rc.MaxDelay
+					}
+					p.logger.Info("respecting Retry-After header",
+						"delay", delay,
+						"attempt", attempt,
+					)
+					resp.Body.Close()
+					select {
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					case <-time.After(delay):
+					}
+					continue
+				}
+			}
+		}
+
+		lastErr = fmt.Errorf("API returned status %d", resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	return nil, fmt.Errorf("gemini: max retries (%d) exceeded: %w", rc.MaxRetries, lastErr)
+}
+
+// backoffDelay computes the wait duration for a given retry attempt.
+func (p *Plugin) backoffDelay(attempt int, rc retryConfig) time.Duration {
+	var delay time.Duration
+
+	switch rc.Backoff {
+	case BackoffConstant:
+		delay = rc.InitialDelay
+	case BackoffLinear:
+		delay = rc.InitialDelay + time.Duration(float64(attempt)*rc.Multiplier*float64(rc.InitialDelay))
+	case BackoffExponential:
+		delay = time.Duration(float64(rc.InitialDelay) * math.Pow(rc.Multiplier, float64(attempt)))
+	case BackoffJitter:
+		base := float64(rc.InitialDelay) * math.Pow(rc.Multiplier, float64(attempt))
+		jitter := rand.Float64() * base
+		delay = time.Duration(base + jitter)
+	default:
+		delay = rc.InitialDelay
+	}
+
+	if delay > rc.MaxDelay {
+		delay = rc.MaxDelay
+	}
+
+	return delay
+}

--- a/plugins/providers/gemini/retry_test.go
+++ b/plugins/providers/gemini/retry_test.go
@@ -1,0 +1,150 @@
+package gemini
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestParseRetryConfig_Defaults(t *testing.T) {
+	rc := parseRetryConfig(map[string]any{})
+	if rc.Enabled {
+		t.Fatal("expected retry disabled by default")
+	}
+	if rc.MaxRetries != 3 {
+		t.Fatalf("expected 3 max retries, got %d", rc.MaxRetries)
+	}
+	if rc.Backoff != BackoffJitter {
+		t.Fatalf("expected exponential_jitter, got %s", rc.Backoff)
+	}
+}
+
+func TestParseRetryConfig_Full(t *testing.T) {
+	rc := parseRetryConfig(map[string]any{
+		"retry": map[string]any{
+			"max_retries":   5,
+			"initial_delay": "500ms",
+			"max_delay":     "30s",
+			"backoff":       "linear",
+			"multiplier":    1.5,
+			"statuses":      []any{429, 503},
+		},
+	})
+	if !rc.Enabled {
+		t.Fatal("expected enabled")
+	}
+	if rc.MaxRetries != 5 || rc.Backoff != BackoffLinear || rc.Multiplier != 1.5 {
+		t.Fatalf("unexpected: %+v", rc)
+	}
+	if rc.InitialDelay != 500*time.Millisecond || rc.MaxDelay != 30*time.Second {
+		t.Fatalf("unexpected delays: %+v", rc)
+	}
+	if !rc.RetryableStatuses[429] || !rc.RetryableStatuses[503] || len(rc.RetryableStatuses) != 2 {
+		t.Fatalf("unexpected statuses: %+v", rc.RetryableStatuses)
+	}
+}
+
+func TestBackoffDelay_Constant(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+	rc := retryConfig{InitialDelay: 100 * time.Millisecond, MaxDelay: 10 * time.Second, Backoff: BackoffConstant}
+	for i := 0; i < 5; i++ {
+		if d := p.backoffDelay(i, rc); d != 100*time.Millisecond {
+			t.Fatalf("attempt %d: %v", i, d)
+		}
+	}
+}
+
+func TestBackoffDelay_Exponential(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+	rc := retryConfig{InitialDelay: 100 * time.Millisecond, MaxDelay: 10 * time.Second, Backoff: BackoffExponential, Multiplier: 2.0}
+	want := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond}
+	for i, exp := range want {
+		if d := p.backoffDelay(i, rc); d != exp {
+			t.Fatalf("attempt %d: got %v want %v", i, d, exp)
+		}
+	}
+}
+
+func TestBackoffDelay_MaxDelayCap(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+	rc := retryConfig{InitialDelay: 1 * time.Second, MaxDelay: 2 * time.Second, Backoff: BackoffExponential, Multiplier: 10.0}
+	if d := p.backoffDelay(3, rc); d != 2*time.Second {
+		t.Fatalf("expected 2s cap, got %v", d)
+	}
+}
+
+func TestDoWithRetry_RetriesOnRetryableStatus(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := &Plugin{
+		logger: slog.Default(),
+		client: srv.Client(),
+		retry: retryConfig{
+			Enabled:           true,
+			MaxRetries:        3,
+			InitialDelay:      1 * time.Millisecond,
+			MaxDelay:          10 * time.Millisecond,
+			Backoff:           BackoffConstant,
+			Multiplier:        1.0,
+			RetryableStatuses: map[int]bool{503: true},
+		},
+	}
+
+	resp, err := p.doWithRetry(context.Background(), func() (*http.Request, error) {
+		return http.NewRequest("POST", srv.URL, nil)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if calls.Load() != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls.Load())
+	}
+}
+
+func TestDoWithRetry_NonRetryableStatusPassesThrough(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	p := &Plugin{
+		logger: slog.Default(),
+		client: srv.Client(),
+		retry: retryConfig{
+			Enabled:           true,
+			MaxRetries:        3,
+			InitialDelay:      1 * time.Millisecond,
+			MaxDelay:          10 * time.Millisecond,
+			Backoff:           BackoffConstant,
+			Multiplier:        1.0,
+			RetryableStatuses: map[int]bool{503: true},
+		},
+	}
+
+	resp, err := p.doWithRetry(context.Background(), func() (*http.Request, error) {
+		return http.NewRequest("POST", srv.URL, nil)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest || calls.Load() != 1 {
+		t.Fatalf("expected 1 call with 400, got %d / %d", calls.Load(), resp.StatusCode)
+	}
+}

--- a/plugins/providers/gemini/thinking.go
+++ b/plugins/providers/gemini/thinking.go
@@ -1,0 +1,34 @@
+package gemini
+
+// thinkingConfig controls Gemini 2.5's reasoning ("thinking") behavior.
+//
+//	thinking:
+//	  enabled: true
+//	  budget_tokens: 8192       # max thought tokens; -1 = dynamic, 0 = disabled
+//	  include_thoughts: true    # surface thought parts as thinking.step events
+type thinkingConfig struct {
+	Enabled         bool
+	BudgetTokens    int  // -1 dynamic, 0 disabled (sent only when non-zero)
+	IncludeThoughts bool // mirrors thinkingConfig.includeThoughts
+}
+
+func parseThinkingConfig(cfg map[string]any) thinkingConfig {
+	tc := thinkingConfig{}
+
+	raw, ok := cfg["thinking"].(map[string]any)
+	if !ok {
+		return tc
+	}
+
+	if v, ok := raw["enabled"].(bool); ok {
+		tc.Enabled = v
+	}
+	if v, ok := raw["budget_tokens"].(int); ok {
+		tc.BudgetTokens = v
+	}
+	if v, ok := raw["include_thoughts"].(bool); ok {
+		tc.IncludeThoughts = v
+	}
+
+	return tc
+}

--- a/plugins/providers/gemini/thinking_test.go
+++ b/plugins/providers/gemini/thinking_test.go
@@ -1,0 +1,38 @@
+package gemini
+
+import "testing"
+
+func TestParseThinkingConfig_Empty(t *testing.T) {
+	tc := parseThinkingConfig(map[string]any{})
+	if tc.Enabled || tc.BudgetTokens != 0 || tc.IncludeThoughts {
+		t.Fatalf("expected zero values, got %+v", tc)
+	}
+}
+
+func TestParseThinkingConfig_Full(t *testing.T) {
+	tc := parseThinkingConfig(map[string]any{
+		"thinking": map[string]any{
+			"enabled":          true,
+			"budget_tokens":    8192,
+			"include_thoughts": true,
+		},
+	})
+	if !tc.Enabled || tc.BudgetTokens != 8192 || !tc.IncludeThoughts {
+		t.Fatalf("unexpected: %+v", tc)
+	}
+}
+
+func TestParseThinkingConfig_DisabledExplicit(t *testing.T) {
+	tc := parseThinkingConfig(map[string]any{
+		"thinking": map[string]any{
+			"enabled":       false,
+			"budget_tokens": 4096,
+		},
+	})
+	if tc.Enabled {
+		t.Fatal("expected enabled=false")
+	}
+	if tc.BudgetTokens != 4096 {
+		t.Fatalf("budget should still parse, got %d", tc.BudgetTokens)
+	}
+}

--- a/plugins/providers/gemini/tool_choice.go
+++ b/plugins/providers/gemini/tool_choice.go
@@ -1,0 +1,93 @@
+package gemini
+
+import "github.com/frankbardon/nexus/pkg/events"
+
+// applyToolFilter returns a filtered copy of tools based on the filter config.
+// Include takes precedence over Exclude. Nil filter returns tools unchanged.
+func applyToolFilter(tools []events.ToolDef, filter *events.ToolFilter) []events.ToolDef {
+	if filter == nil {
+		return tools
+	}
+
+	if len(filter.Include) > 0 {
+		allowed := make(map[string]bool, len(filter.Include))
+		for _, name := range filter.Include {
+			allowed[name] = true
+		}
+		var out []events.ToolDef
+		for _, t := range tools {
+			if allowed[t.Name] {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	if len(filter.Exclude) > 0 {
+		blocked := make(map[string]bool, len(filter.Exclude))
+		for _, name := range filter.Exclude {
+			blocked[name] = true
+		}
+		var out []events.ToolDef
+		for _, t := range tools {
+			if !blocked[t.Name] {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	return tools
+}
+
+// resolveToolChoice maps an events.ToolChoice to the Gemini API
+// tool_config.function_calling_config block. Returns nil when no tool_config
+// should be sent (default AUTO behavior).
+func resolveToolChoice(tc *events.ToolChoice, tools []events.ToolDef) map[string]any {
+	if tc == nil {
+		return nil
+	}
+
+	switch tc.Mode {
+	case "auto":
+		return map[string]any{
+			"function_calling_config": map[string]any{"mode": "AUTO"},
+		}
+	case "required":
+		return map[string]any{
+			"function_calling_config": map[string]any{"mode": "ANY"},
+		}
+	case "none":
+		// Gemini supports NONE natively; tools are still sent but unusable.
+		return map[string]any{
+			"function_calling_config": map[string]any{"mode": "NONE"},
+		}
+	case "tool":
+		if tc.Name == "" {
+			return map[string]any{
+				"function_calling_config": map[string]any{"mode": "ANY"},
+			}
+		}
+		// Validate the named tool exists in the filtered set.
+		found := false
+		for _, t := range tools {
+			if t.Name == tc.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return map[string]any{
+				"function_calling_config": map[string]any{"mode": "ANY"},
+			}
+		}
+		return map[string]any{
+			"function_calling_config": map[string]any{
+				"mode":                   "ANY",
+				"allowed_function_names": []string{tc.Name},
+			},
+		}
+	default:
+		return nil
+	}
+}

--- a/plugins/providers/gemini/tool_choice_test.go
+++ b/plugins/providers/gemini/tool_choice_test.go
@@ -1,0 +1,106 @@
+package gemini
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func TestApplyToolFilter_NilFilter(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}}
+	got := applyToolFilter(tools, nil)
+	if !reflect.DeepEqual(got, tools) {
+		t.Fatalf("nil filter should pass through, got %+v", got)
+	}
+}
+
+func TestApplyToolFilter_Include(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	got := applyToolFilter(tools, &events.ToolFilter{Include: []string{"a", "c"}})
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "c" {
+		t.Fatalf("Include=[a,c] expected [a,c], got %+v", got)
+	}
+}
+
+func TestApplyToolFilter_Exclude(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	got := applyToolFilter(tools, &events.ToolFilter{Exclude: []string{"b"}})
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "c" {
+		t.Fatalf("Exclude=[b] expected [a,c], got %+v", got)
+	}
+}
+
+func TestApplyToolFilter_IncludeWinsOverExclude(t *testing.T) {
+	tools := []events.ToolDef{{Name: "a"}, {Name: "b"}}
+	got := applyToolFilter(tools, &events.ToolFilter{Include: []string{"a"}, Exclude: []string{"a"}})
+	if len(got) != 1 || got[0].Name != "a" {
+		t.Fatalf("Include should take precedence; got %+v", got)
+	}
+}
+
+func TestResolveToolChoice_Nil(t *testing.T) {
+	if resolveToolChoice(nil, nil) != nil {
+		t.Fatal("nil tc should return nil")
+	}
+}
+
+func TestResolveToolChoice_Auto(t *testing.T) {
+	got := resolveToolChoice(&events.ToolChoice{Mode: "auto"}, nil)
+	want := map[string]any{"function_calling_config": map[string]any{"mode": "AUTO"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("auto: got %+v want %+v", got, want)
+	}
+}
+
+func TestResolveToolChoice_Required(t *testing.T) {
+	got := resolveToolChoice(&events.ToolChoice{Mode: "required"}, nil)
+	want := map[string]any{"function_calling_config": map[string]any{"mode": "ANY"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("required: got %+v want %+v", got, want)
+	}
+}
+
+func TestResolveToolChoice_None(t *testing.T) {
+	got := resolveToolChoice(&events.ToolChoice{Mode: "none"}, nil)
+	want := map[string]any{"function_calling_config": map[string]any{"mode": "NONE"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("none: got %+v want %+v", got, want)
+	}
+}
+
+func TestResolveToolChoice_SpecificTool(t *testing.T) {
+	tools := []events.ToolDef{{Name: "search"}, {Name: "fetch"}}
+	got := resolveToolChoice(&events.ToolChoice{Mode: "tool", Name: "search"}, tools)
+	cfg, ok := got["function_calling_config"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing function_calling_config: %+v", got)
+	}
+	if cfg["mode"] != "ANY" {
+		t.Fatalf("expected mode ANY, got %v", cfg["mode"])
+	}
+	allowed, ok := cfg["allowed_function_names"].([]string)
+	if !ok || len(allowed) != 1 || allowed[0] != "search" {
+		t.Fatalf("expected allowed_function_names=[search], got %+v", cfg["allowed_function_names"])
+	}
+}
+
+func TestResolveToolChoice_SpecificToolNotInSet(t *testing.T) {
+	tools := []events.ToolDef{{Name: "search"}}
+	got := resolveToolChoice(&events.ToolChoice{Mode: "tool", Name: "missing"}, tools)
+	cfg := got["function_calling_config"].(map[string]any)
+	if cfg["mode"] != "ANY" {
+		t.Fatalf("expected fallback mode ANY, got %v", cfg["mode"])
+	}
+	if _, ok := cfg["allowed_function_names"]; ok {
+		t.Fatalf("should not set allowed_function_names when tool absent")
+	}
+}
+
+func TestResolveToolChoice_ToolWithoutName(t *testing.T) {
+	got := resolveToolChoice(&events.ToolChoice{Mode: "tool"}, nil)
+	cfg := got["function_calling_config"].(map[string]any)
+	if cfg["mode"] != "ANY" {
+		t.Fatalf("expected mode ANY when Name empty, got %v", cfg["mode"])
+	}
+}

--- a/plugins/search/gemini_native/plugin.go
+++ b/plugins/search/gemini_native/plugin.go
@@ -1,0 +1,284 @@
+// Package geminative implements the search.provider capability backed by
+// Gemini's server-side google_search tool. Mirrors the anthropic_native and
+// openai_native search plugins so projects can pick a search provider
+// independently of their primary LLM provider.
+package geminative
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID   = "nexus.search.gemini_native"
+	pluginName = "Gemini Native Search Provider"
+	version    = "0.1.0"
+)
+
+// Plugin answers search.request via a one-shot generateContent call with the
+// google_search tool enabled.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+
+	apiKey  string
+	model   string
+	client  *http.Client
+	unsubs  []func()
+	timeout time.Duration
+}
+
+func New() engine.Plugin {
+	return &Plugin{
+		model:   "gemini-2.5-flash",
+		timeout: 30 * time.Second,
+	}
+}
+
+func (p *Plugin) ID() string                     { return pluginID }
+func (p *Plugin) Name() string                   { return pluginName }
+func (p *Plugin) Version() string                { return version }
+func (p *Plugin) Dependencies() []string         { return nil }
+func (p *Plugin) Requires() []engine.Requirement { return nil }
+
+func (p *Plugin) Capabilities() []engine.Capability {
+	return []engine.Capability{{
+		Name:        "search.provider",
+		Description: "Web search via Gemini's server-side google_search tool.",
+	}}
+}
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+
+	if key, ok := ctx.Config["api_key"].(string); ok && key != "" {
+		p.apiKey = key
+	} else {
+		envVar, _ := ctx.Config["api_key_env"].(string)
+		if envVar != "" {
+			p.apiKey = os.Getenv(envVar)
+		} else {
+			if v := os.Getenv("GEMINI_API_KEY"); v != "" {
+				p.apiKey = v
+			} else if v := os.Getenv("GOOGLE_API_KEY"); v != "" {
+				p.apiKey = v
+			}
+		}
+	}
+	if p.apiKey == "" {
+		return fmt.Errorf("gemini_native: no API key configured (set api_key in config or GEMINI_API_KEY / GOOGLE_API_KEY env var)")
+	}
+
+	if m, ok := ctx.Config["model"].(string); ok && m != "" {
+		p.model = m
+	}
+	if ts, ok := ctx.Config["timeout"].(string); ok {
+		d, err := time.ParseDuration(ts)
+		if err != nil {
+			return fmt.Errorf("gemini_native: invalid timeout %q: %w", ts, err)
+		}
+		p.timeout = d
+	}
+
+	p.client = &http.Client{Timeout: p.timeout}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("search.request", p.handleSearch,
+			engine.WithPriority(50), engine.WithSource(pluginID)),
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	if p.client != nil {
+		p.client.CloseIdleConnections()
+	}
+	return nil
+}
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "search.request", Priority: 50},
+	}
+}
+
+func (p *Plugin) Emissions() []string { return nil }
+
+func (p *Plugin) handleSearch(event engine.Event[any]) {
+	req, ok := event.Payload.(*events.SearchRequest)
+	if !ok {
+		return
+	}
+	if req.Provider != "" {
+		return
+	}
+
+	results, err := p.search(req)
+	req.Provider = pluginID
+	if err != nil {
+		req.Error = err.Error()
+		return
+	}
+	req.Results = results
+}
+
+func (p *Plugin) search(req *events.SearchRequest) ([]events.SearchResult, error) {
+	count := req.Count
+	if count <= 0 {
+		count = 10
+	}
+
+	body := map[string]any{
+		"contents": []map[string]any{{
+			"role":  "user",
+			"parts": []map[string]any{{"text": buildSearchPrompt(req.Query, req.Freshness)}},
+		}},
+		"tools": []map[string]any{{"google_search": map[string]any{}}},
+		"generationConfig": map[string]any{
+			"maxOutputTokens": 4096,
+			"temperature":     0.0,
+		},
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", p.model)
+
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("x-goog-api-key", p.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("gemini returned HTTP %d: %s", resp.StatusCode, truncate(string(raw), 300))
+	}
+
+	var decoded geminiResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+
+	return extractResults(decoded, count), nil
+}
+
+func buildSearchPrompt(query, freshness string) string {
+	var b strings.Builder
+	b.WriteString("Use google_search to look up current information for the query below. ")
+	b.WriteString("Do not answer from memory. Return concise summaries with sources.\n\n")
+	fmt.Fprintf(&b, "Query: %s\n", query)
+	if f := strings.TrimSpace(freshness); f != "" {
+		fmt.Fprintf(&b, "Freshness: prefer results from the last %s.\n", f)
+	}
+	return b.String()
+}
+
+type geminiResponse struct {
+	Candidates []struct {
+		Content struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"content"`
+		GroundingMetadata *struct {
+			GroundingChunks []struct {
+				Web *struct {
+					URI   string `json:"uri"`
+					Title string `json:"title"`
+				} `json:"web,omitempty"`
+			} `json:"groundingChunks"`
+			GroundingSupports []struct {
+				Segment struct {
+					Text string `json:"text"`
+				} `json:"segment"`
+				GroundingChunkIndices []int `json:"groundingChunkIndices"`
+			} `json:"groundingSupports"`
+		} `json:"groundingMetadata,omitempty"`
+	} `json:"candidates"`
+}
+
+func extractResults(resp geminiResponse, limit int) []events.SearchResult {
+	if len(resp.Candidates) == 0 || resp.Candidates[0].GroundingMetadata == nil {
+		return nil
+	}
+
+	gm := resp.Candidates[0].GroundingMetadata
+	seen := make(map[string]struct{}, len(gm.GroundingChunks))
+
+	// Build a chunk-index → snippet map by walking groundingSupports.
+	snippetsByChunk := make(map[int][]string)
+	for _, s := range gm.GroundingSupports {
+		text := strings.TrimSpace(s.Segment.Text)
+		if text == "" {
+			continue
+		}
+		for _, idx := range s.GroundingChunkIndices {
+			snippetsByChunk[idx] = append(snippetsByChunk[idx], text)
+		}
+	}
+
+	var out []events.SearchResult
+	for i, chunk := range gm.GroundingChunks {
+		if chunk.Web == nil || chunk.Web.URI == "" {
+			continue
+		}
+		if _, dup := seen[chunk.Web.URI]; dup {
+			continue
+		}
+		seen[chunk.Web.URI] = struct{}{}
+
+		snippet := ""
+		if snips, ok := snippetsByChunk[i]; ok && len(snips) > 0 {
+			snippet = snips[0]
+		}
+
+		out = append(out, events.SearchResult{
+			Title:   chunk.Web.Title,
+			URL:     chunk.Web.URI,
+			Snippet: snippet,
+		})
+	}
+
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}


### PR DESCRIPTION
## Summary

- New `nexus.llm.gemini` provider with parity to OpenAI/Anthropic (sync + SSE streaming, tool calls, tool choice, tool filter, native structured output, retry, cancellation, debug logs, fallback hook, role-based resolution, cost tracking) plus Gemini-only features: thinking parts (2.5), multimodal inputs (inline + Files API auto-upload), built-in code execution tool, and prompt caching via `cachedContents`.
- Auth supports both api-key (`x-goog-api-key`) and Vertex AI service-account JWT (RS256, stdlib only — no oauth2 dep).
- New `nexus.search.gemini_native` plugin advertising `search.provider` via Gemini's `google_search` grounding tool, mirroring `anthropic_native` / `openai_native`.
- Additive `pkg/events/llm.go` schema: `Message.Parts` + `MessagePart`, `Usage.ReasoningTokens`, `Usage.CachedTokens`. Existing providers and callers unchanged.
- Per-stream synthetic `TurnID` so the TUI streaming bubble is keyed correctly (Gemini's API does not return one).

## Files

- `plugins/providers/gemini/` — `plugin.go`, `auth.go`, `retry.go`, `tool_choice.go`, `thinking.go`, `multimodal.go`, `files.go`, `cache.go`, `pricing.go` + tests
- `plugins/search/gemini_native/plugin.go`
- `pkg/engine/allplugins/register.go` — registers both new plugin IDs
- `configs/test-gemini.yaml`, `test-gemini-thinking.yaml`, `test-gemini-vertex.yaml`
- `docs/src/plugins/providers/gemini.md` + SUMMARY/index updates + CLAUDE.md

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `make lint` (staticcheck) clean
- [x] Unit tests cover tool_choice, retry, thinking parser, multimodal parts, cache hash + populate/lookup/expiry/invalidate + httptest of `cachedContents.create`, Files API resumable upload via httptest, JWT round-trip + Vertex URL routing + SA parsing
- [x] Manual smoke: `bin/nexus -config configs/test-gemini.yaml` with `GEMINI_API_KEY` set — verify TUI streams response token-by-token
- [x] Manual: thinking config — verify `plugins/nexus.observe.thinking/thinking.jsonl` populated with `Source: nexus.llm.gemini`
- [x] Manual: tool call round-trip (e.g. read a file) — confirms synthetic tool-call ID + `functionResponse` mapping
- [x] Manual (optional): Vertex AI auth with service-account key

🤖 Generated with [Claude Code](https://claude.com/claude-code)