### PR TITLE
feat(providers): wire native Anthropic + OpenAI features

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,36 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(env)",
+      "Bash(gh issue:*)",
+      "Bash(go build:*)",
+      "Bash(go doc *)",
+      "Bash(go get:*)",
+      "Bash(go mod:*)",
+      "Bash(go test:*)",
+      "Bash(go tool:*)",
+      "Bash(go version:*)",
+      "Bash(go vet:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(make build:*)",
+      "Bash(make fmt:*)",
+      "Bash(make lint:*)",
+      "Bash(make test:*)",
+      "Bash(make vet:*)",
+      "Bash(staticcheck:*)",
+      "Bash(wails build:*)",
+      "Bash(wc:*)",
+      "Bash(./bin/pulse)",
+      "Bash(./bin/pulse --help)",
+      "Bash(./bin/pulse api:*)",
+      "Bash(./bin/pulse cohort:*)",
+      "Bash(./bin/pulse import:*)",
+      "Bash(./bin/pulse skills:*)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:www.anthropic.com)"
+    ]
+  },
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Thumbs.db
 
 # Claude
 .claude/settings.local.json
+.planning/

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -21,6 +21,9 @@ import (
 	testioplugin "github.com/frankbardon/nexus/plugins/io/test"
 	tuiplugin "github.com/frankbardon/nexus/plugins/io/tui"
 
+	// LLM coordination plugins.
+	batchplugin "github.com/frankbardon/nexus/plugins/llm/batch"
+
 	// Memory plugins.
 	"github.com/frankbardon/nexus/plugins/memory/capped"
 	compactionplugin "github.com/frankbardon/nexus/plugins/memory/compaction"
@@ -112,6 +115,9 @@ func RegisterAll(r *engine.PluginRegistry) {
 	r.Register("nexus.io.browser", browserplugin.New)
 	r.Register("nexus.io.oneshot", oneshotplugin.New)
 	r.Register("nexus.io.test", testioplugin.New)
+
+	// LLM coordination
+	r.Register("nexus.llm.batch", batchplugin.New)
 
 	// Memory
 	r.Register("nexus.memory.simple", simple.New)

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -47,6 +47,17 @@ type Message struct {
 	// Providers without multimodal support fall back to Content (text-only path).
 	ToolCallID string            // for tool result messages
 	ToolCalls  []ToolCallRequest // for assistant messages with tool calls
+
+	// Metadata carries provider-specific round-trip data that must survive a
+	// turn boundary. Example: Anthropic extended-thinking emits opaque
+	// `thinking` and `redacted_thinking` blocks (with cryptographic signatures)
+	// that MUST be echoed back verbatim on the next assistant turn after a
+	// tool result, otherwise the API rejects the request with HTTP 400.
+	// Providers stash these as Metadata["thinking_blocks"] on the assistant
+	// Message and read them back when serializing the next request body.
+	// Keys are namespaced informally per-provider; consumers other than the
+	// owning provider should treat this map as opaque.
+	Metadata map[string]any
 }
 
 // MessagePart carries a single piece of multimodal content. Providers that

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -110,11 +110,32 @@ type LLMResponse struct {
 	FinishReason string
 	Metadata     map[string]any
 
+	// Citations carries native source attributions emitted by providers that
+	// support them (currently Anthropic). Nil when the provider doesn't emit
+	// citations or the request didn't include citation-enabled documents.
+	Citations []Citation
+
 	// Alternatives holds additional responses from parallel fanout providers.
 	// Nil for normal (non-fanout) requests. When populated, the primary fields
 	// above contain the first successful response (or selected winner), and
 	// Alternatives contains the remaining responses.
 	Alternatives []LLMResponse
+}
+
+// Citation is a single source attribution returned by a provider that supports
+// native citation tracking (currently Anthropic). Other providers leave the
+// LLMResponse.Citations slice nil.
+type Citation struct {
+	Type            string // "char_location" | "page_location" | "content_block_location"
+	CitedText       string
+	DocumentIndex   int
+	DocumentTitle   string
+	StartCharIndex  int
+	EndCharIndex    int
+	StartPageNumber int
+	EndPageNumber   int
+	StartBlockIndex int
+	EndBlockIndex   int
 }
 
 // Usage tracks token consumption for an LLM call.

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -164,3 +164,60 @@ type StreamEnd struct {
 	Usage        Usage
 	FinishReason string
 }
+
+// BatchSubmit is published by callers (CLI subcommand, agent tool, etc.) to
+// request that a slice of LLMRequests be sent to a provider's batch endpoint
+// rather than the synchronous llm.request path. The coordinator plugin
+// (`nexus.llm.batch`) handles dispatch, polling, and result aggregation.
+//
+// Bus event type: "llm.batch.submit".
+type BatchSubmit struct {
+	Provider string // "anthropic" | "openai"
+	Requests []BatchRequest
+	Metadata map[string]any
+}
+
+// BatchRequest pairs a stable caller-defined id with an LLMRequest. The
+// CustomID is how the caller correlates results (per-request) when the
+// batch returns out of order.
+type BatchRequest struct {
+	CustomID string
+	Request  LLMRequest
+}
+
+// BatchStatus is emitted periodically by the coordinator while the batch is
+// in flight. Counts are best-effort — providers report different shapes.
+//
+// Bus event type: "llm.batch.status".
+type BatchStatus struct {
+	Provider string
+	BatchID  string
+	Status   string // "submitted" | "in_progress" | "completed" | "failed" | "cancelled"
+	Counts   BatchCounts
+}
+
+// BatchCounts is a best-effort snapshot of per-request progress in a batch.
+type BatchCounts struct {
+	Total     int
+	Completed int
+	Failed    int
+}
+
+// BatchResults is emitted once at the end of a batch, carrying all per-request
+// results.
+//
+// Bus event type: "llm.batch.results".
+type BatchResults struct {
+	Provider string
+	BatchID  string
+	Results  []BatchResult
+}
+
+// BatchResult is a single per-request entry in a BatchResults payload. Either
+// Response is non-nil (success) or Error is non-empty (this individual request
+// failed); callers must check both.
+type BatchResult struct {
+	CustomID string
+	Response *LLMResponse // nil when Error is set
+	Error    string       // non-empty when this individual request failed
+}

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -35,7 +35,9 @@ type LLMRequest struct {
 	MaxTokens      int
 	Temperature    *float64
 	Stream         bool
-	Metadata       map[string]any
+	Prediction     string // OpenAI-only: known-content prediction for low-latency edits.
+	// Other providers ignore this field. Empty = no prediction.
+	Metadata map[string]any
 }
 
 // Message represents a single message in an LLM conversation.

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -107,6 +107,7 @@ type Usage struct {
 	TotalTokens      int
 	ReasoningTokens  int // thinking/reasoning tokens (Gemini 2.5 thoughtTokenCount, etc.)
 	CachedTokens     int // tokens served from a prompt cache (billed at a discount)
+	CacheWriteTokens int // tokens written into a prompt cache (billed at a premium over plain input)
 }
 
 // StreamChunk is a single chunk from a streaming LLM response.

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -71,6 +71,12 @@ type MessagePart struct {
 	MimeType string // e.g. "image/png", "application/pdf"; required when Data or URI set
 	Data     []byte // inline bytes
 	URI      string // provider-hosted reference (e.g. Gemini Files API URI)
+	FileID   string // provider-issued file id (e.g. Anthropic file_..., OpenAI file-...).
+	// When set, providers reference the file by id rather than re-uploading or
+	// inlining bytes. Takes precedence over Data if both are set; takes
+	// precedence over URI for providers that have a native file_id source type
+	// (Anthropic Files API, OpenAI plan 14). Cross-provider field — Anthropic
+	// owns it first, OpenAI will reuse on plan 14.
 }
 
 // ToolCallRequest represents a tool invocation requested by the LLM.

--- a/pkg/events/thinking.go
+++ b/pkg/events/thinking.go
@@ -9,4 +9,9 @@ type ThinkingStep struct {
 	Content   string
 	Phase     string // "planning", "executing", "reasoning"
 	Timestamp time.Time
+	// Index is the sequence number of this step within a single TurnID.
+	// Providers that emit one event per logical thinking block (or chunk
+	// thereof) use this to order steps for reconstruction; planners that
+	// emit a single thinking event per turn leave it at 0.
+	Index int
 }

--- a/plugins/llm/batch/anthropic.go
+++ b/plugins/llm/batch/anthropic.go
@@ -1,0 +1,422 @@
+package batch
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// Anthropic Message Batches endpoints + headers.
+//
+// The Messages Batches API ships behind a beta gate. We send the beta header
+// on every batch request so the gate stays on regardless of deployment.
+const (
+	anthropicBatchBaseURL    = "https://api.anthropic.com/v1/messages/batches"
+	anthropicAPIVersion      = "2023-06-01"
+	anthropicBatchBetaHeader = "message-batches-2024-09-24"
+)
+
+// submitAnthropic POSTs a new Message Batches job and returns the batch id.
+//
+// Body shape:
+//
+//	{"requests": [
+//	  {"custom_id":"...","params":{...messages-api-body...}},
+//	  ...
+//	]}
+//
+// The per-request "params" payload is constructed by buildAnthropicMessageBody —
+// a deliberately minimal text-only adapter (no thinking, no caching, no
+// multimodal). The full provider plugin's buildRequestBody isn't reused here
+// because it's tightly coupled to Plugin state (auth modes, file uploads,
+// metadata side-effects). Surfacing those features in batched mode is a
+// follow-up; calling them out here so it's not a silent gap.
+func (p *Plugin) submitAnthropic(ctx context.Context, requests []events.BatchRequest) (string, error) {
+	if p.anthropicAPIKey == "" {
+		return "", fmt.Errorf("batch: anthropic api key not configured")
+	}
+	if len(requests) == 0 {
+		return "", fmt.Errorf("batch: anthropic requires at least one request")
+	}
+
+	type wireRequest struct {
+		CustomID string         `json:"custom_id"`
+		Params   map[string]any `json:"params"`
+	}
+	wire := make([]wireRequest, 0, len(requests))
+	for _, r := range requests {
+		params, err := buildAnthropicMessageBody(r.Request, p.defaultMaxTokens)
+		if err != nil {
+			return "", fmt.Errorf("batch: anthropic request %q: %w", r.CustomID, err)
+		}
+		wire = append(wire, wireRequest{CustomID: r.CustomID, Params: params})
+	}
+
+	body, err := json.Marshal(map[string]any{"requests": wire})
+	if err != nil {
+		return "", fmt.Errorf("batch: anthropic marshal submit body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.anthropicURL(""), bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("batch: anthropic build submit request: %w", err)
+	}
+	p.applyAnthropicHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("batch: anthropic submit HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("batch: anthropic submit returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("batch: anthropic decode submit response: %w", err)
+	}
+	if parsed.ID == "" {
+		return "", fmt.Errorf("batch: anthropic submit response missing id: %s", string(respBody))
+	}
+	return parsed.ID, nil
+}
+
+// statusAnthropic fetches the current status of a Messages batch and maps the
+// provider's processing_status to the canonical status vocabulary.
+func (p *Plugin) statusAnthropic(ctx context.Context, batchID string) (string, events.BatchCounts, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", p.anthropicURL("/"+batchID), nil)
+	if err != nil {
+		return "", events.BatchCounts{}, fmt.Errorf("batch: anthropic build status request: %w", err)
+	}
+	p.applyAnthropicHeaders(req)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", events.BatchCounts{}, fmt.Errorf("batch: anthropic status HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", events.BatchCounts{}, fmt.Errorf("batch: anthropic status returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		ID               string `json:"id"`
+		ProcessingStatus string `json:"processing_status"`
+		RequestCounts    struct {
+			Processing int `json:"processing"`
+			Succeeded  int `json:"succeeded"`
+			Errored    int `json:"errored"`
+			Canceled   int `json:"canceled"`
+			Expired    int `json:"expired"`
+		} `json:"request_counts"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", events.BatchCounts{}, fmt.Errorf("batch: anthropic decode status: %w", err)
+	}
+
+	counts := events.BatchCounts{
+		Total: parsed.RequestCounts.Processing + parsed.RequestCounts.Succeeded +
+			parsed.RequestCounts.Errored + parsed.RequestCounts.Canceled +
+			parsed.RequestCounts.Expired,
+		Completed: parsed.RequestCounts.Succeeded,
+		Failed:    parsed.RequestCounts.Errored + parsed.RequestCounts.Canceled + parsed.RequestCounts.Expired,
+	}
+
+	// Anthropic uses "ended" for the terminal state regardless of outcome —
+	// flip it to "completed" when at least one request succeeded, "failed"
+	// when none did. "in_progress" stays as-is.
+	canonical := parsed.ProcessingStatus
+	switch parsed.ProcessingStatus {
+	case "ended":
+		if parsed.RequestCounts.Succeeded > 0 {
+			canonical = statusCompleted
+		} else {
+			canonical = statusFailed
+		}
+	case "in_progress":
+		canonical = statusInProgress
+	case "canceling", "canceled", "cancelled":
+		canonical = statusCancelled
+	}
+	return canonical, counts, nil
+}
+
+// resultsAnthropic downloads the JSONL results file for a batch and decodes
+// each line into a BatchResult.
+//
+// Anthropic's results endpoint redirects to a presigned URL; net/http follows
+// 3xx by default. We don't reauthenticate the redirect — the presigned URL
+// carries its own credentials.
+func (p *Plugin) resultsAnthropic(ctx context.Context, batchID string) ([]events.BatchResult, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", p.anthropicURL("/"+batchID+"/results"), nil)
+	if err != nil {
+		return nil, fmt.Errorf("batch: anthropic build results request: %w", err)
+	}
+	p.applyAnthropicHeaders(req)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("batch: anthropic results HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("batch: anthropic results returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	out := make([]events.BatchResult, 0, 16)
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024*16) // up to 16 MiB per line
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		res, err := decodeAnthropicResultLine([]byte(line))
+		if err != nil {
+			out = append(out, events.BatchResult{Error: fmt.Sprintf("decode line: %v", err)})
+			continue
+		}
+		out = append(out, res)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("batch: anthropic results read: %w", err)
+	}
+	return out, nil
+}
+
+// decodeAnthropicResultLine parses one JSONL line from Anthropic's results
+// stream. Each line carries a custom_id and a result envelope of one of:
+//
+//	{"type":"succeeded","message":{...messages-api-response...}}
+//	{"type":"errored","error":{"type":"...","message":"..."}}
+//	{"type":"canceled"} | {"type":"expired"}
+func decodeAnthropicResultLine(line []byte) (events.BatchResult, error) {
+	var raw struct {
+		CustomID string `json:"custom_id"`
+		Result   struct {
+			Type    string          `json:"type"`
+			Message json.RawMessage `json:"message,omitempty"`
+			Error   struct {
+				Type    string `json:"type"`
+				Message string `json:"message"`
+			} `json:"error,omitempty"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return events.BatchResult{}, err
+	}
+
+	br := events.BatchResult{CustomID: raw.CustomID}
+	switch raw.Result.Type {
+	case "succeeded":
+		resp, err := decodeAnthropicMessage(raw.Result.Message)
+		if err != nil {
+			br.Error = fmt.Sprintf("decode message: %v", err)
+			return br, nil
+		}
+		br.Response = resp
+	case "errored":
+		if raw.Result.Error.Type != "" || raw.Result.Error.Message != "" {
+			br.Error = fmt.Sprintf("%s: %s", raw.Result.Error.Type, raw.Result.Error.Message)
+		} else {
+			br.Error = "errored"
+		}
+	case "canceled", "cancelled":
+		br.Error = "canceled"
+	case "expired":
+		br.Error = "expired"
+	default:
+		br.Error = fmt.Sprintf("unknown result type: %s", raw.Result.Type)
+	}
+	return br, nil
+}
+
+// decodeAnthropicMessage maps an Anthropic Messages API response object onto
+// our LLMResponse. Mirrors plugins/providers/anthropic/plugin.go's
+// convertAPIResponse but kept local to avoid pulling in that plugin's
+// internal types here.
+func decodeAnthropicMessage(raw json.RawMessage) (*events.LLMResponse, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty message payload")
+	}
+	var msg struct {
+		ID         string `json:"id"`
+		Model      string `json:"model"`
+		StopReason string `json:"stop_reason"`
+		Content    []struct {
+			Type  string          `json:"type"`
+			Text  string          `json:"text,omitempty"`
+			ID    string          `json:"id,omitempty"`
+			Name  string          `json:"name,omitempty"`
+			Input json.RawMessage `json:"input,omitempty"`
+		} `json:"content"`
+		Usage struct {
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return nil, err
+	}
+
+	var content strings.Builder
+	var toolCalls []events.ToolCallRequest
+	for _, block := range msg.Content {
+		switch block.Type {
+		case "text":
+			content.WriteString(block.Text)
+		case "tool_use":
+			toolCalls = append(toolCalls, events.ToolCallRequest{
+				ID:        block.ID,
+				Name:      block.Name,
+				Arguments: string(block.Input),
+			})
+		}
+	}
+
+	return &events.LLMResponse{
+		Content:      content.String(),
+		ToolCalls:    toolCalls,
+		Model:        msg.Model,
+		FinishReason: msg.StopReason,
+		Usage: events.Usage{
+			PromptTokens:     msg.Usage.InputTokens,
+			CompletionTokens: msg.Usage.OutputTokens,
+			CachedTokens:     msg.Usage.CacheReadInputTokens,
+			CacheWriteTokens: msg.Usage.CacheCreationInputTokens,
+			TotalTokens:      msg.Usage.InputTokens + msg.Usage.OutputTokens,
+		},
+	}, nil
+}
+
+// buildAnthropicMessageBody is the minimal LLMRequest -> Messages-API body
+// adapter used by the batch coordinator. It supports text-only messages
+// (system + user/assistant turns + tool calls/results) and basic tool
+// definitions; multimodal parts, extended thinking, prompt caching, citations,
+// structured outputs, and Bedrock/Vertex auth are intentionally OUT OF SCOPE
+// for v1. The provider plugin's buildRequestBody owns those features and is
+// not exported, so reusing it here would require a refactor.
+//
+// defaultMaxTokens is the fallback applied when a request didn't pin a value
+// itself (Anthropic requires max_tokens; sending zero is rejected).
+func buildAnthropicMessageBody(req events.LLMRequest, defaultMaxTokens int) (map[string]any, error) {
+	if req.Model == "" {
+		return nil, fmt.Errorf("model is required for anthropic batch requests")
+	}
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
+	}
+	if maxTokens <= 0 {
+		maxTokens = 1024
+	}
+
+	body := map[string]any{
+		"model":      req.Model,
+		"max_tokens": maxTokens,
+	}
+	if req.Temperature != nil {
+		body["temperature"] = *req.Temperature
+	}
+
+	var systemPrompt string
+	apiMessages := make([]map[string]any, 0, len(req.Messages))
+	for _, msg := range req.Messages {
+		switch msg.Role {
+		case "system":
+			if systemPrompt == "" {
+				systemPrompt = msg.Content
+			} else {
+				systemPrompt = systemPrompt + "\n\n" + msg.Content
+			}
+		case "assistant":
+			if len(msg.ToolCalls) > 0 {
+				content := make([]map[string]any, 0, len(msg.ToolCalls)+1)
+				if msg.Content != "" {
+					content = append(content, map[string]any{"type": "text", "text": msg.Content})
+				}
+				for _, tc := range msg.ToolCalls {
+					var input any
+					if err := json.Unmarshal([]byte(tc.Arguments), &input); err != nil {
+						input = map[string]any{}
+					}
+					content = append(content, map[string]any{
+						"type":  "tool_use",
+						"id":    tc.ID,
+						"name":  tc.Name,
+						"input": input,
+					})
+				}
+				apiMessages = append(apiMessages, map[string]any{"role": "assistant", "content": content})
+				continue
+			}
+			apiMessages = append(apiMessages, map[string]any{"role": "assistant", "content": msg.Content})
+		case "tool":
+			apiMessages = append(apiMessages, map[string]any{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "tool_result", "tool_use_id": msg.ToolCallID, "content": msg.Content},
+				},
+			})
+		case "user":
+			apiMessages = append(apiMessages, map[string]any{"role": "user", "content": msg.Content})
+		default:
+			apiMessages = append(apiMessages, map[string]any{"role": msg.Role, "content": msg.Content})
+		}
+	}
+	if systemPrompt != "" {
+		body["system"] = systemPrompt
+	}
+	body["messages"] = apiMessages
+
+	if len(req.Tools) > 0 {
+		tools := make([]map[string]any, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			tools = append(tools, map[string]any{
+				"name":         t.Name,
+				"description":  t.Description,
+				"input_schema": t.Parameters,
+			})
+		}
+		body["tools"] = tools
+	}
+
+	return body, nil
+}
+
+// anthropicURL composes the absolute URL for an endpoint suffix. Tests
+// override anthropicBaseURL to point at an httptest server.
+func (p *Plugin) anthropicURL(suffix string) string {
+	base := p.anthropicBaseURL
+	if base == "" {
+		base = anthropicBatchBaseURL
+	}
+	return base + suffix
+}
+
+// applyAnthropicHeaders attaches the API key, version, and beta gate to req.
+// Centralized so submit/status/results stay in lockstep.
+func (p *Plugin) applyAnthropicHeaders(req *http.Request) {
+	req.Header.Set("x-api-key", p.anthropicAPIKey)
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+	req.Header.Set("anthropic-beta", anthropicBatchBetaHeader)
+}

--- a/plugins/llm/batch/openai.go
+++ b/plugins/llm/batch/openai.go
@@ -1,0 +1,497 @@
+package batch
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// OpenAI Batch API endpoints.
+//
+// Submit is a two-step dance: upload a JSONL request file via /v1/files with
+// purpose=batch, then create a batch job pointing at the resulting file id.
+// Results are downloaded by fetching the output file's content.
+const (
+	openaiFilesURL          = "https://api.openai.com/v1/files"
+	openaiBatchesURL        = "https://api.openai.com/v1/batches"
+	openaiCompletionWindow  = "24h"
+	openaiBatchEndpointPath = "/v1/chat/completions"
+)
+
+// submitOpenAI uploads a JSONL request file then creates a batch job.
+//
+// JSONL line shape:
+//
+//	{"custom_id":"...","method":"POST","url":"/v1/chat/completions","body":{...}}
+//
+// Each line's "body" is built by buildOpenAIChatBody — a minimal text-only
+// adapter mirroring the Anthropic counterpart. The full provider plugin's
+// buildRequestBody isn't reused (private + tightly coupled to plugin state).
+func (p *Plugin) submitOpenAI(ctx context.Context, requests []events.BatchRequest) (string, error) {
+	if p.openaiAPIKey == "" {
+		return "", fmt.Errorf("batch: openai api key not configured")
+	}
+	if len(requests) == 0 {
+		return "", fmt.Errorf("batch: openai requires at least one request")
+	}
+
+	// Step 1: build JSONL bytes.
+	var jsonl bytes.Buffer
+	enc := json.NewEncoder(&jsonl)
+	for _, r := range requests {
+		body, err := buildOpenAIChatBody(r.Request, p.defaultMaxTokens)
+		if err != nil {
+			return "", fmt.Errorf("batch: openai request %q: %w", r.CustomID, err)
+		}
+		line := map[string]any{
+			"custom_id": r.CustomID,
+			"method":    "POST",
+			"url":       openaiBatchEndpointPath,
+			"body":      body,
+		}
+		if err := enc.Encode(line); err != nil {
+			return "", fmt.Errorf("batch: openai encode jsonl line: %w", err)
+		}
+	}
+
+	// Step 2: upload as a "batch"-purpose file.
+	fileID, err := p.uploadOpenAIBatchFile(ctx, jsonl.Bytes())
+	if err != nil {
+		return "", err
+	}
+
+	// Step 3: create the batch job.
+	body, err := json.Marshal(map[string]any{
+		"input_file_id":     fileID,
+		"endpoint":          openaiBatchEndpointPath,
+		"completion_window": openaiCompletionWindow,
+	})
+	if err != nil {
+		return "", fmt.Errorf("batch: openai marshal create-batch body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.openaiBatchesURL(""), bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("batch: openai build create-batch request: %w", err)
+	}
+	p.applyOpenAIHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("batch: openai create-batch HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("batch: openai create-batch returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("batch: openai decode create-batch response: %w", err)
+	}
+	if parsed.ID == "" {
+		return "", fmt.Errorf("batch: openai create-batch missing id: %s", string(respBody))
+	}
+	return parsed.ID, nil
+}
+
+// uploadOpenAIBatchFile multipart-POSTs the JSONL bytes to /v1/files with
+// purpose=batch and returns the file id. Tests inject an alternate base URL
+// via Plugin.openaiFilesBaseURL.
+func (p *Plugin) uploadOpenAIBatchFile(ctx context.Context, jsonl []byte) (string, error) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	if err := mw.WriteField("purpose", "batch"); err != nil {
+		return "", fmt.Errorf("batch: openai write multipart purpose: %w", err)
+	}
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", `form-data; name="file"; filename="batch.jsonl"`)
+	header.Set("Content-Type", "application/jsonl")
+	part, err := mw.CreatePart(header)
+	if err != nil {
+		return "", fmt.Errorf("batch: openai create multipart part: %w", err)
+	}
+	if _, err := part.Write(jsonl); err != nil {
+		return "", fmt.Errorf("batch: openai write multipart payload: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return "", fmt.Errorf("batch: openai close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.openaiFilesURL(""), &buf)
+	if err != nil {
+		return "", fmt.Errorf("batch: openai build files request: %w", err)
+	}
+	p.applyOpenAIHeaders(req)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("batch: openai files HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("batch: openai files returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	var parsed struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("batch: openai decode files response: %w", err)
+	}
+	if parsed.ID == "" {
+		return "", fmt.Errorf("batch: openai files response missing id: %s", string(respBody))
+	}
+	return parsed.ID, nil
+}
+
+// statusOpenAI fetches the current state of an OpenAI batch and maps OpenAI's
+// status vocabulary to ours. Returns the (possibly empty) output_file_id via
+// the metadata side-channel — fetched only once at completion time, so we
+// expose it through a sentinel field on activeBatch rather than the public
+// BatchStatus payload.
+func (p *Plugin) statusOpenAI(ctx context.Context, batchID string) (status string, counts events.BatchCounts, outputFileID string, errorFileID string, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", p.openaiBatchesURL("/"+batchID), nil)
+	if err != nil {
+		return "", events.BatchCounts{}, "", "", fmt.Errorf("batch: openai build status request: %w", err)
+	}
+	p.applyOpenAIHeaders(req)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", events.BatchCounts{}, "", "", fmt.Errorf("batch: openai status HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", events.BatchCounts{}, "", "", fmt.Errorf("batch: openai status returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		ID            string `json:"id"`
+		Status        string `json:"status"`
+		OutputFileID  string `json:"output_file_id"`
+		ErrorFileID   string `json:"error_file_id"`
+		RequestCounts struct {
+			Total     int `json:"total"`
+			Completed int `json:"completed"`
+			Failed    int `json:"failed"`
+		} `json:"request_counts"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", events.BatchCounts{}, "", "", fmt.Errorf("batch: openai decode status: %w", err)
+	}
+
+	canonical := parsed.Status
+	switch parsed.Status {
+	case "validating", "in_progress", "finalizing":
+		canonical = statusInProgress
+	case "completed":
+		canonical = statusCompleted
+	case "failed", "expired":
+		canonical = statusFailed
+	case "cancelling", "cancelled", "canceling", "canceled":
+		canonical = statusCancelled
+	}
+	counts = events.BatchCounts{
+		Total:     parsed.RequestCounts.Total,
+		Completed: parsed.RequestCounts.Completed,
+		Failed:    parsed.RequestCounts.Failed,
+	}
+	return canonical, counts, parsed.OutputFileID, parsed.ErrorFileID, nil
+}
+
+// resultsOpenAI downloads the JSONL output file for a completed batch and
+// decodes each line into a BatchResult.
+func (p *Plugin) resultsOpenAI(ctx context.Context, outputFileID string) ([]events.BatchResult, error) {
+	if outputFileID == "" {
+		return nil, fmt.Errorf("batch: openai missing output_file_id")
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", p.openaiFilesURL("/"+outputFileID+"/content"), nil)
+	if err != nil {
+		return nil, fmt.Errorf("batch: openai build results request: %w", err)
+	}
+	p.applyOpenAIHeaders(req)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("batch: openai results HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("batch: openai results returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	out := make([]events.BatchResult, 0, 16)
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024*16) // up to 16 MiB per line
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		res, err := decodeOpenAIResultLine([]byte(line))
+		if err != nil {
+			out = append(out, events.BatchResult{Error: fmt.Sprintf("decode line: %v", err)})
+			continue
+		}
+		out = append(out, res)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("batch: openai results read: %w", err)
+	}
+	return out, nil
+}
+
+// decodeOpenAIResultLine parses one JSONL line from OpenAI's output file.
+// Each line carries either a successful response wrapped in
+// {"response":{"status_code":200,"body":{...chat-completion...}}} or an error
+// wrapped in {"error":{"code":"...","message":"..."}}.
+func decodeOpenAIResultLine(line []byte) (events.BatchResult, error) {
+	var raw struct {
+		ID       string `json:"id"`
+		CustomID string `json:"custom_id"`
+		Response *struct {
+			StatusCode int             `json:"status_code"`
+			Body       json.RawMessage `json:"body"`
+		} `json:"response,omitempty"`
+		Error *struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return events.BatchResult{}, err
+	}
+
+	br := events.BatchResult{CustomID: raw.CustomID}
+	switch {
+	case raw.Error != nil && (raw.Error.Code != "" || raw.Error.Message != ""):
+		br.Error = fmt.Sprintf("%s: %s", raw.Error.Code, raw.Error.Message)
+	case raw.Response != nil:
+		if raw.Response.StatusCode < 200 || raw.Response.StatusCode >= 300 {
+			br.Error = fmt.Sprintf("http %d: %s", raw.Response.StatusCode, string(raw.Response.Body))
+			return br, nil
+		}
+		resp, err := decodeOpenAIChatBody(raw.Response.Body)
+		if err != nil {
+			br.Error = fmt.Sprintf("decode body: %v", err)
+			return br, nil
+		}
+		br.Response = resp
+	default:
+		br.Error = "missing response and error fields"
+	}
+	return br, nil
+}
+
+// decodeOpenAIChatBody maps an OpenAI Chat Completions response onto our
+// LLMResponse. Mirrors plugins/providers/openai/plugin.go's convertAPIResponse.
+func decodeOpenAIChatBody(raw json.RawMessage) (*events.LLMResponse, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty body")
+	}
+	var resp struct {
+		ID      string `json:"id"`
+		Model   string `json:"model"`
+		Choices []struct {
+			Index   int `json:"index"`
+			Message struct {
+				Role      string  `json:"role"`
+				Content   *string `json:"content"`
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Type     string `json:"type"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls,omitempty"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens        int `json:"prompt_tokens"`
+			CompletionTokens    int `json:"completion_tokens"`
+			TotalTokens         int `json:"total_tokens"`
+			PromptTokensDetails struct {
+				CachedTokens int `json:"cached_tokens"`
+			} `json:"prompt_tokens_details"`
+			CompletionTokensDetails struct {
+				ReasoningTokens int `json:"reasoning_tokens"`
+			} `json:"completion_tokens_details"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, err
+	}
+
+	out := &events.LLMResponse{
+		Model: resp.Model,
+		Usage: events.Usage{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+			CachedTokens:     resp.Usage.PromptTokensDetails.CachedTokens,
+			ReasoningTokens:  resp.Usage.CompletionTokensDetails.ReasoningTokens,
+		},
+	}
+	if len(resp.Choices) > 0 {
+		choice := resp.Choices[0]
+		out.FinishReason = choice.FinishReason
+		if choice.Message.Content != nil {
+			out.Content = *choice.Message.Content
+		}
+		for _, tc := range choice.Message.ToolCalls {
+			out.ToolCalls = append(out.ToolCalls, events.ToolCallRequest{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			})
+		}
+	}
+	return out, nil
+}
+
+// buildOpenAIChatBody is the minimal LLMRequest -> Chat Completions adapter.
+// Mirrors buildAnthropicMessageBody — text-only messages, basic tools/tool-
+// choice, response_format passthrough. Multimodal, predicted outputs,
+// reasoning effort, and Azure auth are OUT OF SCOPE for v1.
+func buildOpenAIChatBody(req events.LLMRequest, defaultMaxTokens int) (map[string]any, error) {
+	if req.Model == "" {
+		return nil, fmt.Errorf("model is required for openai batch requests")
+	}
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
+	}
+
+	body := map[string]any{
+		"model": req.Model,
+	}
+	if maxTokens > 0 {
+		body["max_tokens"] = maxTokens
+	}
+	if req.Temperature != nil {
+		body["temperature"] = *req.Temperature
+	}
+
+	apiMessages := make([]map[string]any, 0, len(req.Messages))
+	for _, msg := range req.Messages {
+		switch msg.Role {
+		case "system", "user":
+			apiMessages = append(apiMessages, map[string]any{"role": msg.Role, "content": msg.Content})
+		case "assistant":
+			m := map[string]any{"role": "assistant"}
+			if msg.Content != "" {
+				m["content"] = msg.Content
+			}
+			if len(msg.ToolCalls) > 0 {
+				calls := make([]map[string]any, 0, len(msg.ToolCalls))
+				for _, tc := range msg.ToolCalls {
+					calls = append(calls, map[string]any{
+						"id":   tc.ID,
+						"type": "function",
+						"function": map[string]any{
+							"name":      tc.Name,
+							"arguments": tc.Arguments,
+						},
+					})
+				}
+				m["tool_calls"] = calls
+			}
+			apiMessages = append(apiMessages, m)
+		case "tool":
+			apiMessages = append(apiMessages, map[string]any{
+				"role":         "tool",
+				"tool_call_id": msg.ToolCallID,
+				"content":      msg.Content,
+			})
+		default:
+			apiMessages = append(apiMessages, map[string]any{"role": msg.Role, "content": msg.Content})
+		}
+	}
+	body["messages"] = apiMessages
+
+	if len(req.Tools) > 0 {
+		tools := make([]map[string]any, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			tools = append(tools, map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        t.Name,
+					"description": t.Description,
+					"parameters":  t.Parameters,
+				},
+			})
+		}
+		body["tools"] = tools
+	}
+
+	if rf := req.ResponseFormat; rf != nil {
+		switch rf.Type {
+		case "json_object":
+			body["response_format"] = map[string]any{"type": "json_object"}
+		case "json_schema":
+			body["response_format"] = map[string]any{
+				"type": "json_schema",
+				"json_schema": map[string]any{
+					"name":   rf.Name,
+					"schema": rf.Schema,
+					"strict": rf.Strict,
+				},
+			}
+		}
+	}
+
+	return body, nil
+}
+
+// openaiFilesURL composes the absolute URL for a /v1/files endpoint suffix.
+// Tests override openaiFilesBaseURL.
+func (p *Plugin) openaiFilesURL(suffix string) string {
+	base := p.openaiFilesBaseURL
+	if base == "" {
+		base = openaiFilesURL
+	}
+	return base + suffix
+}
+
+// openaiBatchesURL composes the absolute URL for a /v1/batches endpoint
+// suffix. Tests override openaiBatchesBaseURL.
+func (p *Plugin) openaiBatchesURL(suffix string) string {
+	base := p.openaiBatchesBaseURL
+	if base == "" {
+		base = openaiBatchesURL
+	}
+	return base + suffix
+}
+
+// applyOpenAIHeaders attaches the bearer token. /v1/files multipart requests
+// rely on the caller setting Content-Type explicitly to the multipart boundary,
+// so this helper deliberately leaves Content-Type alone.
+func (p *Plugin) applyOpenAIHeaders(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+p.openaiAPIKey)
+}

--- a/plugins/llm/batch/plugin.go
+++ b/plugins/llm/batch/plugin.go
@@ -1,0 +1,539 @@
+// Package batch implements the cross-provider LLM Batch coordinator.
+//
+// One plugin, two providers, three event surfaces:
+//
+//   - Subscribe: "llm.batch.submit"  (events.BatchSubmit)
+//   - Emit:      "llm.batch.status"  (events.BatchStatus)
+//   - Emit:      "llm.batch.results" (events.BatchResults)
+//
+// The coordinator dispatches each submit to the configured provider's batch
+// endpoint (Anthropic Messages Batches or OpenAI Batch API), persists state to
+// disk so pollers survive restart, and polls in the background until the batch
+// completes — at which point per-request results are emitted via the bus.
+//
+// v1 scope notes (intentionally explicit so future readers know what's not
+// here):
+//   - Direct-API auth only. Bedrock / Vertex / Azure modes are not plumbed
+//     through; the per-provider auth code stays in providers/* and isn't
+//     reused here. A second-caller refactor is the right time to extract.
+//   - Text-only LLMRequest -> wire-format adapters. Multimodal, extended
+//     thinking, prompt caching, predicted outputs, reasoning effort, and
+//     citations are NOT carried into batched requests yet. The synchronous
+//     llm.request path remains the supported way to use those features.
+//   - Cross-provider batches (split N requests across providers) are out of
+//     scope — one BatchSubmit = one provider.
+//   - Cancellation is not exposed; pollers run until completion or process
+//     exit.
+package batch
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID   = "nexus.llm.batch"
+	pluginName = "LLM Batch Coordinator"
+	version    = "0.1.0"
+
+	// Canonical status vocabulary surfaced via BatchStatus.Status. Provider-
+	// specific status strings are mapped onto these by the per-provider
+	// status fetchers.
+	statusSubmitted  = "submitted"
+	statusInProgress = "in_progress"
+	statusCompleted  = "completed"
+	statusFailed     = "failed"
+	statusCancelled  = "cancelled"
+
+	defaultPollInterval   = 5 * time.Minute
+	defaultDataDir        = "~/.nexus/batches"
+	defaultBatchMaxTokens = 1024
+	httpClientTimeout     = 5 * time.Minute
+)
+
+// Plugin is the batch coordinator. It owns:
+//   - the bus subscription on "llm.batch.submit"
+//   - the on-disk state directory
+//   - the in-memory map of active batches and their pollers
+//   - the per-provider auth credentials (api keys only in v1)
+type Plugin struct {
+	bus     engine.EventBus
+	logger  *slog.Logger
+	session *engine.SessionWorkspace
+	models  *engine.ModelRegistry
+
+	pollInterval     time.Duration
+	dataDir          string
+	defaultMaxTokens int
+	client           *http.Client
+
+	// Direct-API credentials. Read from config (api_key / api_key_env) at
+	// Init time. v1 deliberately doesn't reach into the anthropic/openai
+	// provider plugins for credentials — config-driven keeps the plugin
+	// independently activatable.
+	anthropicAPIKey string
+	openaiAPIKey    string
+
+	// Test overrides. When non-empty these replace the production base URLs
+	// — the per-provider helpers always check the override first, so unit
+	// tests can point at httptest.Servers without touching production code
+	// paths.
+	anthropicBaseURL     string
+	openaiFilesBaseURL   string
+	openaiBatchesBaseURL string
+
+	mu      sync.Mutex
+	active  map[string]*activeBatch       // batch_id -> in-flight metadata
+	pollers map[string]context.CancelFunc // batch_id -> poller cancel
+	wg      sync.WaitGroup                // tracks running pollers for clean shutdown
+	unsubs  []func()
+}
+
+// activeBatch is the in-memory record for one in-flight batch. It mirrors
+// batchState (which is the persisted form) plus a few coordination fields.
+type activeBatch struct {
+	Provider     string
+	BatchID      string
+	SubmittedAt  time.Time
+	OriginalReqs []events.BatchRequest
+	Metadata     map[string]any
+}
+
+// New constructs a fresh Plugin instance.
+func New() engine.Plugin { return &Plugin{} }
+
+func (p *Plugin) ID() string                        { return pluginID }
+func (p *Plugin) Name() string                      { return pluginName }
+func (p *Plugin) Version() string                   { return version }
+func (p *Plugin) Dependencies() []string            { return nil }
+func (p *Plugin) Requires() []engine.Requirement    { return nil }
+func (p *Plugin) Capabilities() []engine.Capability { return nil }
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+	p.session = ctx.Session
+	p.models = ctx.Models
+
+	p.client = &http.Client{Timeout: httpClientTimeout}
+	p.active = make(map[string]*activeBatch)
+	p.pollers = make(map[string]context.CancelFunc)
+
+	// Poll interval. Strings get parsed with time.ParseDuration so users can
+	// write "5m", "30s", "1h" in YAML.
+	p.pollInterval = defaultPollInterval
+	if v, ok := ctx.Config["poll_interval"].(string); ok && v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("batch: invalid poll_interval %q: %w", v, err)
+		}
+		p.pollInterval = d
+	}
+
+	// Data directory for state files. Always tilde-expand before use.
+	p.dataDir = engine.ExpandPath(defaultDataDir)
+	if v, ok := ctx.Config["data_dir"].(string); ok && v != "" {
+		p.dataDir = engine.ExpandPath(v)
+	}
+	if err := os.MkdirAll(p.dataDir, 0o755); err != nil {
+		return fmt.Errorf("batch: create data dir %q: %w", p.dataDir, err)
+	}
+
+	// Default max_tokens applied when a batched LLMRequest didn't pin a
+	// value itself. Anthropic requires the field; sending zero is rejected.
+	p.defaultMaxTokens = defaultBatchMaxTokens
+	switch v := ctx.Config["default_max_tokens"].(type) {
+	case int:
+		if v > 0 {
+			p.defaultMaxTokens = v
+		}
+	case float64:
+		if v > 0 {
+			p.defaultMaxTokens = int(v)
+		}
+	}
+
+	// Provider credentials. The shape mirrors the per-provider plugins for
+	// muscle memory:
+	//
+	//   nexus.llm.batch:
+	//     providers:
+	//       anthropic:
+	//         api_key: "sk-..."
+	//         api_key_env: "ANTHROPIC_API_KEY"
+	//       openai:
+	//         api_key_env: "OPENAI_API_KEY"
+	//
+	// Either api_key (literal) or api_key_env (env-var indirection) wins;
+	// missing both leaves the credential empty and the corresponding submit
+	// path will fail loudly when called.
+	if providers, ok := ctx.Config["providers"].(map[string]any); ok {
+		if a, ok := providers["anthropic"].(map[string]any); ok {
+			p.anthropicAPIKey = readAPIKey(a, "ANTHROPIC_API_KEY")
+		}
+		if o, ok := providers["openai"].(map[string]any); ok {
+			p.openaiAPIKey = readAPIKey(o, "OPENAI_API_KEY")
+		}
+	}
+	// Backwards-compat: also look at flat top-level keys, in case operators
+	// prefer nexus.llm.batch.api_key_env (single-provider deployments).
+	if p.anthropicAPIKey == "" {
+		if v, ok := ctx.Config["anthropic_api_key_env"].(string); ok && v != "" {
+			p.anthropicAPIKey = os.Getenv(v)
+		}
+	}
+	if p.openaiAPIKey == "" {
+		if v, ok := ctx.Config["openai_api_key_env"].(string); ok && v != "" {
+			p.openaiAPIKey = os.Getenv(v)
+		}
+	}
+
+	// Subscribe to submit events.
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("llm.batch.submit", p.handleSubmit,
+			engine.WithPriority(10),
+			engine.WithSource(pluginID),
+		),
+	)
+
+	// Resume any batches we left behind on a previous run.
+	if err := p.resumePersistedBatches(); err != nil {
+		// Resume failures are logged but non-fatal — the plugin should still
+		// accept new submits even if the on-disk state is partially busted.
+		p.logger.Warn("batch: resume persisted batches failed", "error", err)
+	}
+
+	p.logger.Info("batch coordinator ready",
+		"poll_interval", p.pollInterval,
+		"data_dir", p.dataDir,
+		"anthropic_configured", p.anthropicAPIKey != "",
+		"openai_configured", p.openaiAPIKey != "",
+		"resumed", len(p.active),
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+// Shutdown unsubscribes and stops every poller. State files are intentionally
+// left on disk so the next process boot resumes the same batches.
+func (p *Plugin) Shutdown(ctx context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+
+	p.mu.Lock()
+	for id, cancel := range p.pollers {
+		cancel()
+		delete(p.pollers, id)
+	}
+	p.mu.Unlock()
+
+	// Wait for pollers to exit (best-effort; bounded by ctx).
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
+
+	if p.client != nil {
+		p.client.CloseIdleConnections()
+	}
+	return nil
+}
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "llm.batch.submit", Priority: 10},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"llm.batch.status",
+		"llm.batch.results",
+	}
+}
+
+// handleSubmit is the entrypoint for new batches.
+func (p *Plugin) handleSubmit(event engine.Event[any]) {
+	submit, ok := event.Payload.(events.BatchSubmit)
+	if !ok {
+		// Accept the pointer form too — bus emitters sometimes hand a *T to
+		// the bus despite our convention. Cheap defensive cast.
+		if ptr, ptrOK := event.Payload.(*events.BatchSubmit); ptrOK && ptr != nil {
+			submit = *ptr
+			ok = true
+		}
+	}
+	if !ok {
+		p.logger.Error("batch: invalid llm.batch.submit payload type", "type", fmt.Sprintf("%T", event.Payload))
+		return
+	}
+	if err := p.submit(context.Background(), submit); err != nil {
+		p.logger.Error("batch: submit failed", "provider", submit.Provider, "error", err)
+	}
+}
+
+// submit dispatches one BatchSubmit to the right provider. Public-ish (lower-
+// case but called directly in tests) so callers can drive the coordinator
+// without going through the bus when the bus isn't relevant to the test.
+func (p *Plugin) submit(ctx context.Context, sub events.BatchSubmit) error {
+	if len(sub.Requests) == 0 {
+		return fmt.Errorf("batch: no requests in submit payload")
+	}
+	var (
+		batchID string
+		err     error
+	)
+	switch sub.Provider {
+	case "anthropic":
+		batchID, err = p.submitAnthropic(ctx, sub.Requests)
+	case "openai":
+		batchID, err = p.submitOpenAI(ctx, sub.Requests)
+	default:
+		return fmt.Errorf("batch: unsupported provider %q (expected anthropic or openai)", sub.Provider)
+	}
+	if err != nil {
+		return err
+	}
+
+	ab := &activeBatch{
+		Provider:     sub.Provider,
+		BatchID:      batchID,
+		SubmittedAt:  time.Now().UTC(),
+		OriginalReqs: sub.Requests,
+		Metadata:     sub.Metadata,
+	}
+	if err := saveBatch(p.dataDir, &batchState{
+		Provider:     ab.Provider,
+		BatchID:      ab.BatchID,
+		SubmittedAt:  ab.SubmittedAt,
+		OriginalReqs: ab.OriginalReqs,
+		Metadata:     ab.Metadata,
+	}); err != nil {
+		// Persist failure is non-fatal but loud — the poller still runs in
+		// memory. Operator just loses restart resilience for this batch.
+		p.logger.Error("batch: persist state failed", "batch_id", batchID, "error", err)
+	}
+
+	p.startPoller(ab)
+
+	_ = p.bus.Emit("llm.batch.status", events.BatchStatus{
+		Provider: ab.Provider,
+		BatchID:  ab.BatchID,
+		Status:   statusSubmitted,
+		Counts:   events.BatchCounts{Total: len(ab.OriginalReqs)},
+	})
+	p.logger.Info("batch submitted", "provider", sub.Provider, "batch_id", batchID, "requests", len(sub.Requests))
+	return nil
+}
+
+// startPoller registers ab in the active map and launches its poller goroutine.
+// Caller must NOT hold p.mu.
+func (p *Plugin) startPoller(ab *activeBatch) {
+	pctx, cancel := context.WithCancel(context.Background())
+
+	p.mu.Lock()
+	p.active[ab.BatchID] = ab
+	p.pollers[ab.BatchID] = cancel
+	p.mu.Unlock()
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.pollLoop(pctx, ab)
+	}()
+}
+
+// pollLoop runs until the batch completes, fails, is cancelled, or the
+// process shuts down. Ticks at p.pollInterval; emits a BatchStatus on each
+// tick so observers can chart progress without subscribing to provider-
+// specific events.
+func (p *Plugin) pollLoop(ctx context.Context, ab *activeBatch) {
+	ticker := time.NewTicker(p.pollInterval)
+	defer ticker.Stop()
+
+	// Run one poll immediately so tests (and impatient operators) don't have
+	// to wait a full interval before seeing any progress signal.
+	for {
+		if p.pollOnce(ctx, ab) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// pollOnce performs a single status check + (on completion) results fetch.
+// Returns true when the batch is in a terminal state and the poller should
+// exit.
+func (p *Plugin) pollOnce(ctx context.Context, ab *activeBatch) bool {
+	switch ab.Provider {
+	case "anthropic":
+		return p.pollOnceAnthropic(ctx, ab)
+	case "openai":
+		return p.pollOnceOpenAI(ctx, ab)
+	default:
+		p.logger.Error("batch: pollOnce called with unsupported provider", "provider", ab.Provider)
+		return true
+	}
+}
+
+func (p *Plugin) pollOnceAnthropic(ctx context.Context, ab *activeBatch) bool {
+	status, counts, err := p.statusAnthropic(ctx, ab.BatchID)
+	if err != nil {
+		p.logger.Warn("batch: anthropic status fetch failed", "batch_id", ab.BatchID, "error", err)
+		return false
+	}
+	_ = p.bus.Emit("llm.batch.status", events.BatchStatus{
+		Provider: ab.Provider,
+		BatchID:  ab.BatchID,
+		Status:   status,
+		Counts:   counts,
+	})
+	switch status {
+	case statusCompleted, statusFailed, statusCancelled:
+		results, err := p.resultsAnthropic(ctx, ab.BatchID)
+		if err != nil {
+			p.logger.Error("batch: anthropic results fetch failed", "batch_id", ab.BatchID, "error", err)
+			// Stop polling regardless — we'll have left the state file alone
+			// so the operator can investigate and re-poll out-of-band.
+			return true
+		}
+		p.finalize(ab, results)
+		return true
+	}
+	return false
+}
+
+func (p *Plugin) pollOnceOpenAI(ctx context.Context, ab *activeBatch) bool {
+	status, counts, outputFileID, errorFileID, err := p.statusOpenAI(ctx, ab.BatchID)
+	if err != nil {
+		p.logger.Warn("batch: openai status fetch failed", "batch_id", ab.BatchID, "error", err)
+		return false
+	}
+	_ = p.bus.Emit("llm.batch.status", events.BatchStatus{
+		Provider: ab.Provider,
+		BatchID:  ab.BatchID,
+		Status:   status,
+		Counts:   counts,
+	})
+	switch status {
+	case statusCompleted, statusFailed, statusCancelled:
+		// Some terminal states have no output_file_id (e.g. fully-failed
+		// batches with only an error_file_id). Try output first, error file
+		// second, then fall through with whatever errors we collected.
+		var (
+			results  []events.BatchResult
+			fetchErr error
+		)
+		if outputFileID != "" {
+			results, fetchErr = p.resultsOpenAI(ctx, outputFileID)
+		} else if errorFileID != "" {
+			results, fetchErr = p.resultsOpenAI(ctx, errorFileID)
+		} else {
+			fetchErr = fmt.Errorf("no output_file_id or error_file_id in terminal status")
+		}
+		if fetchErr != nil {
+			p.logger.Error("batch: openai results fetch failed", "batch_id", ab.BatchID, "error", fetchErr)
+			return true
+		}
+		p.finalize(ab, results)
+		return true
+	}
+	return false
+}
+
+// finalize emits the BatchResults event and tears down state for one batch.
+func (p *Plugin) finalize(ab *activeBatch, results []events.BatchResult) {
+	_ = p.bus.Emit("llm.batch.results", events.BatchResults{
+		Provider: ab.Provider,
+		BatchID:  ab.BatchID,
+		Results:  results,
+	})
+	if err := deleteBatch(p.dataDir, ab.BatchID); err != nil {
+		p.logger.Warn("batch: delete state file failed", "batch_id", ab.BatchID, "error", err)
+	}
+
+	p.mu.Lock()
+	delete(p.active, ab.BatchID)
+	if cancel, ok := p.pollers[ab.BatchID]; ok {
+		// Don't actually call cancel here — the poller loop returning will
+		// release the goroutine. Just clear the map entry.
+		_ = cancel
+		delete(p.pollers, ab.BatchID)
+	}
+	p.mu.Unlock()
+
+	p.logger.Info("batch finalized", "provider", ab.Provider, "batch_id", ab.BatchID, "results", len(results))
+}
+
+// resumePersistedBatches loads every state file from p.dataDir and restarts a
+// poller for each. Called at Init.
+func (p *Plugin) resumePersistedBatches() error {
+	states, err := loadBatches(p.dataDir)
+	if err != nil {
+		return err
+	}
+	for _, s := range states {
+		// Only resume providers we have credentials for — running a poller
+		// against an empty key would just spam 401 errors.
+		switch s.Provider {
+		case "anthropic":
+			if p.anthropicAPIKey == "" {
+				p.logger.Warn("batch: cannot resume — no anthropic api key", "batch_id", s.BatchID)
+				continue
+			}
+		case "openai":
+			if p.openaiAPIKey == "" {
+				p.logger.Warn("batch: cannot resume — no openai api key", "batch_id", s.BatchID)
+				continue
+			}
+		default:
+			p.logger.Warn("batch: cannot resume — unknown provider", "provider", s.Provider, "batch_id", s.BatchID)
+			continue
+		}
+		ab := &activeBatch{
+			Provider:     s.Provider,
+			BatchID:      s.BatchID,
+			SubmittedAt:  s.SubmittedAt,
+			OriginalReqs: s.OriginalReqs,
+			Metadata:     s.Metadata,
+		}
+		p.startPoller(ab)
+	}
+	return nil
+}
+
+// readAPIKey extracts an API key from one provider's config block. Both
+// "api_key" (literal) and "api_key_env" (env-var indirection) are supported;
+// literal wins when both are set.
+func readAPIKey(cfg map[string]any, fallbackEnv string) string {
+	if v, ok := cfg["api_key"].(string); ok && v != "" {
+		return v
+	}
+	envVar, _ := cfg["api_key_env"].(string)
+	if envVar == "" {
+		envVar = fallbackEnv
+	}
+	if envVar != "" {
+		return os.Getenv(envVar)
+	}
+	return ""
+}

--- a/plugins/llm/batch/plugin_test.go
+++ b/plugins/llm/batch/plugin_test.go
@@ -1,0 +1,727 @@
+package batch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// silentLogger returns a logger that swallows everything; tests don't need
+// the noise.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newTestPlugin builds a minimal Plugin wired against an httptest server so
+// the unit tests don't talk to real provider endpoints. fn lets the test
+// register handlers on an http.ServeMux before the server boots.
+func newTestPlugin(t *testing.T, fn func(mux *http.ServeMux)) (*Plugin, *httptest.Server) {
+	t.Helper()
+	mux := http.NewServeMux()
+	if fn != nil {
+		fn(mux)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	p := &Plugin{
+		logger:               silentLogger(),
+		client:               srv.Client(),
+		dataDir:              t.TempDir(),
+		pollInterval:         20 * time.Millisecond,
+		defaultMaxTokens:     1024,
+		anthropicAPIKey:      "test-anthropic-key",
+		openaiAPIKey:         "test-openai-key",
+		anthropicBaseURL:     srv.URL + "/anthropic/batches",
+		openaiFilesBaseURL:   srv.URL + "/openai/files",
+		openaiBatchesBaseURL: srv.URL + "/openai/batches",
+		active:               make(map[string]*activeBatch),
+		pollers:              make(map[string]context.CancelFunc),
+	}
+	return p, srv
+}
+
+// =====================================================================
+// State persistence
+// =====================================================================
+
+func TestStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	state := &batchState{
+		Provider:    "anthropic",
+		BatchID:     "msgbatch_abc123",
+		SubmittedAt: time.Now().UTC().Truncate(time.Second),
+		OriginalReqs: []events.BatchRequest{
+			{
+				CustomID: "req-1",
+				Request: events.LLMRequest{
+					Model:    "claude-sonnet-4-5-20250514",
+					Messages: []events.Message{{Role: "user", Content: "hi"}},
+				},
+			},
+		},
+		Metadata: map[string]any{"job": "label-batch"},
+	}
+
+	if err := saveBatch(dir, state); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := loadBatches(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 state file, got %d", len(loaded))
+	}
+	got := loaded[0]
+	if got.Provider != state.Provider || got.BatchID != state.BatchID {
+		t.Fatalf("got mismatched record: %+v", got)
+	}
+	if len(got.OriginalReqs) != 1 || got.OriginalReqs[0].CustomID != "req-1" {
+		t.Fatalf("custom id round-trip lost: %+v", got.OriginalReqs)
+	}
+	if got.Metadata["job"] != "label-batch" {
+		t.Fatalf("metadata round-trip lost")
+	}
+
+	if err := deleteBatch(dir, state.BatchID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	loaded, err = loadBatches(dir)
+	if err != nil {
+		t.Fatalf("load after delete: %v", err)
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("expected 0 state files after delete, got %d", len(loaded))
+	}
+}
+
+func TestStateFilenameSanitize(t *testing.T) {
+	// Provider-issued ids may contain chars we don't want on disk; the
+	// sanitizer should replace anything outside [A-Za-z0-9-_.] with '_'.
+	got := stateFilename("msgbatch_01HX:slash/dot.")
+	if strings.Contains(got, "/") || strings.Contains(got, ":") {
+		t.Fatalf("filename contains forbidden chars: %q", got)
+	}
+}
+
+func TestLoadBatchesMissingDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+	loaded, err := loadBatches(dir)
+	if err != nil {
+		t.Fatalf("expected nil error on missing dir, got %v", err)
+	}
+	if loaded != nil {
+		t.Fatalf("expected nil slice, got %v", loaded)
+	}
+}
+
+// =====================================================================
+// Anthropic submit
+// =====================================================================
+
+func TestSubmitAnthropic_BodyShape(t *testing.T) {
+	var captured map[string]any
+	p, _ := newTestPlugin(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/anthropic/batches", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if r.Header.Get("x-api-key") != "test-anthropic-key" {
+				t.Errorf("missing x-api-key header")
+			}
+			if r.Header.Get("anthropic-version") == "" {
+				t.Errorf("missing anthropic-version header")
+			}
+			if r.Header.Get("anthropic-beta") == "" {
+				t.Errorf("missing anthropic-beta header")
+			}
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &captured); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"msgbatch_xyz"}`))
+		})
+	})
+
+	id, err := p.submitAnthropic(context.Background(), []events.BatchRequest{
+		{
+			CustomID: "req-a",
+			Request: events.LLMRequest{
+				Model:    "claude-sonnet-4-5-20250514",
+				Messages: []events.Message{{Role: "user", Content: "hello"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("submitAnthropic: %v", err)
+	}
+	if id != "msgbatch_xyz" {
+		t.Fatalf("expected msgbatch_xyz, got %q", id)
+	}
+
+	requests, ok := captured["requests"].([]any)
+	if !ok || len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %#v", captured["requests"])
+	}
+	first, _ := requests[0].(map[string]any)
+	if first["custom_id"] != "req-a" {
+		t.Fatalf("custom_id mismatch: %#v", first)
+	}
+	params, _ := first["params"].(map[string]any)
+	if params["model"] != "claude-sonnet-4-5-20250514" {
+		t.Fatalf("model mismatch: %#v", params)
+	}
+	if _, ok := params["max_tokens"]; !ok {
+		t.Fatalf("expected max_tokens in params, got %#v", params)
+	}
+}
+
+// =====================================================================
+// OpenAI submit (two-step: files upload + batches create)
+// =====================================================================
+
+func TestSubmitOpenAI_TwoStepFlow(t *testing.T) {
+	var (
+		fileHits  atomic.Int32
+		batchHits atomic.Int32
+	)
+	p, _ := newTestPlugin(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/openai/files", func(w http.ResponseWriter, r *http.Request) {
+			fileHits.Add(1)
+			if r.Method != http.MethodPost {
+				t.Errorf("files expected POST, got %s", r.Method)
+			}
+			if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+				t.Errorf("expected multipart Content-Type, got %q", r.Header.Get("Content-Type"))
+			}
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("parse multipart: %v", err)
+			}
+			if got := r.FormValue("purpose"); got != "batch" {
+				t.Errorf("expected purpose=batch, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"file-xyz"}`))
+		})
+		mux.HandleFunc("/openai/batches", func(w http.ResponseWriter, r *http.Request) {
+			batchHits.Add(1)
+			if r.Method != http.MethodPost {
+				t.Errorf("batches expected POST, got %s", r.Method)
+			}
+			body, _ := io.ReadAll(r.Body)
+			var got map[string]any
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got["input_file_id"] != "file-xyz" {
+				t.Errorf("expected input_file_id=file-xyz, got %v", got["input_file_id"])
+			}
+			if got["completion_window"] != "24h" {
+				t.Errorf("expected 24h window, got %v", got["completion_window"])
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"batch_abc"}`))
+		})
+	})
+
+	id, err := p.submitOpenAI(context.Background(), []events.BatchRequest{
+		{
+			CustomID: "req-x",
+			Request: events.LLMRequest{
+				Model:    "gpt-4o-mini",
+				Messages: []events.Message{{Role: "user", Content: "hi"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("submitOpenAI: %v", err)
+	}
+	if id != "batch_abc" {
+		t.Fatalf("expected batch_abc, got %q", id)
+	}
+	if fileHits.Load() != 1 || batchHits.Load() != 1 {
+		t.Fatalf("expected exactly one hit per endpoint, got files=%d batches=%d", fileHits.Load(), batchHits.Load())
+	}
+}
+
+// =====================================================================
+// Status mapping
+// =====================================================================
+
+func TestStatusMappingAnthropic(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`{"processing_status":"in_progress","request_counts":{"processing":3,"succeeded":1,"errored":0}}`, statusInProgress},
+		{`{"processing_status":"ended","request_counts":{"processing":0,"succeeded":4,"errored":0}}`, statusCompleted},
+		{`{"processing_status":"ended","request_counts":{"processing":0,"succeeded":0,"errored":4}}`, statusFailed},
+		{`{"processing_status":"canceled","request_counts":{"processing":0,"succeeded":0,"errored":0,"canceled":4}}`, statusCancelled},
+	}
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			body := c.body
+			p, _ := newTestPlugin(t, func(mux *http.ServeMux) {
+				mux.HandleFunc("/anthropic/batches/", func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(body))
+				})
+			})
+			got, _, err := p.statusAnthropic(context.Background(), "msgbatch_test")
+			if err != nil {
+				t.Fatalf("status: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("expected %q, got %q", c.want, got)
+			}
+		})
+	}
+}
+
+func TestStatusMappingOpenAI(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`{"status":"validating","request_counts":{"total":3}}`, statusInProgress},
+		{`{"status":"in_progress","request_counts":{"total":3,"completed":1}}`, statusInProgress},
+		{`{"status":"finalizing","request_counts":{"total":3,"completed":3}}`, statusInProgress},
+		{`{"status":"completed","output_file_id":"file-out","request_counts":{"total":3,"completed":3}}`, statusCompleted},
+		{`{"status":"failed","request_counts":{"total":3,"failed":3}}`, statusFailed},
+		{`{"status":"cancelled"}`, statusCancelled},
+	}
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			body := c.body
+			p, _ := newTestPlugin(t, func(mux *http.ServeMux) {
+				mux.HandleFunc("/openai/batches/", func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(body))
+				})
+			})
+			got, _, _, _, err := p.statusOpenAI(context.Background(), "batch_test")
+			if err != nil {
+				t.Fatalf("status: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("expected %q, got %q", c.want, got)
+			}
+		})
+	}
+}
+
+// =====================================================================
+// Results parsing
+// =====================================================================
+
+func TestResultsAnthropic_Mixed(t *testing.T) {
+	jsonl := strings.Join([]string{
+		`{"custom_id":"a","result":{"type":"succeeded","message":{"id":"msg_1","model":"claude-sonnet-4-5","stop_reason":"end_turn","content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":3,"output_tokens":1}}}}`,
+		`{"custom_id":"b","result":{"type":"errored","error":{"type":"invalid_request","message":"bad model"}}}`,
+		`{"custom_id":"c","result":{"type":"expired"}}`,
+	}, "\n") + "\n"
+
+	p, _ := newTestPlugin(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/anthropic/batches/msgbatch_test/results", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(jsonl))
+		})
+	})
+
+	results, err := p.resultsAnthropic(context.Background(), "msgbatch_test")
+	if err != nil {
+		t.Fatalf("results: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	if results[0].CustomID != "a" || results[0].Response == nil || results[0].Response.Content != "hello" {
+		t.Fatalf("first result mismatch: %#v", results[0])
+	}
+	if results[1].Error == "" || !strings.Contains(results[1].Error, "bad model") {
+		t.Fatalf("expected errored entry to surface message, got %#v", results[1])
+	}
+	if results[2].Error != "expired" {
+		t.Fatalf("expected expired, got %q", results[2].Error)
+	}
+}
+
+func TestResultsOpenAI_Mixed(t *testing.T) {
+	jsonl := strings.Join([]string{
+		`{"id":"r1","custom_id":"a","response":{"status_code":200,"body":{"id":"chatcmpl_1","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hi there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}},"error":null}`,
+		`{"id":"r2","custom_id":"b","error":{"code":"invalid_request","message":"missing model"}}`,
+	}, "\n") + "\n"
+
+	p, _ := newTestPlugin(t, func(mux *http.ServeMux) {
+		mux.HandleFunc("/openai/files/file-out/content", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(jsonl))
+		})
+	})
+
+	results, err := p.resultsOpenAI(context.Background(), "file-out")
+	if err != nil {
+		t.Fatalf("results: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Response == nil || results[0].Response.Content != "hi there" {
+		t.Fatalf("first result mismatch: %#v", results[0])
+	}
+	if !strings.Contains(results[1].Error, "missing model") {
+		t.Fatalf("expected error message to surface: %#v", results[1])
+	}
+}
+
+// =====================================================================
+// Restart resilience
+// =====================================================================
+
+// TestResumePersistedBatches seeds a state file in a temp data dir and asserts
+// Init reattaches a poller against that batch.
+func TestResumePersistedBatches(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-seed a state file the resume path will pick up.
+	state := &batchState{
+		Provider:    "anthropic",
+		BatchID:     "msgbatch_resume",
+		SubmittedAt: time.Now().UTC(),
+		OriginalReqs: []events.BatchRequest{
+			{CustomID: "r1", Request: events.LLMRequest{Model: "claude-sonnet-4-5-20250514"}},
+		},
+	}
+	if err := saveBatch(dir, state); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	// Mock backend: status returns "completed" immediately, then results
+	// returns one entry. The poller should fire pollOnce, hit completed,
+	// fetch results, emit BatchResults, and tear down.
+	var statusHits, resultsHits atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/anthropic/batches/msgbatch_resume", func(w http.ResponseWriter, r *http.Request) {
+		statusHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"processing_status":"ended","request_counts":{"processing":0,"succeeded":1,"errored":0}}`))
+	})
+	mux.HandleFunc("/anthropic/batches/msgbatch_resume/results", func(w http.ResponseWriter, r *http.Request) {
+		resultsHits.Add(1)
+		_, _ = w.Write([]byte(`{"custom_id":"r1","result":{"type":"succeeded","message":{"id":"m","model":"claude","stop_reason":"end_turn","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}}}` + "\n"))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	bus := &captureBus{}
+	p := &Plugin{
+		bus:              bus,
+		logger:           silentLogger(),
+		client:           srv.Client(),
+		dataDir:          dir,
+		pollInterval:     5 * time.Millisecond,
+		defaultMaxTokens: 1024,
+		anthropicAPIKey:  "test",
+		anthropicBaseURL: srv.URL + "/anthropic/batches",
+		active:           make(map[string]*activeBatch),
+		pollers:          make(map[string]context.CancelFunc),
+	}
+
+	if err := p.resumePersistedBatches(); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+
+	// Wait for the poller to run and finalize.
+	if !waitFor(t, 2*time.Second, func() bool {
+		return bus.hasResult("msgbatch_resume")
+	}) {
+		t.Fatalf("never received results event; status hits=%d, results hits=%d", statusHits.Load(), resultsHits.Load())
+	}
+
+	// State file should be gone after finalize.
+	loaded, _ := loadBatches(dir)
+	if len(loaded) != 0 {
+		t.Fatalf("expected state file deleted after completion, got %d", len(loaded))
+	}
+
+	// Cleanly tear down any lingering pollers (waiting on wg).
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+// =====================================================================
+// Concurrent batches
+// =====================================================================
+
+func TestConcurrentBatches_IndependentPollers(t *testing.T) {
+	mux := http.NewServeMux()
+
+	// Both batches return "completed" and their results are distinguishable
+	// by custom_id.
+	mux.HandleFunc("/anthropic/batches/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/anthropic/batches/")
+		if strings.HasSuffix(path, "/results") {
+			id := strings.TrimSuffix(path, "/results")
+			line := `{"custom_id":"` + id + `","result":{"type":"succeeded","message":{"id":"m","model":"claude","stop_reason":"end_turn","content":[{"type":"text","text":"` + id + `"}],"usage":{"input_tokens":1,"output_tokens":1}}}}` + "\n"
+			_, _ = w.Write([]byte(line))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"processing_status":"ended","request_counts":{"processing":0,"succeeded":1,"errored":0}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	bus := &captureBus{}
+	p := &Plugin{
+		bus:              bus,
+		logger:           silentLogger(),
+		client:           srv.Client(),
+		dataDir:          t.TempDir(),
+		pollInterval:     5 * time.Millisecond,
+		defaultMaxTokens: 1024,
+		anthropicAPIKey:  "test",
+		anthropicBaseURL: srv.URL + "/anthropic/batches",
+		active:           make(map[string]*activeBatch),
+		pollers:          make(map[string]context.CancelFunc),
+	}
+
+	for _, id := range []string{"batch1", "batch2"} {
+		ab := &activeBatch{Provider: "anthropic", BatchID: id, SubmittedAt: time.Now()}
+		p.startPoller(ab)
+	}
+
+	if !waitFor(t, 2*time.Second, func() bool {
+		return bus.hasResult("batch1") && bus.hasResult("batch2")
+	}) {
+		t.Fatalf("expected both batches to finalize")
+	}
+
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+// =====================================================================
+// Shutdown
+// =====================================================================
+
+// TestShutdownStopsPollersWithoutDeletingState confirms that Shutdown drops
+// active pollers but leaves the state files behind for next-boot resume.
+func TestShutdownStopsPollersWithoutDeletingState(t *testing.T) {
+	// Backend that NEVER returns "completed" — in_progress forever.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/anthropic/batches/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"processing_status":"in_progress","request_counts":{"processing":1}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+	state := &batchState{
+		Provider:    "anthropic",
+		BatchID:     "msgbatch_persist",
+		SubmittedAt: time.Now().UTC(),
+	}
+	if err := saveBatch(dir, state); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	bus := &captureBus{}
+	p := &Plugin{
+		bus:              bus,
+		logger:           silentLogger(),
+		client:           srv.Client(),
+		dataDir:          dir,
+		pollInterval:     5 * time.Millisecond,
+		defaultMaxTokens: 1024,
+		anthropicAPIKey:  "test",
+		anthropicBaseURL: srv.URL + "/anthropic/batches",
+		active:           make(map[string]*activeBatch),
+		pollers:          make(map[string]context.CancelFunc),
+	}
+
+	if err := p.resumePersistedBatches(); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+
+	// Give the poller a couple of ticks to start running, then shut down.
+	time.Sleep(20 * time.Millisecond)
+
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	// State file should still be there for next-boot resume.
+	loaded, err := loadBatches(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 state file after shutdown, got %d", len(loaded))
+	}
+}
+
+// =====================================================================
+// Wire-format adapter sanity checks
+// =====================================================================
+
+func TestBuildAnthropicMessageBody_RejectsEmptyModel(t *testing.T) {
+	_, err := buildAnthropicMessageBody(events.LLMRequest{}, 1024)
+	if err == nil {
+		t.Fatalf("expected error for empty model")
+	}
+}
+
+func TestBuildAnthropicMessageBody_DefaultMaxTokens(t *testing.T) {
+	body, err := buildAnthropicMessageBody(events.LLMRequest{
+		Model:    "claude-sonnet-4-5",
+		Messages: []events.Message{{Role: "user", Content: "hi"}},
+	}, 4096)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if body["max_tokens"] != 4096 {
+		t.Fatalf("expected default max_tokens=4096, got %v", body["max_tokens"])
+	}
+}
+
+func TestBuildAnthropicMessageBody_SystemSplitOut(t *testing.T) {
+	body, err := buildAnthropicMessageBody(events.LLMRequest{
+		Model: "claude-sonnet-4-5",
+		Messages: []events.Message{
+			{Role: "system", Content: "be terse"},
+			{Role: "user", Content: "hi"},
+		},
+	}, 1024)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if body["system"] != "be terse" {
+		t.Fatalf("expected system field, got %#v", body)
+	}
+	msgs, _ := body["messages"].([]map[string]any)
+	if len(msgs) != 1 || msgs[0]["role"] != "user" {
+		t.Fatalf("expected only user message, got %#v", msgs)
+	}
+}
+
+func TestBuildOpenAIChatBody_BasicShape(t *testing.T) {
+	body, err := buildOpenAIChatBody(events.LLMRequest{
+		Model: "gpt-4o-mini",
+		Messages: []events.Message{
+			{Role: "system", Content: "be terse"},
+			{Role: "user", Content: "hi"},
+		},
+		ResponseFormat: &events.ResponseFormat{
+			Type:   "json_schema",
+			Name:   "answer",
+			Schema: map[string]any{"type": "object"},
+			Strict: true,
+		},
+	}, 1024)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if body["model"] != "gpt-4o-mini" {
+		t.Fatalf("expected model field, got %#v", body)
+	}
+	rf, ok := body["response_format"].(map[string]any)
+	if !ok || rf["type"] != "json_schema" {
+		t.Fatalf("expected json_schema response_format, got %#v", body["response_format"])
+	}
+}
+
+// =====================================================================
+// Test bus + helpers
+// =====================================================================
+
+// captureBus is a minimal EventBus implementation that records every event
+// emitted. We don't need full bus semantics — just the assertion path.
+type captureBus struct {
+	mu     sync.Mutex
+	events []events.BatchResults
+	status []events.BatchStatus
+}
+
+func (b *captureBus) Emit(eventType string, payload any) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch eventType {
+	case "llm.batch.results":
+		if r, ok := payload.(events.BatchResults); ok {
+			b.events = append(b.events, r)
+		}
+	case "llm.batch.status":
+		if s, ok := payload.(events.BatchStatus); ok {
+			b.status = append(b.status, s)
+		}
+	}
+	return nil
+}
+
+func (b *captureBus) EmitEvent(_ engine.Event[any]) error { return nil }
+func (b *captureBus) EmitAsync(_ string, _ any) <-chan error {
+	ch := make(chan error, 1)
+	ch <- nil
+	close(ch)
+	return ch
+}
+func (b *captureBus) Subscribe(_ string, _ engine.HandlerFunc, _ ...engine.SubscribeOption) func() {
+	return func() {}
+}
+func (b *captureBus) SubscribeAll(_ engine.HandlerFunc) func()       { return func() {} }
+func (b *captureBus) SubscribeAllReplay(_ engine.HandlerFunc) func() { return func() {} }
+func (b *captureBus) EmitVetoable(_ string, _ any) (engine.VetoResult, error) {
+	return engine.VetoResult{}, nil
+}
+func (b *captureBus) Drain(_ context.Context) error { return nil }
+
+func (b *captureBus) hasResult(batchID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, r := range b.events {
+		if r.BatchID == batchID {
+			return true
+		}
+	}
+	return false
+}
+
+// waitFor polls fn until it returns true or the timeout elapses. Returns the
+// final state of fn() so the caller can fail the test cleanly.
+func waitFor(t *testing.T, timeout time.Duration, fn func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return fn()
+}
+
+// Compile-time check: captureBus implements engine.EventBus.
+var _ engine.EventBus = (*captureBus)(nil)
+
+// Compile-time check: errors.New is referenced so we don't get unused-import
+// flags when the tests below don't use it. (Reserved for future error-path
+// tests.)
+var _ = errors.New

--- a/plugins/llm/batch/state.go
+++ b/plugins/llm/batch/state.go
@@ -1,0 +1,125 @@
+package batch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// batchState is the on-disk record for one in-flight batch. The coordinator
+// writes one JSON file per batch into the configured data dir at submit time
+// and deletes it once results are emitted. On boot the coordinator scans the
+// data dir, loads every state file, and resumes a poller for each — that's
+// what makes batches survive process restarts.
+type batchState struct {
+	Provider     string                `json:"provider"`
+	BatchID      string                `json:"batch_id"`
+	SubmittedAt  time.Time             `json:"submitted_at"`
+	OriginalReqs []events.BatchRequest `json:"original_reqs"`
+	Metadata     map[string]any        `json:"metadata,omitempty"`
+}
+
+// stateFilename returns the basename used for a given batch id. We sanitize
+// the id to a filesystem-safe form so providers' own id schemes (which may
+// contain ":" or "/" — e.g. Anthropic's `msgbatch_…`, OpenAI's `batch_…`)
+// don't escape the data dir or create unintended subdirectories.
+func stateFilename(batchID string) string {
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'A' && r <= 'Z',
+			r >= 'a' && r <= 'z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '_'
+		}
+	}, batchID)
+	return safe + ".json"
+}
+
+// saveBatch writes (or overwrites) the state file for one batch. The caller
+// is responsible for ensuring dir exists; we don't MkdirAll here so accidental
+// typos in config don't silently create stray directories.
+func saveBatch(dir string, b *batchState) error {
+	if dir == "" {
+		return fmt.Errorf("batch: empty state dir")
+	}
+	if b == nil || b.BatchID == "" {
+		return fmt.Errorf("batch: cannot save state with empty batch id")
+	}
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return fmt.Errorf("batch: marshal state: %w", err)
+	}
+	path := filepath.Join(dir, stateFilename(b.BatchID))
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("batch: write tmp state file %q: %w", tmp, err)
+	}
+	// Atomic-ish swap so a crash mid-write doesn't leave a half-baked file
+	// that loadBatches will choke on later.
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("batch: rename state file %q: %w", path, err)
+	}
+	return nil
+}
+
+// loadBatches scans dir for *.json files and decodes each into a batchState.
+// Files that fail to decode are skipped (with the error returned aggregated)
+// — better to recover the surviving batches than abort entirely.
+func loadBatches(dir string) ([]*batchState, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("batch: read state dir %q: %w", dir, err)
+	}
+
+	var states []*batchState
+	var firstErr error
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("batch: read state %q: %w", path, err)
+			}
+			continue
+		}
+		var s batchState
+		if err := json.Unmarshal(data, &s); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("batch: decode state %q: %w", path, err)
+			}
+			continue
+		}
+		if s.BatchID == "" {
+			continue
+		}
+		states = append(states, &s)
+	}
+	return states, firstErr
+}
+
+// deleteBatch removes the on-disk state file for a batch. Missing-file errors
+// are treated as success — the caller may have cleaned up already.
+func deleteBatch(dir, batchID string) error {
+	if dir == "" || batchID == "" {
+		return nil
+	}
+	path := filepath.Join(dir, stateFilename(batchID))
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("batch: delete state %q: %w", path, err)
+	}
+	return nil
+}

--- a/plugins/memory/capped/plugin.go
+++ b/plugins/memory/capped/plugin.go
@@ -187,6 +187,12 @@ func (p *Plugin) handleInput(e engine.Event[any]) {
 // preserving any ToolCalls so the next request carries a matched tool_use →
 // tool_result pair structure. Skips responses tagged for other plugins (e.g.
 // planner-internal calls that use Metadata["_source"]).
+//
+// Provider-specific round-trip data (e.g. Anthropic extended-thinking blocks
+// with cryptographic signatures) is forwarded via Message.Metadata so the
+// next request can echo them back verbatim. Anthropic returns HTTP 400 if
+// thinking_blocks aren't preserved on the assistant turn that follows a
+// tool_result.
 func (p *Plugin) handleLLMResponse(e engine.Event[any]) {
 	resp, ok := e.Payload.(events.LLMResponse)
 	if !ok {
@@ -199,7 +205,24 @@ func (p *Plugin) handleLLMResponse(e engine.Event[any]) {
 		Role:      "assistant",
 		Content:   resp.Content,
 		ToolCalls: resp.ToolCalls,
+		Metadata:  forwardMessageMetadata(resp.Metadata),
 	})
+}
+
+// forwardMessageMetadata extracts the subset of LLMResponse.Metadata that
+// should travel with a stored Message. We deliberately do NOT copy the whole
+// map — engine-internal flags like _source / _structured_output / _target_*
+// are request-scoped routing hints, not message-scoped state. Only keys that
+// providers identify as required for round-trip continuity are preserved.
+func forwardMessageMetadata(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	var out map[string]any
+	if v, ok := src["thinking_blocks"]; ok {
+		out = map[string]any{"thinking_blocks": v}
+	}
+	return out
 }
 
 // handleToolInvoke only tracks the internal-call filter; the invocation

--- a/plugins/memory/simple/plugin.go
+++ b/plugins/memory/simple/plugin.go
@@ -123,7 +123,23 @@ func (p *Plugin) handleLLMResponse(e engine.Event[any]) {
 		Role:      "assistant",
 		Content:   resp.Content,
 		ToolCalls: resp.ToolCalls,
+		Metadata:  forwardMessageMetadata(resp.Metadata),
 	})
+}
+
+// forwardMessageMetadata extracts the subset of LLMResponse.Metadata that
+// should travel with a stored Message — currently just thinking_blocks, which
+// Anthropic requires echoed back on the next assistant turn after a
+// tool_result. Engine-internal routing flags are intentionally dropped.
+func forwardMessageMetadata(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	var out map[string]any
+	if v, ok := src["thinking_blocks"]; ok {
+		out = map[string]any{"thinking_blocks": v}
+	}
+	return out
 }
 
 func (p *Plugin) handleToolInvoke(e engine.Event[any]) {

--- a/plugins/providers/anthropic/auth.go
+++ b/plugins/providers/anthropic/auth.go
@@ -1,0 +1,669 @@
+package anthropic
+
+import (
+	"context"
+	"crypto"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+)
+
+// authMode determines how requests are authenticated and routed.
+type authMode string
+
+const (
+	// authModeAPIKey uses the public api.anthropic.com endpoint with an
+	// x-api-key header.
+	authModeAPIKey authMode = "api_key"
+	// authModeBedrock routes requests through AWS Bedrock with SigV4-signed
+	// requests against bedrock-runtime.<region>.amazonaws.com.
+	authModeBedrock authMode = "bedrock"
+	// authModeVertex routes requests through GCP Vertex AI with an OAuth2
+	// service-account JWT bearer token.
+	authModeVertex authMode = "vertex"
+)
+
+// Body version markers for non-direct backends. The direct API uses the
+// anthropic-version: 2023-06-01 HTTP header; Bedrock + Vertex want the version
+// in the request body instead.
+const (
+	bedrockBodyVersion = "bedrock-2023-05-31"
+	vertexBodyVersion  = "vertex-2023-10-16"
+)
+
+// authState holds resolved auth configuration and any cached credentials.
+//
+// One authState is constructed at Init time and reused for every request.
+// Token caching for Vertex is guarded by mu; the API-key and Bedrock paths
+// don't need locking.
+type authState struct {
+	mode authMode
+
+	// API-key path. Also kept populated by the Bedrock and Vertex paths if
+	// the user provided one — the Files API and a few other endpoints are
+	// only available on the public Anthropic endpoint, so callers that need
+	// them can fall back to direct auth even in cross-cloud mode.
+	apiKey string
+
+	// Bedrock path (AWS SigV4).
+	bedrockRegion       string
+	bedrockAccessKeyID  string
+	bedrockSecretKey    string
+	bedrockSessionToken string
+
+	// Vertex path (GCP OAuth2 JWT).
+	vertexProject string
+	vertexRegion  string
+	saEmail       string
+	saKey         *rsa.PrivateKey
+
+	mu        sync.Mutex
+	token     string
+	tokExpiry time.Time
+
+	// tokenEndpointOverride redirects the OAuth2 token exchange to a test
+	// server. Production code leaves this empty; tests set it to an
+	// httptest.Server URL.
+	tokenEndpointOverride string
+}
+
+// parseAuthConfig builds an authState from the raw plugin config map.
+//
+// Backwards compatible: if auth_mode is missing or "api_key", the existing
+// api_key / api_key_env top-level keys are honored.
+func parseAuthConfig(cfg map[string]any) (*authState, error) {
+	mode := authModeAPIKey
+	if v, ok := cfg["auth_mode"].(string); ok && v != "" {
+		switch authMode(v) {
+		case authModeAPIKey, authModeBedrock, authModeVertex:
+			mode = authMode(v)
+		default:
+			return nil, fmt.Errorf("anthropic: unknown auth_mode %q (expected api_key, bedrock, or vertex)", v)
+		}
+	}
+
+	a := &authState{mode: mode}
+
+	// Read the API key from top-level keys regardless of mode — Bedrock and
+	// Vertex don't require it, but optional fall-back to direct auth for the
+	// Files API stays useful.
+	if key, ok := cfg["api_key"].(string); ok && key != "" {
+		a.apiKey = key
+	} else {
+		envVar, _ := cfg["api_key_env"].(string)
+		if envVar == "" {
+			envVar = "ANTHROPIC_API_KEY"
+		}
+		if v := os.Getenv(envVar); v != "" {
+			a.apiKey = v
+		}
+	}
+
+	switch mode {
+	case authModeAPIKey:
+		if a.apiKey == "" {
+			return nil, fmt.Errorf("anthropic: no API key configured (set api_key in config or ANTHROPIC_API_KEY env var)")
+		}
+
+	case authModeBedrock:
+		raw, _ := cfg["bedrock"].(map[string]any)
+		if raw == nil {
+			raw = map[string]any{}
+		}
+
+		region, _ := raw["region"].(string)
+		if region == "" {
+			region = os.Getenv("AWS_REGION")
+		}
+		if region == "" {
+			region = os.Getenv("AWS_DEFAULT_REGION")
+		}
+		if region == "" {
+			return nil, fmt.Errorf("anthropic: bedrock auth requires bedrock.region (or AWS_REGION env var)")
+		}
+		a.bedrockRegion = region
+
+		akid := readEnvOrLiteral(raw, "access_key_id", "access_key_id_env", "AWS_ACCESS_KEY_ID")
+		if akid == "" {
+			return nil, fmt.Errorf("anthropic: bedrock auth requires access_key_id (config or AWS_ACCESS_KEY_ID env var)")
+		}
+		a.bedrockAccessKeyID = akid
+
+		secret := readEnvOrLiteral(raw, "secret_access_key", "secret_access_key_env", "AWS_SECRET_ACCESS_KEY")
+		if secret == "" {
+			return nil, fmt.Errorf("anthropic: bedrock auth requires secret_access_key (config or AWS_SECRET_ACCESS_KEY env var)")
+		}
+		a.bedrockSecretKey = secret
+
+		// Session token is optional (only needed for STS-issued temporary creds).
+		a.bedrockSessionToken = readEnvOrLiteral(raw, "session_token", "session_token_env", "AWS_SESSION_TOKEN")
+
+	case authModeVertex:
+		raw, _ := cfg["vertex"].(map[string]any)
+		if raw == nil {
+			raw = map[string]any{}
+		}
+
+		project, _ := raw["project"].(string)
+		if project == "" {
+			project, _ = raw["project_id"].(string)
+		}
+		if project == "" {
+			project = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		}
+		if project == "" {
+			return nil, fmt.Errorf("anthropic: vertex auth requires vertex.project (or GOOGLE_CLOUD_PROJECT env var)")
+		}
+		a.vertexProject = project
+
+		region, _ := raw["region"].(string)
+		if region == "" {
+			region, _ = raw["location"].(string)
+		}
+		if region == "" {
+			region = "us-east5"
+		}
+		a.vertexRegion = region
+
+		var saJSON []byte
+		if path, ok := raw["sa_key_file"].(string); ok && path != "" {
+			data, err := os.ReadFile(engine.ExpandPath(path))
+			if err != nil {
+				return nil, fmt.Errorf("anthropic: read sa_key_file: %w", err)
+			}
+			saJSON = data
+		} else if path, ok := raw["service_account_json"].(string); ok && path != "" {
+			data, err := os.ReadFile(engine.ExpandPath(path))
+			if err != nil {
+				return nil, fmt.Errorf("anthropic: read service_account_json: %w", err)
+			}
+			saJSON = data
+		} else {
+			envVar, _ := raw["sa_key_file_env"].(string)
+			if envVar == "" {
+				envVar, _ = raw["service_account_json_env"].(string)
+			}
+			if envVar == "" {
+				envVar = "GOOGLE_APPLICATION_CREDENTIALS"
+			}
+			if path := os.Getenv(envVar); path != "" {
+				data, err := os.ReadFile(engine.ExpandPath(path))
+				if err != nil {
+					return nil, fmt.Errorf("anthropic: read %s=%s: %w", envVar, path, err)
+				}
+				saJSON = data
+			}
+		}
+		if saJSON == nil {
+			return nil, fmt.Errorf("anthropic: vertex auth requires sa_key_file (or GOOGLE_APPLICATION_CREDENTIALS env var)")
+		}
+
+		email, key, err := parseAnthropicVertexServiceAccount(saJSON)
+		if err != nil {
+			return nil, fmt.Errorf("anthropic: parse service account: %w", err)
+		}
+		a.saEmail = email
+		a.saKey = key
+	}
+
+	return a, nil
+}
+
+// readEnvOrLiteral reads a config field that may be supplied either inline
+// (key) or by env-var indirection (key+"_env"); returns "" if neither is set.
+// fallbackEnv is consulted when the config block omits both keys, mirroring
+// AWS' standard env-var conventions.
+func readEnvOrLiteral(raw map[string]any, literalKey, envKey, fallbackEnv string) string {
+	if v, ok := raw[literalKey].(string); ok && v != "" {
+		return v
+	}
+	if v, ok := raw[envKey].(string); ok && v != "" {
+		if val := os.Getenv(v); val != "" {
+			return val
+		}
+	}
+	if fallbackEnv != "" {
+		return os.Getenv(fallbackEnv)
+	}
+	return ""
+}
+
+// buildURL returns the full request URL for the given model + stream flag.
+//
+//	api_key:  https://api.anthropic.com/v1/messages
+//	bedrock:  https://bedrock-runtime.<region>.amazonaws.com/model/<model>/invoke[-with-response-stream]
+//	vertex:   https://<region>-aiplatform.googleapis.com/v1/projects/<project>/locations/<region>/publishers/anthropic/models/<model>:rawPredict[-streamed]
+func (a *authState) buildURL(model string, stream bool) string {
+	switch a.mode {
+	case authModeBedrock:
+		op := "invoke"
+		if stream {
+			op = "invoke-with-response-stream"
+		}
+		// Bedrock model ids contain ":" (e.g. anthropic.claude-sonnet-4-5-v1:0)
+		// which url.PathEscape considers a valid pchar and leaves alone.
+		// SigV4's canonical URI path explicitly percent-encodes ":" though, so
+		// the signature wouldn't match the URL on the wire if we left the
+		// colon raw. Force the encoding via sigv4Escape (which honors the
+		// RFC 3986 unreserved set) on the model segment so request URL and
+		// signing input agree.
+		return fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s/%s",
+			a.bedrockRegion, sigv4Escape(model), op)
+	case authModeVertex:
+		op := "rawPredict"
+		if stream {
+			op = "streamRawPredict"
+		}
+		return fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:%s",
+			a.vertexRegion, a.vertexProject, a.vertexRegion, url.PathEscape(model), op)
+	default:
+		return "https://api.anthropic.com/v1/messages"
+	}
+}
+
+// bodyVersionField returns the value to inject into body["anthropic_version"]
+// for Bedrock/Vertex paths, or "" for the API-key path (which uses the
+// anthropic-version: 2023-06-01 HTTP header instead).
+func (a *authState) bodyVersionField() string {
+	switch a.mode {
+	case authModeBedrock:
+		return bedrockBodyVersion
+	case authModeVertex:
+		return vertexBodyVersion
+	default:
+		return ""
+	}
+}
+
+// stripModelFromBody reports whether the model field should be omitted from
+// the JSON request body. Bedrock encodes the model id in the URL path and
+// rejects bodies that also carry "model"; Vertex and the direct API both
+// expect the field in the body.
+func (a *authState) stripModelFromBody() bool {
+	return a.mode == authModeBedrock
+}
+
+// applyAuth attaches the right auth credentials (and signs the body for
+// Bedrock SigV4) onto the outgoing request. body is required for Bedrock so
+// the SigV4 payload hash matches what the server sees; pass the same byte
+// slice that's wrapped in req.Body. For other modes, body is ignored.
+//
+// Bedrock SigV4 must be recomputed on every retry because the timestamp is
+// part of the signature — callers funnel this through the doWithRetry
+// closure so each attempt gets a fresh signature.
+func (a *authState) applyAuth(ctx context.Context, req *http.Request, body []byte, client *http.Client) error {
+	switch a.mode {
+	case authModeAPIKey:
+		req.Header.Set("x-api-key", a.apiKey)
+		req.Header.Set("anthropic-version", "2023-06-01")
+		return nil
+
+	case authModeBedrock:
+		return a.signBedrockSigV4(req, body, time.Now().UTC())
+
+	case authModeVertex:
+		token, err := a.vertexAccessToken(ctx, client)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+	return fmt.Errorf("anthropic: unknown auth mode %q", a.mode)
+}
+
+// =====================================================================
+// Bedrock SigV4
+// =====================================================================
+
+const (
+	awsSigningAlgorithm = "AWS4-HMAC-SHA256"
+	bedrockServiceName  = "bedrock"
+)
+
+// signBedrockSigV4 is the per-mode wrapper that fixes service=bedrock and
+// reuses the credentials stored on authState. The actual SigV4 math lives in
+// signSigV4 so it's reusable for tests against the AWS-published "Get example"
+// vector (which signs against service=iam).
+func (a *authState) signBedrockSigV4(req *http.Request, body []byte, now time.Time) error {
+	return signSigV4(req, body, sigv4Creds{
+		Service:      bedrockServiceName,
+		Region:       a.bedrockRegion,
+		AccessKey:    a.bedrockAccessKeyID,
+		SecretKey:    a.bedrockSecretKey,
+		SessionToken: a.bedrockSessionToken,
+	}, now)
+}
+
+// sigv4Creds bundles the inputs needed for one SigV4 signature.
+type sigv4Creds struct {
+	Service      string
+	Region       string
+	AccessKey    string
+	SecretKey    string
+	SessionToken string // optional STS session token
+}
+
+// signSigV4 computes an AWS Signature Version 4 signature for req and sets
+// the matching headers in place. Follows
+// https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html.
+//
+// Hand-rolled (no AWS SDK) per the project's minimal-dependency convention.
+// Body bytes must be supplied separately because http.Request.Body is an
+// io.ReadCloser; the canonical request needs the hex sha256 of the payload.
+func signSigV4(req *http.Request, body []byte, creds sigv4Creds, now time.Time) error {
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	payloadHashHex := hex.EncodeToString(sha256Sum(body))
+
+	// Required signed headers. host is implicitly populated from req.URL.Host
+	// (Go won't expose it via req.Header until the request is sent), so we
+	// stash it under "host" for canonicalization purposes.
+	req.Header.Set("host", req.URL.Host)
+	req.Header.Set("x-amz-date", amzDate)
+	req.Header.Set("x-amz-content-sha256", payloadHashHex)
+	if creds.SessionToken != "" {
+		req.Header.Set("x-amz-security-token", creds.SessionToken)
+	}
+
+	canonHeaders, signedHeaders := canonicalHeaders(req)
+	canonicalQuery := canonicalQueryString(req.URL)
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURIPath(req.URL.Path),
+		canonicalQuery,
+		canonHeaders, // already terminated by trailing newlines per spec
+		signedHeaders,
+		payloadHashHex,
+	}, "\n")
+
+	scope := strings.Join([]string{dateStamp, creds.Region, creds.Service, "aws4_request"}, "/")
+	stringToSign := strings.Join([]string{
+		awsSigningAlgorithm,
+		amzDate,
+		scope,
+		hex.EncodeToString(sha256Sum([]byte(canonicalRequest))),
+	}, "\n")
+
+	signingKey := deriveSigningKey(creds.SecretKey, dateStamp, creds.Region, creds.Service)
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	auth := fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		awsSigningAlgorithm,
+		creds.AccessKey,
+		scope,
+		signedHeaders,
+		signature)
+	req.Header.Set("Authorization", auth)
+	return nil
+}
+
+// canonicalHeaders returns (joinedCanonHeaders, signedHeaders) per SigV4 spec.
+// All headers currently set on req are signed.
+func canonicalHeaders(req *http.Request) (string, string) {
+	names := make([]string, 0, len(req.Header))
+	for name := range req.Header {
+		names = append(names, strings.ToLower(name))
+	}
+	sort.Strings(names)
+
+	var canon strings.Builder
+	for _, name := range names {
+		// Use the original header name to fetch values — http.Header is
+		// case-insensitive on Get but we want the lowered name for the
+		// canonical form output.
+		values := req.Header.Values(name)
+		canon.WriteString(name)
+		canon.WriteByte(':')
+		for i, v := range values {
+			if i > 0 {
+				canon.WriteByte(',')
+			}
+			canon.WriteString(strings.TrimSpace(v))
+		}
+		canon.WriteByte('\n')
+	}
+	return canon.String(), strings.Join(names, ";")
+}
+
+// canonicalURIPath URI-encodes the path per SigV4 (each segment is percent-
+// encoded, but "/" between segments is preserved). For Bedrock we don't
+// double-encode — the spec says non-S3 services do encode once.
+func canonicalURIPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	// Split + escape each segment, preserving leading "/".
+	segs := strings.Split(p, "/")
+	for i, seg := range segs {
+		segs[i] = sigv4Escape(seg)
+	}
+	return strings.Join(segs, "/")
+}
+
+// canonicalQueryString sorts query parameters by name (then by value) and
+// percent-encodes each. SigV4 requires keys and values escaped with the
+// same RFC 3986 rules used for the path.
+func canonicalQueryString(u *url.URL) string {
+	if u.RawQuery == "" {
+		return ""
+	}
+	q := u.Query()
+	keys := make([]string, 0, len(q))
+	for k := range q {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	first := true
+	for _, k := range keys {
+		values := q[k]
+		sort.Strings(values)
+		ek := sigv4Escape(k)
+		for _, v := range values {
+			if !first {
+				b.WriteByte('&')
+			}
+			first = false
+			b.WriteString(ek)
+			b.WriteByte('=')
+			b.WriteString(sigv4Escape(v))
+		}
+	}
+	return b.String()
+}
+
+// sigv4Escape percent-encodes per RFC 3986 unreserved set ([A-Za-z0-9-_.~]).
+// Differs from net/url.QueryEscape in that "+" encodes spaces as %20 and
+// nothing else gets a special pass.
+func sigv4Escape(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z',
+			c >= 'a' && c <= 'z',
+			c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.', c == '~':
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+
+// deriveSigningKey runs the four-step HMAC chain from the spec:
+//
+//	kDate    = HMAC("AWS4" + secret, date)
+//	kRegion  = HMAC(kDate, region)
+//	kService = HMAC(kRegion, service)
+//	kSigning = HMAC(kService, "aws4_request")
+func deriveSigningKey(secret, date, region, service string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secret), []byte(date))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte(service))
+	return hmacSHA256(kService, []byte("aws4_request"))
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func sha256Sum(data []byte) []byte {
+	h := sha256.Sum256(data)
+	return h[:]
+}
+
+// =====================================================================
+// Vertex JWT bearer
+// =====================================================================
+
+// vertexAccessToken returns a valid OAuth2 access token, minting a new one
+// when the cached token is empty or within 60s of expiry.
+func (a *authState) vertexAccessToken(ctx context.Context, client *http.Client) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.token != "" && time.Now().Before(a.tokExpiry) {
+		return a.token, nil
+	}
+
+	jwt, err := a.signVertexJWT()
+	if err != nil {
+		return "", fmt.Errorf("sign JWT: %w", err)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+	form.Set("assertion", jwt)
+
+	endpoint := vertexTokenEndpoint
+	if a.tokenEndpointOverride != "" {
+		endpoint = a.tokenEndpointOverride
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token exchange failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var tr struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return "", fmt.Errorf("empty access_token in response: %s", string(body))
+	}
+
+	a.token = tr.AccessToken
+	expiresIn := time.Duration(tr.ExpiresIn) * time.Second
+	if expiresIn <= 0 {
+		expiresIn = 1 * time.Hour
+	}
+	a.tokExpiry = time.Now().Add(expiresIn - 60*time.Second)
+	return a.token, nil
+}
+
+// signVertexJWT mints an RS256-signed JWT bearer assertion suitable for
+// Google's OAuth2 token endpoint.
+func (a *authState) signVertexJWT() (string, error) {
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	headerJSON, _ := json.Marshal(header)
+
+	now := time.Now().Unix()
+	claims := map[string]any{
+		"iss":   a.saEmail,
+		"scope": "https://www.googleapis.com/auth/cloud-platform",
+		"aud":   "https://oauth2.googleapis.com/token",
+		"exp":   now + 3600,
+		"iat":   now,
+	}
+	claimsJSON, _ := json.Marshal(claims)
+
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON)
+
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, a.saKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// parseAnthropicVertexServiceAccount extracts client_email + RSA private key
+// from a GCP service-account JSON blob. Mirrors the Gemini provider's helper
+// — kept package-local to avoid cross-plugin imports.
+func parseAnthropicVertexServiceAccount(data []byte) (string, *rsa.PrivateKey, error) {
+	var sa struct {
+		ClientEmail string `json:"client_email"`
+		PrivateKey  string `json:"private_key"`
+	}
+	if err := json.Unmarshal(data, &sa); err != nil {
+		return "", nil, fmt.Errorf("decode JSON: %w", err)
+	}
+	if sa.ClientEmail == "" || sa.PrivateKey == "" {
+		return "", nil, fmt.Errorf("missing client_email or private_key")
+	}
+
+	block, _ := pem.Decode([]byte(sa.PrivateKey))
+	if block == nil {
+		return "", nil, fmt.Errorf("invalid PEM in private_key")
+	}
+
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return sa.ClientEmail, k, nil
+	}
+	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse private_key: %w", err)
+	}
+	rsaKey, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return "", nil, fmt.Errorf("private_key is not RSA")
+	}
+	return sa.ClientEmail, rsaKey, nil
+}
+
+// vertexTokenEndpoint is Google's public OAuth2 token exchange URL. Tests
+// override authState.tokenEndpointOverride to point at an httptest server.
+const vertexTokenEndpoint = "https://oauth2.googleapis.com/token"

--- a/plugins/providers/anthropic/auth_test.go
+++ b/plugins/providers/anthropic/auth_test.go
@@ -1,0 +1,575 @@
+package anthropic
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// =====================================================================
+// parseAuthConfig
+// =====================================================================
+
+func TestParseAuthConfig_DefaultsToAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "secret-key")
+
+	a, err := parseAuthConfig(map[string]any{})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.mode != authModeAPIKey {
+		t.Fatalf("mode = %q, want %q", a.mode, authModeAPIKey)
+	}
+	if a.apiKey != "secret-key" {
+		t.Fatalf("apiKey = %q, want %q", a.apiKey, "secret-key")
+	}
+}
+
+func TestParseAuthConfig_APIKey_LiteralWins(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "from-env")
+
+	a, err := parseAuthConfig(map[string]any{
+		"api_key": "from-config",
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.apiKey != "from-config" {
+		t.Fatalf("apiKey = %q, want %q", a.apiKey, "from-config")
+	}
+}
+
+func TestParseAuthConfig_APIKey_NoKeyErrors(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	_, err := parseAuthConfig(map[string]any{})
+	if err == nil {
+		t.Fatal("expected error when no API key configured")
+	}
+}
+
+func TestParseAuthConfig_UnknownMode(t *testing.T) {
+	_, err := parseAuthConfig(map[string]any{"auth_mode": "azure"})
+	if err == nil {
+		t.Fatal("expected error for unknown auth_mode")
+	}
+}
+
+func TestParseAuthConfig_Bedrock_Full(t *testing.T) {
+	a, err := parseAuthConfig(map[string]any{
+		"auth_mode": "bedrock",
+		"bedrock": map[string]any{
+			"region":            "us-east-1",
+			"access_key_id":     "AKIDEXAMPLE",
+			"secret_access_key": "secret-yo",
+			"session_token":     "sess-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.mode != authModeBedrock {
+		t.Fatalf("mode = %q, want bedrock", a.mode)
+	}
+	if a.bedrockRegion != "us-east-1" {
+		t.Fatalf("region = %q", a.bedrockRegion)
+	}
+	if a.bedrockAccessKeyID != "AKIDEXAMPLE" {
+		t.Fatalf("access_key = %q", a.bedrockAccessKeyID)
+	}
+	if a.bedrockSecretKey != "secret-yo" {
+		t.Fatalf("secret = %q", a.bedrockSecretKey)
+	}
+	if a.bedrockSessionToken != "sess-token" {
+		t.Fatalf("session_token = %q", a.bedrockSessionToken)
+	}
+}
+
+func TestParseAuthConfig_Bedrock_FromEnvVars(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-west-2")
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-akid")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+
+	a, err := parseAuthConfig(map[string]any{
+		"auth_mode": "bedrock",
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.bedrockRegion != "us-west-2" {
+		t.Fatalf("region = %q, want us-west-2", a.bedrockRegion)
+	}
+	if a.bedrockAccessKeyID != "env-akid" {
+		t.Fatalf("akid = %q, want env-akid", a.bedrockAccessKeyID)
+	}
+	if a.bedrockSecretKey != "env-secret" {
+		t.Fatalf("secret = %q, want env-secret", a.bedrockSecretKey)
+	}
+}
+
+func TestParseAuthConfig_Bedrock_MissingRegionErrors(t *testing.T) {
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_ACCESS_KEY_ID", "akid")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "bedrock",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing region")
+	}
+}
+
+func TestParseAuthConfig_Bedrock_MissingCredsErrors(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "bedrock",
+		"bedrock":   map[string]any{"region": "us-east-1"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing access_key_id")
+	}
+}
+
+func TestParseAuthConfig_Vertex_Full(t *testing.T) {
+	dir := t.TempDir()
+	saPath := filepath.Join(dir, "sa.json")
+	writeFakeServiceAccount(t, saPath, "test-sa@example.iam.gserviceaccount.com")
+
+	a, err := parseAuthConfig(map[string]any{
+		"auth_mode": "vertex",
+		"vertex": map[string]any{
+			"project":     "my-proj",
+			"region":      "us-east5",
+			"sa_key_file": saPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.mode != authModeVertex {
+		t.Fatalf("mode = %q", a.mode)
+	}
+	if a.vertexProject != "my-proj" {
+		t.Fatalf("project = %q", a.vertexProject)
+	}
+	if a.vertexRegion != "us-east5" {
+		t.Fatalf("region = %q", a.vertexRegion)
+	}
+	if a.saEmail != "test-sa@example.iam.gserviceaccount.com" {
+		t.Fatalf("saEmail = %q", a.saEmail)
+	}
+	if a.saKey == nil {
+		t.Fatal("saKey not parsed")
+	}
+}
+
+func TestParseAuthConfig_Vertex_MissingProjectErrors(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "vertex",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing project")
+	}
+}
+
+func TestParseAuthConfig_Vertex_MissingSAErrors(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "vertex",
+		"vertex":    map[string]any{"project": "p"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing sa_key_file")
+	}
+}
+
+// =====================================================================
+// buildURL / bodyVersionField / stripModelFromBody
+// =====================================================================
+
+func TestBuildURL_APIKey(t *testing.T) {
+	a := &authState{mode: authModeAPIKey}
+	got := a.buildURL("claude-sonnet-4-5-20250514", false)
+	want := "https://api.anthropic.com/v1/messages"
+	if got != want {
+		t.Errorf("buildURL = %q, want %q", got, want)
+	}
+	if a.buildURL("claude-sonnet-4-5-20250514", true) != want {
+		t.Errorf("api_key url should be the same regardless of stream flag")
+	}
+}
+
+func TestBuildURL_Bedrock(t *testing.T) {
+	a := &authState{mode: authModeBedrock, bedrockRegion: "us-east-1"}
+
+	got := a.buildURL("anthropic.claude-sonnet-4-5-v1:0", false)
+	want := "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-5-v1%3A0/invoke"
+	if got != want {
+		t.Errorf("non-stream URL = %q, want %q", got, want)
+	}
+
+	gotStream := a.buildURL("anthropic.claude-sonnet-4-5-v1:0", true)
+	wantStream := "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-5-v1%3A0/invoke-with-response-stream"
+	if gotStream != wantStream {
+		t.Errorf("stream URL = %q, want %q", gotStream, wantStream)
+	}
+}
+
+func TestBuildURL_Vertex(t *testing.T) {
+	a := &authState{mode: authModeVertex, vertexProject: "my-proj", vertexRegion: "us-east5"}
+
+	got := a.buildURL("claude-sonnet-4@20250514", false)
+	want := "https://us-east5-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-east5/publishers/anthropic/models/claude-sonnet-4@20250514:rawPredict"
+	if got != want {
+		t.Errorf("non-stream URL = %q, want %q", got, want)
+	}
+
+	gotStream := a.buildURL("claude-sonnet-4@20250514", true)
+	wantStream := "https://us-east5-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-east5/publishers/anthropic/models/claude-sonnet-4@20250514:streamRawPredict"
+	if gotStream != wantStream {
+		t.Errorf("stream URL = %q, want %q", gotStream, wantStream)
+	}
+}
+
+func TestBodyVersionField(t *testing.T) {
+	cases := []struct {
+		mode authMode
+		want string
+	}{
+		{authModeAPIKey, ""},
+		{authModeBedrock, "bedrock-2023-05-31"},
+		{authModeVertex, "vertex-2023-10-16"},
+	}
+	for _, tc := range cases {
+		a := &authState{mode: tc.mode}
+		if got := a.bodyVersionField(); got != tc.want {
+			t.Errorf("bodyVersionField(%q) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+func TestStripModelFromBody(t *testing.T) {
+	cases := []struct {
+		mode authMode
+		want bool
+	}{
+		{authModeAPIKey, false},
+		{authModeBedrock, true},
+		{authModeVertex, false},
+	}
+	for _, tc := range cases {
+		a := &authState{mode: tc.mode}
+		if got := a.stripModelFromBody(); got != tc.want {
+			t.Errorf("stripModelFromBody(%q) = %v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// =====================================================================
+// SigV4 — AWS-published test vectors
+// =====================================================================
+
+// TestDeriveSigningKey_AWSExample verifies the four-step HMAC chain matches
+// AWS's documented signing-key example. From the SigV4 spec reference page:
+//
+//	Secret:    wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY
+//	Date:      20150830
+//	Region:    us-east-1
+//	Service:   iam
+//	Expected kSigning (hex):
+//	  c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9
+//
+// If this passes, the HMAC chain is correct end-to-end; only the canonical-
+// request shape can still go wrong.
+func TestDeriveSigningKey_AWSExample(t *testing.T) {
+	got := hex.EncodeToString(deriveSigningKey(
+		"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		"20150830",
+		"us-east-1",
+		"iam",
+	))
+	want := "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+	if got != want {
+		t.Errorf("deriveSigningKey = %s, want %s", got, want)
+	}
+}
+
+// TestSigv4Escape exercises the percent-encoder for both unreserved and
+// reserved input. AWS SigV4 requires unreserved RFC-3986 characters to pass
+// through and everything else (including ":", "/", "@") to be encoded.
+func TestSigv4Escape(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"a/b", "a%2Fb"},
+		{"a:b", "a%3Ab"},
+		{"a b", "a%20b"},
+		{"~_-.", "~_-."},
+		{"foo+bar", "foo%2Bbar"},
+	}
+	for _, tc := range cases {
+		if got := sigv4Escape(tc.in); got != tc.want {
+			t.Errorf("sigv4Escape(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestSignSigV4_RoundTripDeterministic signs a request, then independently
+// recomputes the signature using the same building blocks against a frozen
+// timestamp — proves the public Authorization header is well-formed and
+// reproducible. Combined with TestDeriveSigningKey_AWSExample (which pins the
+// HMAC chain) and TestSigv4Escape (which pins the encoder), this gives high
+// confidence in the full SigV4 path without bundling a giant test-vector
+// fixture.
+func TestSignSigV4_RoundTripDeterministic(t *testing.T) {
+	body := []byte(`{"hello":"world"}`)
+	req, err := http.NewRequest("POST",
+		"https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-5-v1%3A0/invoke",
+		strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("content-type", "application/json")
+
+	now := time.Date(2025, 4, 29, 12, 0, 0, 0, time.UTC)
+	creds := sigv4Creds{
+		Service:   "bedrock",
+		Region:    "us-east-1",
+		AccessKey: "AKIDEXAMPLE",
+		SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+	}
+	if err := signSigV4(req, body, creds, now); err != nil {
+		t.Fatalf("signSigV4: %v", err)
+	}
+
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 ") {
+		t.Fatalf("Authorization header missing algorithm: %q", auth)
+	}
+	if !strings.Contains(auth, "Credential=AKIDEXAMPLE/20250429/us-east-1/bedrock/aws4_request") {
+		t.Errorf("Authorization missing/incorrect credential scope: %q", auth)
+	}
+	if !strings.Contains(auth, "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date") {
+		t.Errorf("SignedHeaders incorrect: %q", auth)
+	}
+	if req.Header.Get("x-amz-date") != "20250429T120000Z" {
+		t.Errorf("x-amz-date = %q", req.Header.Get("x-amz-date"))
+	}
+	if got := req.Header.Get("x-amz-content-sha256"); len(got) != 64 {
+		t.Errorf("x-amz-content-sha256 wrong length: %q", got)
+	}
+
+	// Re-sign a second time with the same inputs; signature should match.
+	req2, _ := http.NewRequest("POST",
+		"https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-5-v1%3A0/invoke",
+		strings.NewReader(string(body)))
+	req2.Header.Set("content-type", "application/json")
+	if err := signSigV4(req2, body, creds, now); err != nil {
+		t.Fatalf("signSigV4 second pass: %v", err)
+	}
+	if req.Header.Get("Authorization") != req2.Header.Get("Authorization") {
+		t.Error("identical inputs produced different signatures")
+	}
+}
+
+func TestSignSigV4_SessionTokenIncluded(t *testing.T) {
+	body := []byte(`{}`)
+	req, _ := http.NewRequest("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/invoke",
+		strings.NewReader(string(body)))
+	req.Header.Set("content-type", "application/json")
+
+	creds := sigv4Creds{
+		Service:      "bedrock",
+		Region:       "us-east-1",
+		AccessKey:    "AKID",
+		SecretKey:    "SECRET",
+		SessionToken: "sess-token",
+	}
+	if err := signSigV4(req, body, creds, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if got := req.Header.Get("x-amz-security-token"); got != "sess-token" {
+		t.Errorf("x-amz-security-token = %q, want sess-token", got)
+	}
+	if !strings.Contains(req.Header.Get("Authorization"), "x-amz-security-token") {
+		t.Error("session-token header missing from SignedHeaders")
+	}
+}
+
+// =====================================================================
+// Vertex JWT bearer
+// =====================================================================
+
+// TestVertexAccessToken_FetchAndCache hits a fake OAuth2 endpoint with a
+// freshly-minted JWT, then asserts the cached token is reused on the second
+// call (no second HTTP roundtrip).
+func TestVertexAccessToken_FetchAndCache(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_ = r.ParseForm()
+		if r.Form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+			t.Errorf("grant_type = %q", r.Form.Get("grant_type"))
+		}
+		if r.Form.Get("assertion") == "" {
+			t.Error("assertion missing")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"fake-token","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	a := &authState{
+		mode:                  authModeVertex,
+		saEmail:               "test@example.iam.gserviceaccount.com",
+		saKey:                 mustGenerateRSAKey(t),
+		tokenEndpointOverride: srv.URL,
+	}
+
+	token, err := a.vertexAccessToken(context.Background(), srv.Client())
+	if err != nil {
+		t.Fatalf("vertexAccessToken: %v", err)
+	}
+	if token != "fake-token" {
+		t.Errorf("token = %q, want fake-token", token)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected 1 token-endpoint hit, got %d", hits.Load())
+	}
+
+	// Second call: should return the cached token without re-hitting endpoint.
+	token2, err := a.vertexAccessToken(context.Background(), srv.Client())
+	if err != nil {
+		t.Fatalf("second vertexAccessToken: %v", err)
+	}
+	if token2 != "fake-token" {
+		t.Errorf("cached token = %q, want fake-token", token2)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected token caching; saw %d hits to endpoint", hits.Load())
+	}
+}
+
+func TestVertexAccessToken_RefreshOnExpiry(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"refreshed","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	a := &authState{
+		mode:                  authModeVertex,
+		saEmail:               "test@example.iam.gserviceaccount.com",
+		saKey:                 mustGenerateRSAKey(t),
+		tokenEndpointOverride: srv.URL,
+		// Pre-seed an expired token; should trigger a refresh.
+		token:     "stale",
+		tokExpiry: time.Now().Add(-1 * time.Minute),
+	}
+
+	token, err := a.vertexAccessToken(context.Background(), srv.Client())
+	if err != nil {
+		t.Fatalf("vertexAccessToken: %v", err)
+	}
+	if token != "refreshed" {
+		t.Errorf("token = %q, want refreshed", token)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected refresh, got %d hits", hits.Load())
+	}
+}
+
+func TestApplyAuth_APIKey(t *testing.T) {
+	a := &authState{mode: authModeAPIKey, apiKey: "k"}
+	req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+	if err := a.applyAuth(context.Background(), req, nil, http.DefaultClient); err != nil {
+		t.Fatal(err)
+	}
+	if got := req.Header.Get("x-api-key"); got != "k" {
+		t.Errorf("x-api-key = %q", got)
+	}
+	if got := req.Header.Get("anthropic-version"); got != "2023-06-01" {
+		t.Errorf("anthropic-version = %q", got)
+	}
+}
+
+func TestApplyAuth_Bedrock_SetsAuthorization(t *testing.T) {
+	a := &authState{
+		mode:               authModeBedrock,
+		bedrockRegion:      "us-east-1",
+		bedrockAccessKeyID: "AKID",
+		bedrockSecretKey:   "SECRET",
+	}
+	body := []byte(`{}`)
+	req, _ := http.NewRequest("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/invoke",
+		strings.NewReader(string(body)))
+	req.Header.Set("content-type", "application/json")
+
+	if err := a.applyAuth(context.Background(), req, body, http.DefaultClient); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(req.Header.Get("Authorization"), "AWS4-HMAC-SHA256 ") {
+		t.Errorf("Authorization missing or wrong prefix: %q", req.Header.Get("Authorization"))
+	}
+}
+
+// =====================================================================
+// Test helpers
+// =====================================================================
+
+// mustGenerateRSAKey generates a 2048-bit RSA key for test signing. 2048 is
+// fast enough (~50ms) and matches what GCP service-accounts use.
+func mustGenerateRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return key
+}
+
+// writeFakeServiceAccount writes a synthetic GCP service-account JSON to
+// `path`, suitable as input to parseAuthConfig with auth_mode=vertex.
+func writeFakeServiceAccount(t *testing.T, path, email string) {
+	t.Helper()
+	key := mustGenerateRSAKey(t)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	sa := map[string]any{
+		"type":         "service_account",
+		"client_email": email,
+		"private_key":  string(pemBytes),
+	}
+	data, err := json.Marshal(sa)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+

--- a/plugins/providers/anthropic/beta.go
+++ b/plugins/providers/anthropic/beta.go
@@ -111,6 +111,13 @@ func (p *Plugin) betaFlags(reqMeta map[string]any) string {
 	if p.multimodal.PDFBeta {
 		add("pdfs-2024-09-25")
 	}
+	// Native structured outputs may still be beta-gated. Operators opt into
+	// the published beta string via `structured_outputs.beta_header` once
+	// Anthropic announces one — we don't ship a guess. Only emitted when
+	// native mode is active so tool-mode requests stay clean.
+	if p.structuredOutputs.Mode == "native" && p.structuredOutputs.BetaHeader != "" {
+		add(p.structuredOutputs.BetaHeader)
+	}
 
 	// Per-request additions from metadata. Server-tool plugins set this on
 	// the outgoing llm.request to opt into the right beta gate

--- a/plugins/providers/anthropic/beta.go
+++ b/plugins/providers/anthropic/beta.go
@@ -1,0 +1,134 @@
+package anthropic
+
+import "strings"
+
+// appendExtraTools appends entries from req.Metadata["_anthropic_extra_tools"]
+// onto body["tools"]. Values are passed through verbatim — they're already in
+// Anthropic's wire format (e.g., {"type":"bash_20250124","name":"bash"}).
+//
+// Accepts both []map[string]any (in-process) and []any (post-JSON unmarshal).
+// Non-map entries in the []any case are skipped with a warn log so a single
+// malformed element doesn't drop the whole batch.
+func (p *Plugin) appendExtraTools(body map[string]any, reqMeta map[string]any) {
+	if reqMeta == nil {
+		return
+	}
+	raw, ok := reqMeta["_anthropic_extra_tools"]
+	if !ok || raw == nil {
+		return
+	}
+
+	var extras []map[string]any
+	switch v := raw.(type) {
+	case []map[string]any:
+		extras = v
+	case []any:
+		for i, elem := range v {
+			m, ok := elem.(map[string]any)
+			if !ok {
+				if p.logger != nil {
+					p.logger.Warn("anthropic: skipping non-map entry in _anthropic_extra_tools",
+						"index", i, "type", typeName(elem))
+				}
+				continue
+			}
+			extras = append(extras, m)
+		}
+	default:
+		if p.logger != nil {
+			p.logger.Warn("anthropic: ignoring _anthropic_extra_tools with unsupported type",
+				"type", typeName(raw))
+		}
+		return
+	}
+
+	if len(extras) == 0 {
+		return
+	}
+
+	if existing, ok := body["tools"].([]map[string]any); ok {
+		body["tools"] = append(existing, extras...)
+	} else {
+		body["tools"] = extras
+	}
+}
+
+// typeName returns a short descriptor for an interface value's dynamic type.
+// Used in warn logs so operators can see what shape arrived.
+func typeName(v any) string {
+	if v == nil {
+		return "nil"
+	}
+	switch v.(type) {
+	case string:
+		return "string"
+	case int, int32, int64:
+		return "int"
+	case float32, float64:
+		return "float"
+	case bool:
+		return "bool"
+	case map[string]any:
+		return "map[string]any"
+	case []any:
+		return "[]any"
+	case []map[string]any:
+		return "[]map[string]any"
+	default:
+		return "unknown"
+	}
+}
+
+// betaFlags returns the comma-joined value for the anthropic-beta header,
+// merging the plugin's standing flags with any per-request additions from
+// req.Metadata["_anthropic_beta_headers"]. Duplicates are removed and order
+// is preserved (standing flags first, then per-request additions in
+// insertion order).
+//
+// Returns an empty string when no flags are active so callers can omit the
+// header entirely.
+func (p *Plugin) betaFlags(reqMeta map[string]any) string {
+	seen := map[string]struct{}{}
+	var flags []string
+	add := func(f string) {
+		if f == "" {
+			return
+		}
+		if _, ok := seen[f]; ok {
+			return
+		}
+		seen[f] = struct{}{}
+		flags = append(flags, f)
+	}
+
+	// Standing plugin flags.
+	if p.cache.Enabled && p.cache.TTL == "1h" {
+		add("extended-cache-ttl-2025-04-11")
+	}
+	if p.files.Enabled {
+		add(filesAPIBetaHeader)
+	}
+	if p.multimodal.PDFBeta {
+		add("pdfs-2024-09-25")
+	}
+
+	// Per-request additions from metadata. Server-tool plugins set this on
+	// the outgoing llm.request to opt into the right beta gate
+	// (e.g. "computer-use-2025-01-24", "code-execution-2025-05-22").
+	if reqMeta != nil {
+		switch raw := reqMeta["_anthropic_beta_headers"].(type) {
+		case []string:
+			for _, f := range raw {
+				add(f)
+			}
+		case []any:
+			for _, v := range raw {
+				if s, ok := v.(string); ok {
+					add(s)
+				}
+			}
+		}
+	}
+
+	return strings.Join(flags, ",")
+}

--- a/plugins/providers/anthropic/cache.go
+++ b/plugins/providers/anthropic/cache.go
@@ -1,0 +1,301 @@
+package anthropic
+
+import (
+	"log/slog"
+)
+
+// maxCacheBreakpoints is Anthropic's hard limit on cache_control markers per
+// request. We enforce it locally so misconfiguration is obvious and we never
+// generate API errors purely from over-budget marker counts.
+const maxCacheBreakpoints = 4
+
+// cacheConfig describes the explicit prompt-caching policy for a single
+// outgoing Anthropic request. Mirrors the `cache:` block under the plugin's
+// YAML config.
+//
+// All fields default to zero values when caching is disabled. When enabled,
+// System and Tools default to true (the high-leverage breakpoints) while
+// MessagePrefix stays at 0 because marking message turns is only safe when
+// the caller can guarantee a stable leading prefix.
+type cacheConfig struct {
+	Enabled       bool
+	System        bool
+	Tools         bool
+	MessagePrefix int
+	TTL           string // "5m" or "1h"
+}
+
+// parseCacheConfig pulls a cacheConfig out of the plugin's raw config map.
+//
+// When the `cache` block is absent or `enabled` is false, returns a zero-value
+// config that suppresses every mutation in applyCacheControl.
+//
+// Invalid TTL values are logged-by-omission (defaulted to "5m") rather than
+// erroring, matching the rest of the plugin's "soft fallback" parsing style.
+func parseCacheConfig(cfg map[string]any) cacheConfig {
+	cc := cacheConfig{}
+
+	raw, ok := cfg["cache"].(map[string]any)
+	if !ok {
+		return cc
+	}
+
+	enabled, _ := raw["enabled"].(bool)
+	if !enabled {
+		return cc
+	}
+
+	cc.Enabled = true
+	cc.System = true
+	cc.Tools = true
+	cc.TTL = "5m"
+
+	if v, ok := raw["system"].(bool); ok {
+		cc.System = v
+	}
+	if v, ok := raw["tools"].(bool); ok {
+		cc.Tools = v
+	}
+
+	// YAML decoders may surface integers as int or float64 depending on path.
+	if v, ok := raw["message_prefix"].(int); ok && v > 0 {
+		cc.MessagePrefix = v
+	} else if v, ok := raw["message_prefix"].(float64); ok && v > 0 {
+		cc.MessagePrefix = int(v)
+	}
+
+	if v, ok := raw["ttl"].(string); ok {
+		switch v {
+		case "5m", "1h":
+			cc.TTL = v
+		}
+	}
+
+	return cc
+}
+
+// applyCacheControl mutates an in-flight Anthropic request body to add
+// `cache_control` markers per cfg. No-op when caching is disabled.
+//
+// Mutations performed (in order):
+//
+//  1. body["system"] is converted from a bare string into the array-of-blocks
+//     form Anthropic requires for cacheable system prompts, with one
+//     cache_control marker on the single text block.
+//  2. The LAST entry in body["tools"] gets a cache_control field. Marking only
+//     the tail covers the entire tools prefix at one breakpoint cost — there's
+//     no benefit to marking individual tools.
+//  3. Up to cfg.MessagePrefix leading user messages get cache_control on the
+//     last content block of each. String content is upgraded to the
+//     array-of-blocks form first. Assistant + tool-result turns are skipped.
+//
+// 4-breakpoint cap: Anthropic accepts at most 4 cache_control markers per
+// request. We tally up our budget (system=1, tools=1, plus per-message) and
+// drop the OLDEST message markers first if the user requested more than the
+// remaining budget. A debug log reports the cap event.
+func applyCacheControl(body map[string]any, cfg cacheConfig, logger *slog.Logger) {
+	if !cfg.Enabled {
+		return
+	}
+
+	marker := buildCacheControl(cfg.TTL)
+
+	used := 0
+
+	if cfg.System {
+		if applySystemCacheControl(body, marker) {
+			used++
+		}
+	}
+	if cfg.Tools {
+		if applyToolsCacheControl(body, marker) {
+			used++
+		}
+	}
+
+	if cfg.MessagePrefix <= 0 {
+		return
+	}
+
+	// Budget remaining for message markers.
+	budget := maxCacheBreakpoints - used
+	wanted := cfg.MessagePrefix
+	allowed := wanted
+	if allowed > budget {
+		allowed = budget
+		if allowed < 0 {
+			allowed = 0
+		}
+		if logger != nil {
+			logger.Debug("cache_control message markers capped at 4-breakpoint limit",
+				"requested", wanted,
+				"granted", allowed,
+				"system_marker", cfg.System,
+				"tools_marker", cfg.Tools,
+			)
+		}
+	}
+
+	if allowed > 0 {
+		applyMessagesCacheControl(body, marker, wanted, allowed)
+	}
+}
+
+// buildCacheControl returns the cache_control value for the given TTL.
+// 5m TTL is the implicit Anthropic default, expressed as a bare ephemeral
+// block. 1h TTL must spell out the ttl field and requires the
+// extended-cache-ttl-2025-04-11 beta header (set by the request builder).
+func buildCacheControl(ttl string) map[string]any {
+	if ttl == "1h" {
+		return map[string]any{"type": "ephemeral", "ttl": "1h"}
+	}
+	return map[string]any{"type": "ephemeral"}
+}
+
+// applySystemCacheControl rewrites body["system"] from string-form to the
+// array-of-blocks form required for cacheable system prompts. Returns true if
+// a marker was placed.
+func applySystemCacheControl(body map[string]any, marker map[string]any) bool {
+	sys, ok := body["system"]
+	if !ok {
+		return false
+	}
+	switch v := sys.(type) {
+	case string:
+		if v == "" {
+			return false
+		}
+		body["system"] = []map[string]any{
+			{
+				"type":          "text",
+				"text":          v,
+				"cache_control": marker,
+			},
+		}
+		return true
+	case []map[string]any:
+		// Already array-form (unexpected at this stage); attach to the last
+		// block so we don't double-mark.
+		if len(v) == 0 {
+			return false
+		}
+		v[len(v)-1]["cache_control"] = marker
+		body["system"] = v
+		return true
+	default:
+		return false
+	}
+}
+
+// applyToolsCacheControl appends cache_control to the LAST tool definition in
+// body["tools"]. Returns true if a marker was placed. Marking only the tail
+// caches the full tools prefix at a single breakpoint.
+func applyToolsCacheControl(body map[string]any, marker map[string]any) bool {
+	tools, ok := body["tools"].([]map[string]any)
+	if !ok || len(tools) == 0 {
+		return false
+	}
+	tools[len(tools)-1]["cache_control"] = marker
+	body["tools"] = tools
+	return true
+}
+
+// applyMessagesCacheControl marks the leading run of user messages with
+// cache_control. The caller passes `wanted` (what the user requested) and
+// `allowed` (the post-cap budget). When allowed < wanted, the OLDEST markers
+// are dropped first — i.e. we keep the markers nearest the end of the
+// requested run because each marker caches everything UP TO and INCLUDING
+// its position, so later markers cover strictly larger prefixes.
+//
+// Assistant + tool-result turns terminate the leading run (they break the
+// stable-prefix invariant). String-form content is upgraded to the
+// array-of-blocks form so the marker has somewhere to live; the marker is
+// attached to the LAST content block of each selected message.
+func applyMessagesCacheControl(body map[string]any, marker map[string]any, wanted, allowed int) {
+	msgs, ok := body["messages"].([]map[string]any)
+	if !ok || len(msgs) == 0 || allowed <= 0 || wanted <= 0 {
+		return
+	}
+
+	// Walk the leading user run and collect candidate indices, stopping at
+	// the first non-user / tool-result turn.
+	var candidates []int
+	for i := range msgs {
+		role, _ := msgs[i]["role"].(string)
+		if role != "user" {
+			break
+		}
+		if isToolResultMessage(msgs[i]) {
+			break
+		}
+		candidates = append(candidates, i)
+		if len(candidates) >= wanted {
+			break
+		}
+	}
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	// If we have fewer candidates than allowed, mark them all. Otherwise
+	// drop the oldest (lowest-index) entries until we fit the budget.
+	if len(candidates) > allowed {
+		candidates = candidates[len(candidates)-allowed:]
+	}
+
+	for _, idx := range candidates {
+		markLastContentBlock(msgs[idx], marker)
+	}
+
+	body["messages"] = msgs
+}
+
+// isToolResultMessage reports whether a user-role message is actually a
+// tool-result envelope (Anthropic packs tool results into role=user with a
+// tool_result content block).
+func isToolResultMessage(msg map[string]any) bool {
+	content, ok := msg["content"].([]map[string]any)
+	if !ok {
+		return false
+	}
+	for _, block := range content {
+		if t, _ := block["type"].(string); t == "tool_result" {
+			return true
+		}
+	}
+	return false
+}
+
+// markLastContentBlock attaches cache_control to the final content block of a
+// message, upgrading string-form content to array-of-blocks form first.
+// Returns true on success.
+func markLastContentBlock(msg map[string]any, marker map[string]any) bool {
+	content, ok := msg["content"]
+	if !ok {
+		return false
+	}
+	switch v := content.(type) {
+	case string:
+		if v == "" {
+			return false
+		}
+		msg["content"] = []map[string]any{
+			{
+				"type":          "text",
+				"text":          v,
+				"cache_control": marker,
+			},
+		}
+		return true
+	case []map[string]any:
+		if len(v) == 0 {
+			return false
+		}
+		v[len(v)-1]["cache_control"] = marker
+		msg["content"] = v
+		return true
+	default:
+		return false
+	}
+}

--- a/plugins/providers/anthropic/cache_test.go
+++ b/plugins/providers/anthropic/cache_test.go
@@ -1,0 +1,538 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// silentLogger returns a slog.Logger that discards all output (we don't
+// inspect logs in these tests beyond the cap-event smoke check below).
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// captureLogger returns a logger that writes structured records into the
+// caller-provided buffer so tests can assert that a specific debug message
+// fired (used to verify the 4-breakpoint cap warning).
+func captureLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+// TestParseCacheConfig_Defaults verifies that a `cache: {enabled: true}` block
+// fills in the high-leverage defaults (system + tools cached, 5m TTL, no
+// message prefix marking).
+func TestParseCacheConfig_Defaults(t *testing.T) {
+	cfg := map[string]any{
+		"cache": map[string]any{
+			"enabled": true,
+		},
+	}
+
+	cc := parseCacheConfig(cfg)
+
+	if !cc.Enabled {
+		t.Fatal("Enabled: got false, want true")
+	}
+	if !cc.System {
+		t.Errorf("System: got false, want true (default)")
+	}
+	if !cc.Tools {
+		t.Errorf("Tools: got false, want true (default)")
+	}
+	if cc.MessagePrefix != 0 {
+		t.Errorf("MessagePrefix: got %d, want 0 (default)", cc.MessagePrefix)
+	}
+	if cc.TTL != "5m" {
+		t.Errorf("TTL: got %q, want %q (default)", cc.TTL, "5m")
+	}
+}
+
+// TestParseCacheConfig_Disabled verifies that an absent or disabled cache
+// block produces a zero-value config (so applyCacheControl is a no-op).
+func TestParseCacheConfig_Disabled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  map[string]any
+	}{
+		{"absent", map[string]any{}},
+		{"explicit-false", map[string]any{"cache": map[string]any{"enabled": false}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := parseCacheConfig(tc.cfg)
+			if cc.Enabled {
+				t.Errorf("Enabled: got true, want false")
+			}
+		})
+	}
+}
+
+// TestParseCacheConfig_Explicit verifies that explicit field values override
+// the enabled-defaults.
+func TestParseCacheConfig_Explicit(t *testing.T) {
+	cfg := map[string]any{
+		"cache": map[string]any{
+			"enabled":        true,
+			"system":         false,
+			"tools":          true,
+			"message_prefix": 2,
+			"ttl":            "1h",
+		},
+	}
+
+	cc := parseCacheConfig(cfg)
+
+	if cc.System {
+		t.Errorf("System: got true, want false")
+	}
+	if !cc.Tools {
+		t.Errorf("Tools: got false, want true")
+	}
+	if cc.MessagePrefix != 2 {
+		t.Errorf("MessagePrefix: got %d, want 2", cc.MessagePrefix)
+	}
+	if cc.TTL != "1h" {
+		t.Errorf("TTL: got %q, want %q", cc.TTL, "1h")
+	}
+}
+
+// TestParseCacheConfig_MessagePrefixFloat verifies that a float64-encoded
+// message_prefix (e.g. JSON-decoded YAML on some paths) is accepted.
+func TestParseCacheConfig_MessagePrefixFloat(t *testing.T) {
+	cfg := map[string]any{
+		"cache": map[string]any{
+			"enabled":        true,
+			"message_prefix": float64(3),
+		},
+	}
+
+	cc := parseCacheConfig(cfg)
+	if cc.MessagePrefix != 3 {
+		t.Errorf("MessagePrefix: got %d, want 3", cc.MessagePrefix)
+	}
+}
+
+// TestParseCacheConfig_InvalidTTL verifies that an unsupported TTL string
+// falls back to "5m" rather than erroring.
+func TestParseCacheConfig_InvalidTTL(t *testing.T) {
+	cfg := map[string]any{
+		"cache": map[string]any{
+			"enabled": true,
+			"ttl":     "30m", // not in {5m, 1h}
+		},
+	}
+
+	cc := parseCacheConfig(cfg)
+	if cc.TTL != "5m" {
+		t.Errorf("TTL: got %q, want %q (fallback)", cc.TTL, "5m")
+	}
+}
+
+// TestApplyCacheControl_Disabled verifies that when caching is disabled the
+// body is left untouched (system stays a string, tools stay clean).
+func TestApplyCacheControl_Disabled(t *testing.T) {
+	body := map[string]any{
+		"system": "you are helpful",
+		"tools": []map[string]any{
+			{"name": "shell", "description": "run a command"},
+		},
+		"messages": []map[string]any{
+			{"role": "user", "content": "hi"},
+		},
+	}
+
+	applyCacheControl(body, cacheConfig{Enabled: false}, silentLogger())
+
+	if _, ok := body["system"].(string); !ok {
+		t.Errorf("system: expected unchanged string, got %T", body["system"])
+	}
+	tools := body["tools"].([]map[string]any)
+	if _, ok := tools[0]["cache_control"]; ok {
+		t.Errorf("tools[0]: expected no cache_control marker, got one")
+	}
+}
+
+// TestApplyCacheControl_SystemOnly verifies that with cache enabled but only
+// the system breakpoint requested, only `system` is mutated (string -> array
+// with one cache_control text block) and tools remain untouched.
+func TestApplyCacheControl_SystemOnly(t *testing.T) {
+	body := map[string]any{
+		"system": "you are helpful",
+		"tools": []map[string]any{
+			{"name": "shell"},
+		},
+	}
+	cfg := cacheConfig{Enabled: true, System: true, Tools: false, TTL: "5m"}
+
+	applyCacheControl(body, cfg, silentLogger())
+
+	sys, ok := body["system"].([]map[string]any)
+	if !ok {
+		t.Fatalf("system: expected []map[string]any, got %T", body["system"])
+	}
+	if len(sys) != 1 {
+		t.Fatalf("system: got %d blocks, want 1", len(sys))
+	}
+	if sys[0]["type"] != "text" {
+		t.Errorf("system[0].type: got %v, want text", sys[0]["type"])
+	}
+	if sys[0]["text"] != "you are helpful" {
+		t.Errorf("system[0].text: got %v", sys[0]["text"])
+	}
+	cc, ok := sys[0]["cache_control"].(map[string]any)
+	if !ok {
+		t.Fatalf("system[0].cache_control: missing or wrong type")
+	}
+	if cc["type"] != "ephemeral" {
+		t.Errorf("cache_control.type: got %v, want ephemeral", cc["type"])
+	}
+	if _, hasTTL := cc["ttl"]; hasTTL {
+		t.Errorf("cache_control.ttl: should be absent for 5m TTL")
+	}
+
+	tools := body["tools"].([]map[string]any)
+	if _, ok := tools[0]["cache_control"]; ok {
+		t.Errorf("tools[0]: expected no cache_control, got one")
+	}
+}
+
+// TestApplyCacheControl_ToolsOnly verifies that with only the tools
+// breakpoint requested, the LAST tool definition gets a cache_control marker
+// and earlier tools remain untouched.
+func TestApplyCacheControl_ToolsOnly(t *testing.T) {
+	body := map[string]any{
+		"system": "you are helpful",
+		"tools": []map[string]any{
+			{"name": "shell"},
+			{"name": "fileio"},
+			{"name": "search"},
+		},
+	}
+	cfg := cacheConfig{Enabled: true, System: false, Tools: true, TTL: "5m"}
+
+	applyCacheControl(body, cfg, silentLogger())
+
+	if _, ok := body["system"].(string); !ok {
+		t.Errorf("system: expected unchanged string when System=false, got %T", body["system"])
+	}
+
+	tools := body["tools"].([]map[string]any)
+	if len(tools) != 3 {
+		t.Fatalf("tools length changed: got %d, want 3", len(tools))
+	}
+	if _, ok := tools[0]["cache_control"]; ok {
+		t.Errorf("tools[0]: expected no marker, got one")
+	}
+	if _, ok := tools[1]["cache_control"]; ok {
+		t.Errorf("tools[1]: expected no marker, got one")
+	}
+	cc, ok := tools[2]["cache_control"].(map[string]any)
+	if !ok {
+		t.Fatalf("tools[2].cache_control: missing")
+	}
+	if cc["type"] != "ephemeral" {
+		t.Errorf("tools[2].cache_control.type: got %v, want ephemeral", cc["type"])
+	}
+}
+
+// TestApplyCacheControl_FourBreakpoints verifies that requesting system +
+// tools + 2 message markers produces all 4 breakpoints (the API limit) with
+// no cap warning.
+func TestApplyCacheControl_FourBreakpoints(t *testing.T) {
+	body := map[string]any{
+		"system": "you are helpful",
+		"tools": []map[string]any{
+			{"name": "shell"},
+		},
+		"messages": []map[string]any{
+			{"role": "user", "content": "msg one"},
+			{"role": "user", "content": "msg two"},
+			{"role": "assistant", "content": "ok"},
+		},
+	}
+	cfg := cacheConfig{Enabled: true, System: true, Tools: true, MessagePrefix: 2, TTL: "5m"}
+
+	buf := new(bytes.Buffer)
+	applyCacheControl(body, cfg, captureLogger(buf))
+
+	if strings.Contains(buf.String(), "capped at 4-breakpoint") {
+		t.Errorf("did not expect cap log, got: %s", buf.String())
+	}
+
+	// system marked
+	if _, ok := body["system"].([]map[string]any); !ok {
+		t.Errorf("system: not converted to array form")
+	}
+	// last tool marked
+	tools := body["tools"].([]map[string]any)
+	if _, ok := tools[0]["cache_control"]; !ok {
+		t.Errorf("tools[0]: missing cache_control")
+	}
+	// first two user msgs marked, assistant untouched
+	msgs := body["messages"].([]map[string]any)
+	for i := 0; i < 2; i++ {
+		blocks, ok := msgs[i]["content"].([]map[string]any)
+		if !ok {
+			t.Errorf("msg[%d]: content not converted to array form: %T", i, msgs[i]["content"])
+			continue
+		}
+		if _, ok := blocks[0]["cache_control"].(map[string]any); !ok {
+			t.Errorf("msg[%d].content[0]: missing cache_control", i)
+		}
+	}
+	// assistant must remain string-form, no marker
+	if _, ok := msgs[2]["content"].(string); !ok {
+		t.Errorf("msg[2] (assistant): content mutated, got %T", msgs[2]["content"])
+	}
+}
+
+// TestApplyCacheControl_CapsAtFour verifies that requesting 5 message markers
+// (alongside system + tools = 2 already used) is silently capped at 2 (the
+// remaining budget) and emits a debug log.
+func TestApplyCacheControl_CapsAtFour(t *testing.T) {
+	msgs := []map[string]any{
+		{"role": "user", "content": "msg 0"},
+		{"role": "user", "content": "msg 1"},
+		{"role": "user", "content": "msg 2"},
+		{"role": "user", "content": "msg 3"},
+		{"role": "user", "content": "msg 4"},
+	}
+	body := map[string]any{
+		"system":   "sys",
+		"tools":    []map[string]any{{"name": "shell"}},
+		"messages": msgs,
+	}
+	cfg := cacheConfig{Enabled: true, System: true, Tools: true, MessagePrefix: 5, TTL: "5m"}
+
+	buf := new(bytes.Buffer)
+	applyCacheControl(body, cfg, captureLogger(buf))
+
+	if !strings.Contains(buf.String(), "capped at 4-breakpoint") {
+		t.Errorf("expected cap log, got: %s", buf.String())
+	}
+
+	// System (1) + tools (1) used 2 of 4 breakpoints, leaving 2 for messages.
+	// User asked for 5 — drop the OLDEST 3, keep the LATEST 2 (msg[3], msg[4]).
+	// Later markers cover strictly larger cacheable prefixes, so keeping the
+	// tail is what the plan calls for.
+	mutated := body["messages"].([]map[string]any)
+	markedCount := 0
+	for i, m := range mutated {
+		blocks, ok := m["content"].([]map[string]any)
+		if !ok {
+			continue
+		}
+		_, has := blocks[0]["cache_control"]
+		if !has {
+			continue
+		}
+		markedCount++
+		if i < 3 {
+			t.Errorf("msg[%d]: should not have been marked (oldest dropped first)", i)
+		}
+	}
+	if markedCount != 2 {
+		t.Errorf("marked count: got %d, want 2 (budget cap)", markedCount)
+	}
+}
+
+// TestApplyCacheControl_StopsAtAssistant verifies that the message-marker
+// pass stops scanning at the first non-user turn (assistant interleavings
+// break the cacheable prefix invariant).
+func TestApplyCacheControl_StopsAtAssistant(t *testing.T) {
+	body := map[string]any{
+		"messages": []map[string]any{
+			{"role": "user", "content": "u0"},
+			{"role": "assistant", "content": "a0"},
+			{"role": "user", "content": "u1"}, // must not be marked
+		},
+	}
+	cfg := cacheConfig{Enabled: true, MessagePrefix: 3, TTL: "5m"}
+
+	applyCacheControl(body, cfg, silentLogger())
+
+	msgs := body["messages"].([]map[string]any)
+	// u0 marked
+	if blocks, ok := msgs[0]["content"].([]map[string]any); !ok {
+		t.Errorf("msg[0]: expected array form")
+	} else if _, has := blocks[0]["cache_control"]; !has {
+		t.Errorf("msg[0]: missing cache_control")
+	}
+	// u1 must remain string-form
+	if _, ok := msgs[2]["content"].(string); !ok {
+		t.Errorf("msg[2]: content mutated past assistant boundary, got %T", msgs[2]["content"])
+	}
+}
+
+// TestApplyCacheControl_StopsAtToolResult verifies that user messages whose
+// content is a tool_result envelope aren't marked (tool results change every
+// iteration, so they can't form a stable cacheable prefix).
+func TestApplyCacheControl_StopsAtToolResult(t *testing.T) {
+	body := map[string]any{
+		"messages": []map[string]any{
+			{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "tool_result", "tool_use_id": "abc", "content": "ok"},
+				},
+			},
+		},
+	}
+	cfg := cacheConfig{Enabled: true, MessagePrefix: 1, TTL: "5m"}
+
+	applyCacheControl(body, cfg, silentLogger())
+
+	blocks := body["messages"].([]map[string]any)[0]["content"].([]map[string]any)
+	if _, has := blocks[0]["cache_control"]; has {
+		t.Errorf("tool_result block: should not be marked")
+	}
+}
+
+// TestApplyCacheControl_OneHourTTL verifies that 1h TTL emits a cache_control
+// block carrying ttl:"1h" (not the bare ephemeral form).
+func TestApplyCacheControl_OneHourTTL(t *testing.T) {
+	body := map[string]any{
+		"system": "sys",
+	}
+	cfg := cacheConfig{Enabled: true, System: true, TTL: "1h"}
+
+	applyCacheControl(body, cfg, silentLogger())
+
+	sys := body["system"].([]map[string]any)
+	cc := sys[0]["cache_control"].(map[string]any)
+	if cc["type"] != "ephemeral" {
+		t.Errorf("cache_control.type: got %v, want ephemeral", cc["type"])
+	}
+	if cc["ttl"] != "1h" {
+		t.Errorf("cache_control.ttl: got %v, want 1h", cc["ttl"])
+	}
+}
+
+// TestApplyCacheControl_NoSystemNoTools verifies that with neither system nor
+// tools enabled, all 4 breakpoints are available for messages.
+func TestApplyCacheControl_NoSystemNoTools(t *testing.T) {
+	msgs := []map[string]any{
+		{"role": "user", "content": "u0"},
+		{"role": "user", "content": "u1"},
+		{"role": "user", "content": "u2"},
+		{"role": "user", "content": "u3"},
+		{"role": "user", "content": "u4"},
+	}
+	body := map[string]any{"messages": msgs}
+	cfg := cacheConfig{Enabled: true, System: false, Tools: false, MessagePrefix: 5, TTL: "5m"}
+
+	buf := new(bytes.Buffer)
+	applyCacheControl(body, cfg, captureLogger(buf))
+
+	if !strings.Contains(buf.String(), "capped at 4-breakpoint") {
+		t.Errorf("expected cap log when MessagePrefix exceeds 4, got: %s", buf.String())
+	}
+
+	mutated := body["messages"].([]map[string]any)
+	marked := 0
+	for i, m := range mutated {
+		blocks, ok := m["content"].([]map[string]any)
+		if !ok {
+			continue
+		}
+		_, has := blocks[0]["cache_control"]
+		if !has {
+			continue
+		}
+		marked++
+		if i == 0 {
+			t.Errorf("msg[0]: should not have been marked (oldest dropped, budget=4 of 5)")
+		}
+	}
+	if marked != 4 {
+		t.Errorf("marked count: got %d, want 4 (full budget)", marked)
+	}
+}
+
+// TestBuildRequestBody_WithCache integrates parseCacheConfig +
+// buildRequestBody to verify the on-the-wire JSON Anthropic actually receives
+// when caching is enabled. Acts as the closest-to-end-to-end check without an
+// HTTP fixture.
+func TestBuildRequestBody_WithCache(t *testing.T) {
+	p := &Plugin{
+		cache:  cacheConfig{Enabled: true, System: true, Tools: true, TTL: "1h"},
+		logger: silentLogger(),
+	}
+
+	req := events.LLMRequest{
+		Model:     "claude-sonnet-4-6-20250514",
+		MaxTokens: 1024,
+		Messages: []events.Message{
+			{Role: "system", Content: "you are helpful"},
+			{Role: "user", Content: "hi"},
+		},
+		Tools: []events.ToolDef{
+			{Name: "shell", Description: "run a command", Parameters: map[string]any{}},
+			{Name: "fileio", Description: "read or write a file", Parameters: map[string]any{}},
+		},
+	}
+
+	body := p.buildRequestBody(req.Model, req.MaxTokens, req)
+
+	// system is now array form with cache_control
+	sys, ok := body["system"].([]map[string]any)
+	if !ok {
+		t.Fatalf("system: got %T, want []map[string]any", body["system"])
+	}
+	if cc, ok := sys[0]["cache_control"].(map[string]any); !ok {
+		t.Errorf("system[0].cache_control: missing")
+	} else if cc["ttl"] != "1h" {
+		t.Errorf("system[0].cache_control.ttl: got %v, want 1h", cc["ttl"])
+	}
+
+	// last tool has cache_control
+	tools := body["tools"].([]map[string]any)
+	if _, ok := tools[len(tools)-1]["cache_control"]; !ok {
+		t.Errorf("last tool: missing cache_control")
+	}
+	// first tool does NOT
+	if _, ok := tools[0]["cache_control"]; ok {
+		t.Errorf("first tool: should not be marked")
+	}
+
+	// JSON roundtrip should succeed (catch any non-marshalable values).
+	if _, err := json.Marshal(body); err != nil {
+		t.Fatalf("json.Marshal(body): %v", err)
+	}
+}
+
+// TestBuildRequestBody_CacheDisabled verifies the body shape is untouched
+// when caching is off — system stays string-form, tools have no markers.
+func TestBuildRequestBody_CacheDisabled(t *testing.T) {
+	p := &Plugin{
+		cache:  cacheConfig{Enabled: false},
+		logger: silentLogger(),
+	}
+
+	req := events.LLMRequest{
+		Model:     "claude-sonnet-4-6-20250514",
+		MaxTokens: 1024,
+		Messages: []events.Message{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "hi"},
+		},
+		Tools: []events.ToolDef{
+			{Name: "shell", Parameters: map[string]any{}},
+		},
+	}
+
+	body := p.buildRequestBody(req.Model, req.MaxTokens, req)
+
+	if _, ok := body["system"].(string); !ok {
+		t.Errorf("system: expected string, got %T", body["system"])
+	}
+	tools := body["tools"].([]map[string]any)
+	if _, ok := tools[0]["cache_control"]; ok {
+		t.Errorf("tools[0]: should not be marked when cache disabled")
+	}
+}

--- a/plugins/providers/anthropic/citations.go
+++ b/plugins/providers/anthropic/citations.go
@@ -1,0 +1,62 @@
+package anthropic
+
+import "github.com/frankbardon/nexus/pkg/events"
+
+// citationsConfig controls Anthropic's native citations feature. When Enabled,
+// outgoing document content blocks gain `citations: {enabled: true}` and the
+// API returns per-text-block citation arrays that the provider surfaces on
+// LLMResponse.Citations.
+//
+//	citations:
+//	  enabled: false  # opt-in; only affects requests that include document blocks
+type citationsConfig struct {
+	Enabled bool
+}
+
+// parseCitationsConfig pulls citationsConfig out of the plugin's raw config map.
+// Absent block returns a zero-value config (disabled).
+func parseCitationsConfig(cfg map[string]any) citationsConfig {
+	raw, ok := cfg["citations"].(map[string]any)
+	if !ok {
+		return citationsConfig{}
+	}
+	cc := citationsConfig{}
+	if v, ok := raw["enabled"].(bool); ok {
+		cc.Enabled = v
+	}
+	return cc
+}
+
+// apiCitation matches the Anthropic Messages API citation response shape.
+// Used inside text content blocks (sync) and inside `citations_delta` deltas
+// (streaming). All location-specific fields are optional; only the subset
+// matching `type` is populated.
+type apiCitation struct {
+	Type            string `json:"type"`
+	CitedText       string `json:"cited_text,omitempty"`
+	DocumentIndex   int    `json:"document_index"`
+	DocumentTitle   string `json:"document_title,omitempty"`
+	StartCharIndex  int    `json:"start_char_index,omitempty"`
+	EndCharIndex    int    `json:"end_char_index,omitempty"`
+	StartPageNumber int    `json:"start_page_number,omitempty"`
+	EndPageNumber   int    `json:"end_page_number,omitempty"`
+	StartBlockIndex int    `json:"start_block_index,omitempty"`
+	EndBlockIndex   int    `json:"end_block_index,omitempty"`
+}
+
+// toEvent converts the API-shape citation into the public events.Citation
+// surfaced on LLMResponse.
+func (c apiCitation) toEvent() events.Citation {
+	return events.Citation{
+		Type:            c.Type,
+		CitedText:       c.CitedText,
+		DocumentIndex:   c.DocumentIndex,
+		DocumentTitle:   c.DocumentTitle,
+		StartCharIndex:  c.StartCharIndex,
+		EndCharIndex:    c.EndCharIndex,
+		StartPageNumber: c.StartPageNumber,
+		EndPageNumber:   c.EndPageNumber,
+		StartBlockIndex: c.StartBlockIndex,
+		EndBlockIndex:   c.EndBlockIndex,
+	}
+}

--- a/plugins/providers/anthropic/citations_test.go
+++ b/plugins/providers/anthropic/citations_test.go
@@ -1,0 +1,283 @@
+package anthropic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// --- parseCitationsConfig ---------------------------------------------------
+
+// TestParseCitationsConfig_Absent verifies an absent block produces a
+// zero-value (disabled) config.
+func TestParseCitationsConfig_Absent(t *testing.T) {
+	cc := parseCitationsConfig(map[string]any{})
+	if cc.Enabled {
+		t.Fatalf("expected Enabled=false on absent config, got %+v", cc)
+	}
+}
+
+// TestParseCitationsConfig_Disabled verifies an explicit `enabled: false`
+// resolves to disabled (default).
+func TestParseCitationsConfig_Disabled(t *testing.T) {
+	cc := parseCitationsConfig(map[string]any{
+		"citations": map[string]any{"enabled": false},
+	})
+	if cc.Enabled {
+		t.Fatalf("expected Enabled=false, got %+v", cc)
+	}
+}
+
+// TestParseCitationsConfig_Enabled covers the opt-in path.
+func TestParseCitationsConfig_Enabled(t *testing.T) {
+	cc := parseCitationsConfig(map[string]any{
+		"citations": map[string]any{"enabled": true},
+	})
+	if !cc.Enabled {
+		t.Fatalf("expected Enabled=true, got %+v", cc)
+	}
+}
+
+// --- buildDocumentBlock with citations -------------------------------------
+
+// TestBuildDocumentBlock_CitationsEnabled verifies the citations marker is
+// appended to outgoing document blocks when the flag is on.
+func TestBuildDocumentBlock_CitationsEnabled(t *testing.T) {
+	part := events.MessagePart{
+		Type: "file", MimeType: "text/plain", Data: []byte("policy v3 ..."),
+	}
+	block, err := buildDocumentBlock(part, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if block["type"] != "document" {
+		t.Fatalf("expected document block, got %v", block["type"])
+	}
+	cit, ok := block["citations"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected citations map, got %T (%v)", block["citations"], block["citations"])
+	}
+	if cit["enabled"] != true {
+		t.Fatalf("expected citations.enabled=true, got %v", cit["enabled"])
+	}
+}
+
+// TestBuildDocumentBlock_CitationsDisabled confirms the citations marker is
+// absent when the flag is off (default).
+func TestBuildDocumentBlock_CitationsDisabled(t *testing.T) {
+	part := events.MessagePart{
+		Type: "file", MimeType: "text/plain", Data: []byte("policy v3 ..."),
+	}
+	block, err := buildDocumentBlock(part, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := block["citations"]; ok {
+		t.Fatalf("expected no citations field when disabled, got %v", block["citations"])
+	}
+}
+
+// TestBuildContentBlocks_CitationsThreaded verifies the flag flows through
+// buildContentBlocks to per-document marker emission.
+func TestBuildContentBlocks_CitationsThreaded(t *testing.T) {
+	msg := events.Message{
+		Role:    "user",
+		Content: "Cite policy v3.",
+		Parts: []events.MessagePart{
+			{Type: "file", MimeType: "text/plain", Data: []byte("doc bytes")},
+		},
+	}
+	blocks, err := buildContentBlocks(msg, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks (text + document), got %d", len(blocks))
+	}
+	doc := blocks[1]
+	if doc["type"] != "document" {
+		t.Fatalf("expected document block at [1], got %v", doc["type"])
+	}
+	cit, ok := doc["citations"].(map[string]any)
+	if !ok || cit["enabled"] != true {
+		t.Fatalf("expected citations marker on document, got %v", doc["citations"])
+	}
+}
+
+// --- sync response citation extraction -------------------------------------
+
+// TestConvertAPIResponse_SingleCitation feeds a fixture text block with a
+// char_location citation and asserts LLMResponse.Citations carries the entry
+// with all populated fields preserved.
+func TestConvertAPIResponse_SingleCitation(t *testing.T) {
+	p := &Plugin{logger: silentLogger(), pricing: defaultPricing}
+	api := apiResponse{
+		ID:    "msg_cite",
+		Model: "claude-sonnet-4-5-20250514",
+		Content: []apiContentBlock{
+			{
+				Type: "text",
+				Text: "The policy mandates retention.",
+				Citations: []apiCitation{
+					{
+						Type:           "char_location",
+						CitedText:      "retention is required",
+						DocumentIndex:  0,
+						DocumentTitle:  "Policy v3",
+						StartCharIndex: 12,
+						EndCharIndex:   48,
+					},
+				},
+			},
+		},
+		StopReason: "end_turn",
+	}
+	resp := p.convertAPIResponse(api)
+	if len(resp.Citations) != 1 {
+		t.Fatalf("expected 1 citation, got %d", len(resp.Citations))
+	}
+	c := resp.Citations[0]
+	if c.Type != "char_location" {
+		t.Errorf("Type: got %q, want char_location", c.Type)
+	}
+	if c.CitedText != "retention is required" {
+		t.Errorf("CitedText: got %q", c.CitedText)
+	}
+	if c.DocumentIndex != 0 {
+		t.Errorf("DocumentIndex: got %d", c.DocumentIndex)
+	}
+	if c.DocumentTitle != "Policy v3" {
+		t.Errorf("DocumentTitle: got %q", c.DocumentTitle)
+	}
+	if c.StartCharIndex != 12 || c.EndCharIndex != 48 {
+		t.Errorf("char range mismatch: got [%d, %d]", c.StartCharIndex, c.EndCharIndex)
+	}
+	if resp.Content != "The policy mandates retention." {
+		t.Errorf("Content: got %q", resp.Content)
+	}
+}
+
+// TestConvertAPIResponse_MultipleCitations verifies citations from multiple
+// text blocks accumulate in the order produced by the API.
+func TestConvertAPIResponse_MultipleCitations(t *testing.T) {
+	p := &Plugin{logger: silentLogger(), pricing: defaultPricing}
+	api := apiResponse{
+		ID:    "msg_multi",
+		Model: "claude-sonnet-4-5-20250514",
+		Content: []apiContentBlock{
+			{
+				Type: "text",
+				Text: "First sentence. ",
+				Citations: []apiCitation{
+					{Type: "char_location", DocumentIndex: 0, DocumentTitle: "A", StartCharIndex: 0, EndCharIndex: 5},
+				},
+			},
+			{
+				Type: "text",
+				Text: "Second sentence.",
+				Citations: []apiCitation{
+					{Type: "page_location", DocumentIndex: 1, DocumentTitle: "B", StartPageNumber: 7, EndPageNumber: 8},
+					{Type: "content_block_location", DocumentIndex: 2, DocumentTitle: "C", StartBlockIndex: 3, EndBlockIndex: 4},
+				},
+			},
+		},
+		StopReason: "end_turn",
+	}
+	resp := p.convertAPIResponse(api)
+	if len(resp.Citations) != 3 {
+		t.Fatalf("expected 3 citations, got %d", len(resp.Citations))
+	}
+	if resp.Citations[0].DocumentTitle != "A" || resp.Citations[0].Type != "char_location" {
+		t.Errorf("citation[0] mismatch: %+v", resp.Citations[0])
+	}
+	if resp.Citations[1].Type != "page_location" || resp.Citations[1].StartPageNumber != 7 || resp.Citations[1].EndPageNumber != 8 {
+		t.Errorf("citation[1] mismatch: %+v", resp.Citations[1])
+	}
+	if resp.Citations[2].Type != "content_block_location" || resp.Citations[2].StartBlockIndex != 3 || resp.Citations[2].EndBlockIndex != 4 {
+		t.Errorf("citation[2] mismatch: %+v", resp.Citations[2])
+	}
+}
+
+// TestConvertAPIResponse_NoCitations confirms responses without citations
+// produce a nil Citations slice (not an empty non-nil slice).
+func TestConvertAPIResponse_NoCitations(t *testing.T) {
+	p := &Plugin{logger: silentLogger(), pricing: defaultPricing}
+	api := apiResponse{
+		ID:         "msg_plain",
+		Model:      "claude-sonnet-4-5-20250514",
+		Content:    []apiContentBlock{{Type: "text", Text: "hello"}},
+		StopReason: "end_turn",
+	}
+	resp := p.convertAPIResponse(api)
+	if resp.Citations != nil {
+		t.Fatalf("expected nil Citations on plain response, got %+v", resp.Citations)
+	}
+}
+
+// --- streaming citation extraction -----------------------------------------
+
+// canonicalCitationsStream mirrors Anthropic's SSE format for a text block
+// that emits a single char_location citation via citations_delta.
+const canonicalCitationsStream = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_stream_cite","model":"claude-sonnet-4-5-20250514","usage":{"input_tokens":50,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The doc says X."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"char_location","cited_text":"the doc says X","document_index":0,"document_title":"Source","start_char_index":10,"end_char_index":24}}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+// TestStream_CitationsRoundTrip feeds the canned SSE into the streaming
+// state machine and asserts the final llm.response carries the citation.
+func TestStream_CitationsRoundTrip(t *testing.T) {
+	rec := newBusRecorder()
+
+	p := &Plugin{
+		bus:     rec.bus,
+		logger:  silentLogger(),
+		pricing: defaultPricing,
+	}
+
+	p.handleStreamResponse(strings.NewReader(canonicalCitationsStream))
+
+	resps := rec.byType("llm.response")
+	if len(resps) != 1 {
+		t.Fatalf("llm.response count: got %d, want 1", len(resps))
+	}
+	resp := resps[0].Payload.(events.LLMResponse)
+
+	if resp.Content != "The doc says X." {
+		t.Errorf("Content: got %q", resp.Content)
+	}
+	if len(resp.Citations) != 1 {
+		t.Fatalf("expected 1 citation, got %d (%+v)", len(resp.Citations), resp.Citations)
+	}
+	c := resp.Citations[0]
+	if c.Type != "char_location" {
+		t.Errorf("Type: got %q, want char_location", c.Type)
+	}
+	if c.CitedText != "the doc says X" {
+		t.Errorf("CitedText: got %q", c.CitedText)
+	}
+	if c.DocumentTitle != "Source" {
+		t.Errorf("DocumentTitle: got %q", c.DocumentTitle)
+	}
+	if c.StartCharIndex != 10 || c.EndCharIndex != 24 {
+		t.Errorf("char range mismatch: got [%d, %d]", c.StartCharIndex, c.EndCharIndex)
+	}
+}

--- a/plugins/providers/anthropic/files.go
+++ b/plugins/providers/anthropic/files.go
@@ -151,7 +151,7 @@ func (p *Plugin) uploadFile(ctx context.Context, data []byte, mimeType, filename
 	if err != nil {
 		return "", fmt.Errorf("anthropic: build files request: %w", err)
 	}
-	httpReq.Header.Set("x-api-key", p.apiKey)
+	httpReq.Header.Set("x-api-key", p.auth.apiKey)
 	httpReq.Header.Set("anthropic-version", "2023-06-01")
 	httpReq.Header.Set("anthropic-beta", filesAPIBetaHeader)
 	httpReq.Header.Set("Content-Type", mw.FormDataContentType())
@@ -197,7 +197,7 @@ func (p *Plugin) deleteFile(ctx context.Context, id string) error {
 	if err != nil {
 		return fmt.Errorf("anthropic: build delete request: %w", err)
 	}
-	httpReq.Header.Set("x-api-key", p.apiKey)
+	httpReq.Header.Set("x-api-key", p.auth.apiKey)
 	httpReq.Header.Set("anthropic-version", "2023-06-01")
 	httpReq.Header.Set("anthropic-beta", filesAPIBetaHeader)
 

--- a/plugins/providers/anthropic/files.go
+++ b/plugins/providers/anthropic/files.go
@@ -1,0 +1,316 @@
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"sync"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	// filesAPIBaseURL is the production Anthropic Files API endpoint. Tests
+	// override Plugin.filesAPIURL with an httptest server URL.
+	filesAPIBaseURL = "https://api.anthropic.com/v1/files"
+	// filesAPIBetaHeader is the beta gate the Files API requires today.
+	// Send it on every request when the files feature is enabled — Anthropic
+	// accepts the header even when no file_id is referenced, and the cost of
+	// always sending it is one short string in the request header.
+	filesAPIBetaHeader = "files-api-2025-04-14"
+	// uploadThresholdDefault is 5MB; matches Anthropic's documented inline
+	// image cap and is the smallest of the inline limits we care about. Parts
+	// over this size get auto-uploaded.
+	uploadThresholdDefault = 5 * 1024 * 1024
+)
+
+// filesConfig controls Anthropic Files API behavior.
+//
+//	files:
+//	  enabled: true                # default false; when false the plugin never uploads
+//	  upload_threshold: 5242880    # bytes; auto-upload Data parts over this size
+//	  cache_uploads: true          # in-memory sha256(content) -> file_id reuse within session
+//	  delete_on_shutdown: false    # best-effort DELETE for session-uploaded ids on Shutdown
+type filesConfig struct {
+	Enabled          bool
+	UploadThreshold  int
+	CacheUploads     bool
+	DeleteOnShutdown bool
+}
+
+// parseFilesConfig pulls filesConfig out of the plugin's raw config map.
+// Absent block returns Enabled=false; an explicit empty map returns
+// Enabled=false but with sensible defaults for the other fields. When Enabled
+// is true and UploadThreshold is unset/zero, fall back to uploadThresholdDefault.
+func parseFilesConfig(cfg map[string]any) filesConfig {
+	fc := filesConfig{
+		UploadThreshold: uploadThresholdDefault,
+		CacheUploads:    true,
+	}
+
+	raw, ok := cfg["files"].(map[string]any)
+	if !ok {
+		return fc
+	}
+
+	if v, ok := raw["enabled"].(bool); ok {
+		fc.Enabled = v
+	}
+	if v, ok := raw["upload_threshold"].(int); ok && v > 0 {
+		fc.UploadThreshold = v
+	} else if v, ok := raw["upload_threshold"].(float64); ok && v > 0 {
+		fc.UploadThreshold = int(v)
+	}
+	if v, ok := raw["cache_uploads"].(bool); ok {
+		fc.CacheUploads = v
+	}
+	if v, ok := raw["delete_on_shutdown"].(bool); ok {
+		fc.DeleteOnShutdown = v
+	}
+
+	return fc
+}
+
+// fileCache maps content hash -> file_id for in-session deduplication. Backed
+// by a plain mutex; Files API uploads are infrequent enough that contention
+// isn't a concern.
+//
+// Note: Anthropic's Files API has 30-day retention. This cache is intentionally
+// in-memory only — cross-session caching would have to handle 404s on stale
+// ids, and we don't implement that recovery path here. If the user restarts
+// the process, files get re-uploaded; the cap on this is the per-session
+// workspace storage, which is generous in practice.
+type fileCache struct {
+	mu      sync.Mutex
+	entries map[string]string
+}
+
+func newFileCache() *fileCache {
+	return &fileCache{entries: make(map[string]string)}
+}
+
+func (c *fileCache) get(key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id, ok := c.entries[key]
+	return id, ok
+}
+
+func (c *fileCache) put(key, id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = id
+}
+
+// hashKey computes the cache key for an inline payload. MimeType is folded in
+// so identical bytes uploaded under different mime types don't collide.
+func hashKey(mimeType string, data []byte) string {
+	h := sha256.New()
+	h.Write([]byte(mimeType))
+	h.Write([]byte{':'})
+	h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// uploadFile multipart-POSTs bytes to the Anthropic Files API and returns the
+// resulting file_id. Tests inject an alternate base URL via p.filesAPIURL.
+func (p *Plugin) uploadFile(ctx context.Context, data []byte, mimeType, filename string) (string, error) {
+	endpoint := p.filesAPIURL
+	if endpoint == "" {
+		endpoint = filesAPIBaseURL
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename=%q`, filename))
+	if mimeType != "" {
+		header.Set("Content-Type", mimeType)
+	}
+	part, err := mw.CreatePart(header)
+	if err != nil {
+		return "", fmt.Errorf("anthropic: create multipart part: %w", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		return "", fmt.Errorf("anthropic: write multipart payload: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return "", fmt.Errorf("anthropic: close multipart writer: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, &buf)
+	if err != nil {
+		return "", fmt.Errorf("anthropic: build files request: %w", err)
+	}
+	httpReq.Header.Set("x-api-key", p.apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	httpReq.Header.Set("anthropic-beta", filesAPIBetaHeader)
+	httpReq.Header.Set("Content-Type", mw.FormDataContentType())
+	httpReq.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("anthropic: files upload HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("anthropic: files upload returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		ID        string `json:"id"`
+		Filename  string `json:"filename"`
+		MimeType  string `json:"mime_type"`
+		SizeBytes int    `json:"size_bytes"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("anthropic: parse files response: %w", err)
+	}
+	if parsed.ID == "" {
+		return "", fmt.Errorf("anthropic: files response missing id: %s", string(body))
+	}
+	return parsed.ID, nil
+}
+
+// deleteFile issues a DELETE against /v1/files/{id}. Best-effort — used by
+// Shutdown when delete_on_shutdown is enabled.
+func (p *Plugin) deleteFile(ctx context.Context, id string) error {
+	base := p.filesAPIURL
+	if base == "" {
+		base = filesAPIBaseURL
+	}
+	endpoint := base + "/" + id
+
+	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("anthropic: build delete request: %w", err)
+	}
+	httpReq.Header.Set("x-api-key", p.apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	httpReq.Header.Set("anthropic-beta", filesAPIBetaHeader)
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("anthropic: files delete HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("anthropic: files delete returned status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// preuploadParts walks msgs and replaces oversize Data parts with a Files API
+// file_id. Parts that already carry a FileID are left alone; URI-only parts
+// pass through untouched (the multimodal block builder will use the URI source
+// path). Returns a fresh slice so the caller's messages are not mutated.
+//
+// Cache key is sha256(mime_type + ":" + data) when CacheUploads is true; on
+// hit, the existing FileID is reused without an HTTP call. Successful uploads
+// clear part.Data to free memory and avoid double-send if the message gets
+// re-serialized.
+func (p *Plugin) preuploadParts(ctx context.Context, msgs []events.Message) ([]events.Message, error) {
+	if !p.files.Enabled || len(msgs) == 0 {
+		return msgs, nil
+	}
+
+	threshold := p.files.UploadThreshold
+	if threshold <= 0 {
+		threshold = uploadThresholdDefault
+	}
+
+	out := make([]events.Message, len(msgs))
+	for i, m := range msgs {
+		out[i] = m
+		if len(m.Parts) == 0 {
+			continue
+		}
+		var newParts []events.MessagePart
+		for j, part := range m.Parts {
+			// Skip if FileID already set, URI already set (provider-hosted
+			// reference takes precedence over local Data — no need to upload),
+			// or the inline payload is under threshold.
+			if part.FileID != "" || part.URI != "" || len(part.Data) <= threshold {
+				if newParts != nil {
+					newParts[j] = part
+				}
+				continue
+			}
+			if part.MimeType == "" {
+				return nil, fmt.Errorf("anthropic: oversize %s part requires mime_type for files upload", part.Type)
+			}
+
+			// Allocate the per-message copy lazily — saves an alloc when the
+			// message has no oversize parts (the common case).
+			if newParts == nil {
+				newParts = make([]events.MessagePart, len(m.Parts))
+				copy(newParts, m.Parts)
+			}
+
+			var key string
+			if p.files.CacheUploads && p.fileCache != nil {
+				key = hashKey(part.MimeType, part.Data)
+				if id, ok := p.fileCache.get(key); ok {
+					p.logger.Debug("anthropic: files cache hit", "type", part.Type, "bytes", len(part.Data), "file_id", id)
+					newParts[j].FileID = id
+					newParts[j].Data = nil
+					continue
+				}
+			}
+
+			filename := fmt.Sprintf("nexus-%s-%d-%d", part.Type, i, j)
+			p.logger.Info("anthropic: uploading oversize part via Files API", "type", part.Type, "bytes", len(part.Data), "mime", part.MimeType)
+			id, err := p.uploadFile(ctx, part.Data, part.MimeType, filename)
+			if err != nil {
+				return nil, fmt.Errorf("anthropic: files upload: %w", err)
+			}
+			newParts[j].FileID = id
+			newParts[j].Data = nil
+
+			if p.files.CacheUploads && p.fileCache != nil && key != "" {
+				p.fileCache.put(key, id)
+			}
+			p.trackUploadedID(id)
+		}
+		if newParts != nil {
+			out[i].Parts = newParts
+		}
+	}
+	return out, nil
+}
+
+// trackUploadedID records a file_id this session uploaded so Shutdown can
+// optionally delete it. Safe to call from concurrent request goroutines.
+func (p *Plugin) trackUploadedID(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sessionFileIDs = append(p.sessionFileIDs, id)
+}
+
+// snapshotSessionFileIDs returns a copy of the session-tracked file IDs and
+// clears the slice. Used by Shutdown.
+func (p *Plugin) snapshotSessionFileIDs() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.sessionFileIDs) == 0 {
+		return nil
+	}
+	ids := make([]string, len(p.sessionFileIDs))
+	copy(ids, p.sessionFileIDs)
+	p.sessionFileIDs = nil
+	return ids
+}

--- a/plugins/providers/anthropic/files_test.go
+++ b/plugins/providers/anthropic/files_test.go
@@ -1,0 +1,529 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// TestParseFilesConfig_Defaults asserts that an absent files block yields a
+// zero-valued config (Enabled=false, threshold=default, cache_uploads=true).
+func TestParseFilesConfig_Defaults(t *testing.T) {
+	fc := parseFilesConfig(map[string]any{})
+	if fc.Enabled {
+		t.Fatalf("expected disabled by default, got enabled")
+	}
+	if fc.UploadThreshold != uploadThresholdDefault {
+		t.Fatalf("expected threshold=%d, got %d", uploadThresholdDefault, fc.UploadThreshold)
+	}
+	if !fc.CacheUploads {
+		t.Fatalf("expected cache_uploads=true by default")
+	}
+	if fc.DeleteOnShutdown {
+		t.Fatalf("expected delete_on_shutdown=false by default")
+	}
+}
+
+// TestParseFilesConfig_Explicit covers explicit overrides for every field.
+func TestParseFilesConfig_Explicit(t *testing.T) {
+	cfg := map[string]any{
+		"files": map[string]any{
+			"enabled":            true,
+			"upload_threshold":   1024,
+			"cache_uploads":      false,
+			"delete_on_shutdown": true,
+		},
+	}
+	fc := parseFilesConfig(cfg)
+	if !fc.Enabled {
+		t.Fatalf("expected enabled=true")
+	}
+	if fc.UploadThreshold != 1024 {
+		t.Fatalf("expected threshold=1024, got %d", fc.UploadThreshold)
+	}
+	if fc.CacheUploads {
+		t.Fatalf("expected cache_uploads=false")
+	}
+	if !fc.DeleteOnShutdown {
+		t.Fatalf("expected delete_on_shutdown=true")
+	}
+}
+
+// TestParseFilesConfig_FloatThreshold guards against YAML number-parsing,
+// which decodes integers as float64 by default.
+func TestParseFilesConfig_FloatThreshold(t *testing.T) {
+	cfg := map[string]any{
+		"files": map[string]any{
+			"enabled":          true,
+			"upload_threshold": float64(2048),
+		},
+	}
+	fc := parseFilesConfig(cfg)
+	if fc.UploadThreshold != 2048 {
+		t.Fatalf("expected threshold=2048, got %d", fc.UploadThreshold)
+	}
+}
+
+// newTestPlugin returns a Plugin wired to an httptest server with sane
+// defaults. Tests pass a custom mux; the server URL becomes filesAPIURL so
+// uploadFile and deleteFile route to the fake.
+func newTestPlugin(t *testing.T, handler http.Handler) (*Plugin, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	p := &Plugin{
+		apiKey:      "test-key",
+		client:      srv.Client(),
+		logger:      silentLogger(),
+		filesAPIURL: srv.URL,
+		fileCache:   newFileCache(),
+	}
+	return p, srv
+}
+
+// TestUploadFile_Success verifies the multipart body shape, the headers, and
+// that the parsed file_id is returned.
+func TestUploadFile_Success(t *testing.T) {
+	var capturedHeaders http.Header
+	var capturedBody []byte
+	var capturedContentType string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		capturedContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = body
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file_abc","filename":"foo.png","mime_type":"image/png","size_bytes":42,"created_at":"2026-01-01T00:00:00Z"}`))
+	})
+
+	p, _ := newTestPlugin(t, mux)
+	id, err := p.uploadFile(context.Background(), []byte("payload-bytes"), "image/png", "foo.png")
+	if err != nil {
+		t.Fatalf("uploadFile failed: %v", err)
+	}
+	if id != "file_abc" {
+		t.Fatalf("expected file_abc, got %q", id)
+	}
+
+	// Required Anthropic headers.
+	if capturedHeaders.Get("x-api-key") != "test-key" {
+		t.Fatalf("missing/wrong x-api-key: %q", capturedHeaders.Get("x-api-key"))
+	}
+	if capturedHeaders.Get("anthropic-version") != "2023-06-01" {
+		t.Fatalf("missing anthropic-version header")
+	}
+	if capturedHeaders.Get("anthropic-beta") != filesAPIBetaHeader {
+		t.Fatalf("expected beta header %q, got %q", filesAPIBetaHeader, capturedHeaders.Get("anthropic-beta"))
+	}
+	if !strings.HasPrefix(capturedContentType, "multipart/form-data") {
+		t.Fatalf("expected multipart content-type, got %q", capturedContentType)
+	}
+
+	// Multipart body should contain the file field name, filename, mime, and bytes.
+	bodyStr := string(capturedBody)
+	if !strings.Contains(bodyStr, `name="file"`) {
+		t.Fatalf("multipart body missing field name: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `filename="foo.png"`) {
+		t.Fatalf("multipart body missing filename: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "image/png") {
+		t.Fatalf("multipart body missing content-type: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "payload-bytes") {
+		t.Fatalf("multipart body missing payload bytes: %s", bodyStr)
+	}
+}
+
+// TestUploadFile_Failure asserts that 5xx responses produce a descriptive
+// error including status and body.
+func TestUploadFile_Failure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	})
+	p, _ := newTestPlugin(t, mux)
+
+	_, err := p.uploadFile(context.Background(), []byte("data"), "image/png", "x.png")
+	if err == nil {
+		t.Fatal("expected error on 500 response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error missing status: %v", err)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error missing body: %v", err)
+	}
+}
+
+// TestPreuploadParts_Oversize covers the canonical happy path: an oversize
+// Data part is uploaded, FileID is set, Data is cleared.
+func TestPreuploadParts_Oversize(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file_uploaded","filename":"x","mime_type":"image/png","size_bytes":10,"created_at":"now"}`))
+	})
+
+	p, _ := newTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, UploadThreshold: 4, CacheUploads: true}
+
+	original := []byte{0x01, 0x02, 0x03, 0x04, 0x05} // 5 bytes > threshold 4
+	msgs := []events.Message{
+		{
+			Role: "user",
+			Parts: []events.MessagePart{
+				{Type: "image", MimeType: "image/png", Data: original},
+			},
+		},
+	}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 upload, got %d", calls)
+	}
+	if out[0].Parts[0].FileID != "file_uploaded" {
+		t.Fatalf("expected FileID=file_uploaded, got %q", out[0].Parts[0].FileID)
+	}
+	if out[0].Parts[0].Data != nil {
+		t.Fatalf("expected Data cleared after upload, got %v bytes", len(out[0].Parts[0].Data))
+	}
+	// Caller's slice MUST NOT be mutated.
+	if msgs[0].Parts[0].FileID != "" {
+		t.Fatal("caller's MessagePart was mutated (FileID set on input)")
+	}
+	if len(msgs[0].Parts[0].Data) != len(original) {
+		t.Fatal("caller's MessagePart was mutated (Data cleared)")
+	}
+}
+
+// TestPreuploadParts_UnderThreshold ensures small Data parts are left alone.
+func TestPreuploadParts_UnderThreshold(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file_x"}`))
+	})
+	p, _ := newTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, UploadThreshold: 1024, CacheUploads: true}
+
+	msgs := []events.Message{
+		{Role: "user", Parts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", Data: []byte{0x01, 0x02}},
+		}},
+	}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 uploads for under-threshold data, got %d", calls)
+	}
+	if out[0].Parts[0].FileID != "" {
+		t.Fatal("FileID should not be set for under-threshold data")
+	}
+	if len(out[0].Parts[0].Data) != 2 {
+		t.Fatal("Data should be preserved for under-threshold parts")
+	}
+}
+
+// TestPreuploadParts_URIPassthrough ensures parts that already have a URI are
+// not uploaded (they sidestep the inline cap).
+func TestPreuploadParts_URIPassthrough(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+	})
+	p, _ := newTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, UploadThreshold: 4, CacheUploads: true}
+
+	msgs := []events.Message{
+		{Role: "user", Parts: []events.MessagePart{
+			{Type: "image", URI: "https://example.com/big.png", Data: make([]byte, 10)},
+		}},
+	}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	// URI passthrough: no upload happens, URI is preserved, FileID stays empty.
+	if calls != 0 {
+		t.Fatalf("expected 0 uploads when URI set, got %d", calls)
+	}
+	if out[0].Parts[0].URI != "https://example.com/big.png" {
+		t.Fatalf("URI mutated: %v", out[0].Parts[0].URI)
+	}
+	if out[0].Parts[0].FileID != "" {
+		t.Fatalf("FileID should not be set when URI passthrough, got %v", out[0].Parts[0].FileID)
+	}
+}
+
+// TestPreuploadParts_FileIDPassthrough covers the case where a part already
+// has FileID set: no upload, no mutation.
+func TestPreuploadParts_FileIDPassthrough(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+	})
+	p, _ := newTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, UploadThreshold: 4, CacheUploads: true}
+
+	msgs := []events.Message{
+		{Role: "user", Parts: []events.MessagePart{
+			{Type: "image", FileID: "file_existing", Data: make([]byte, 10)},
+		}},
+	}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 uploads when FileID set, got %d", calls)
+	}
+	if out[0].Parts[0].FileID != "file_existing" {
+		t.Fatalf("FileID should be preserved, got %q", out[0].Parts[0].FileID)
+	}
+}
+
+// TestPreuploadParts_CacheHit verifies that uploading the same content twice
+// hits the in-memory cache and produces only one HTTP call.
+func TestPreuploadParts_CacheHit(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file_cached","filename":"x","mime_type":"image/png","size_bytes":10,"created_at":"now"}`))
+	})
+	p, _ := newTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, UploadThreshold: 4, CacheUploads: true}
+
+	payload := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	mk := func() []events.Message {
+		return []events.Message{{Role: "user", Parts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", Data: append([]byte(nil), payload...)},
+		}}}
+	}
+
+	out1, err := p.preuploadParts(context.Background(), mk())
+	if err != nil {
+		t.Fatalf("first preuploadParts: %v", err)
+	}
+	out2, err := p.preuploadParts(context.Background(), mk())
+	if err != nil {
+		t.Fatalf("second preuploadParts: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 upload (cache hit on second), got %d", calls)
+	}
+	if out1[0].Parts[0].FileID != "file_cached" || out2[0].Parts[0].FileID != "file_cached" {
+		t.Fatalf("expected both calls to resolve to file_cached, got %q / %q",
+			out1[0].Parts[0].FileID, out2[0].Parts[0].FileID)
+	}
+}
+
+// TestPreuploadParts_CacheDisabled verifies cache is bypassed when CacheUploads
+// is false: identical bytes upload twice.
+func TestPreuploadParts_CacheDisabled(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file_xyz"}`))
+	})
+	p, _ := newTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, UploadThreshold: 4, CacheUploads: false}
+	p.fileCache = nil // disable cache entirely
+
+	payload := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	mk := func() []events.Message {
+		return []events.Message{{Role: "user", Parts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", Data: append([]byte(nil), payload...)},
+		}}}
+	}
+	if _, err := p.preuploadParts(context.Background(), mk()); err != nil {
+		t.Fatalf("first preuploadParts: %v", err)
+	}
+	if _, err := p.preuploadParts(context.Background(), mk()); err != nil {
+		t.Fatalf("second preuploadParts: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 uploads with cache disabled, got %d", calls)
+	}
+}
+
+// TestPreuploadParts_MissingMimeType errors out with a clear message rather
+// than uploading garbage.
+func TestPreuploadParts_MissingMimeType(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("unexpected upload — should have failed pre-upload")
+	})
+	p, _ := newTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, UploadThreshold: 4, CacheUploads: true}
+
+	msgs := []events.Message{{Role: "user", Parts: []events.MessagePart{
+		{Type: "image", Data: []byte{0x01, 0x02, 0x03, 0x04, 0x05}}, // no MimeType
+	}}}
+	_, err := p.preuploadParts(context.Background(), msgs)
+	if err == nil {
+		t.Fatal("expected error for missing mime_type")
+	}
+	if !strings.Contains(err.Error(), "mime_type") {
+		t.Fatalf("expected mime_type error, got %v", err)
+	}
+}
+
+// TestPreuploadParts_Disabled is a no-op when files.Enabled is false even if
+// parts would otherwise trigger uploads.
+func TestPreuploadParts_Disabled(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+	})
+	p, _ := newTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: false}
+
+	msgs := []events.Message{{Role: "user", Parts: []events.MessagePart{
+		{Type: "image", MimeType: "image/png", Data: make([]byte, 10*1024*1024)},
+	}}}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 uploads when feature disabled, got %d", calls)
+	}
+	if out[0].Parts[0].FileID != "" {
+		t.Fatal("FileID should not be set when feature disabled")
+	}
+}
+
+// TestDeleteFile_Success exercises the DELETE happy path and header set.
+func TestDeleteFile_Success(t *testing.T) {
+	var capturedPath string
+	var capturedHeaders http.Header
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedHeaders = r.Header.Clone()
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	p, _ := newTestPlugin(t, mux)
+
+	if err := p.deleteFile(context.Background(), "file_abc"); err != nil {
+		t.Fatalf("deleteFile: %v", err)
+	}
+	if !strings.HasSuffix(capturedPath, "/file_abc") {
+		t.Fatalf("expected path ending in /file_abc, got %s", capturedPath)
+	}
+	if capturedHeaders.Get("anthropic-beta") != filesAPIBetaHeader {
+		t.Fatalf("missing files beta header on delete")
+	}
+}
+
+// TestDeleteFile_FailureNonFatal asserts that 4xx surfaces a descriptive error
+// (callers in Shutdown swallow it).
+func TestDeleteFile_FailureNonFatal(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	})
+	p, _ := newTestPlugin(t, mux)
+	err := p.deleteFile(context.Background(), "file_missing")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Fatalf("error missing status: %v", err)
+	}
+}
+
+// TestSessionFileIDTracking_DeleteOnShutdown simulates a session where two
+// uploads happen, then verifies the snapshot returns both ids and a follow-up
+// snapshot is empty (the slice is consumed).
+func TestSessionFileIDTracking_DeleteOnShutdown(t *testing.T) {
+	var deleted []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			// fake upload; return predictable ids per call order
+			id := "file_" + r.URL.Path
+			body, _ := json.Marshal(map[string]any{"id": id})
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		case http.MethodDelete:
+			parts := strings.Split(r.URL.Path, "/")
+			deleted = append(deleted, parts[len(parts)-1])
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+	p, _ := newTestPlugin(t, mux)
+
+	p.trackUploadedID("file_one")
+	p.trackUploadedID("file_two")
+	ids := p.snapshotSessionFileIDs()
+	if len(ids) != 2 || ids[0] != "file_one" || ids[1] != "file_two" {
+		t.Fatalf("unexpected snapshot: %v", ids)
+	}
+	if again := p.snapshotSessionFileIDs(); again != nil {
+		t.Fatalf("expected second snapshot empty, got %v", again)
+	}
+
+	// Round-trip the delete path: deleting both ids should hit the fake.
+	for _, id := range ids {
+		if err := p.deleteFile(context.Background(), id); err != nil {
+			t.Fatalf("deleteFile(%s): %v", id, err)
+		}
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("expected 2 deletes, got %d (%v)", len(deleted), deleted)
+	}
+}
+
+// TestHashKey_Stability verifies the cache key changes when content or
+// mime_type changes, and is stable for identical inputs.
+func TestHashKey_Stability(t *testing.T) {
+	a := hashKey("image/png", []byte("hello"))
+	b := hashKey("image/png", []byte("hello"))
+	c := hashKey("image/jpeg", []byte("hello"))
+	d := hashKey("image/png", []byte("world"))
+	if a != b {
+		t.Fatal("expected identical hashes for identical inputs")
+	}
+	if a == c {
+		t.Fatal("expected different hash for different mime")
+	}
+	if a == d {
+		t.Fatal("expected different hash for different bytes")
+	}
+}

--- a/plugins/providers/anthropic/files_test.go
+++ b/plugins/providers/anthropic/files_test.go
@@ -79,7 +79,7 @@ func newTestPlugin(t *testing.T, handler http.Handler) (*Plugin, *httptest.Serve
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	p := &Plugin{
-		apiKey:      "test-key",
+		auth:        &authState{mode: authModeAPIKey, apiKey: "test-key"},
 		client:      srv.Client(),
 		logger:      silentLogger(),
 		filesAPIURL: srv.URL,

--- a/plugins/providers/anthropic/multimodal.go
+++ b/plugins/providers/anthropic/multimodal.go
@@ -49,7 +49,10 @@ func parseMultimodalConfig(cfg map[string]any) multimodalConfig {
 //
 // When msg.Content is non-empty, it leads as a text block before any Parts —
 // matches the convention already used in Gemini's buildParts.
-func buildContentBlocks(msg events.Message) ([]map[string]any, error) {
+//
+// citationsEnabled toggles per-document `citations: {enabled: true}` markers
+// on outgoing document blocks; threaded from the plugin's citations config.
+func buildContentBlocks(msg events.Message, citationsEnabled bool) ([]map[string]any, error) {
 	if len(msg.Parts) == 0 {
 		return nil, nil
 	}
@@ -74,7 +77,7 @@ func buildContentBlocks(msg events.Message) ([]map[string]any, error) {
 		case "file":
 			// Treat any non-image binary part as a document. mime_type drives
 			// whether Anthropic interprets it as a PDF or another doc format.
-			block, err := buildDocumentBlock(part)
+			block, err := buildDocumentBlock(part, citationsEnabled)
 			if err != nil {
 				return nil, err
 			}
@@ -135,43 +138,51 @@ func buildImageBlock(part events.MessagePart) (map[string]any, error) {
 
 // buildDocumentBlock emits an Anthropic `document` content block from a
 // MessagePart. Same source-selection rules as buildImageBlock (FileID > URI >
-// inline Data) but with a 32MB inline cap. Plan 05 will add
-// `citations: {enabled: true}` here behind a config flag — not handled in
-// this commit.
-func buildDocumentBlock(part events.MessagePart) (map[string]any, error) {
-	if part.FileID != "" {
-		return map[string]any{
+// inline Data) but with a 32MB inline cap.
+//
+// When citationsEnabled is true the block carries a `citations:{enabled:true}`
+// marker so Anthropic returns char/page/block-level source attributions on the
+// generated text blocks.
+func buildDocumentBlock(part events.MessagePart, citationsEnabled bool) (map[string]any, error) {
+	var block map[string]any
+	switch {
+	case part.FileID != "":
+		block = map[string]any{
 			"type": "document",
 			"source": map[string]any{
 				"type":    "file",
 				"file_id": part.FileID,
 			},
-		}, nil
-	}
-	if part.URI != "" {
-		return map[string]any{
+		}
+	case part.URI != "":
+		block = map[string]any{
 			"type": "document",
 			"source": map[string]any{
 				"type": "url",
 				"url":  part.URI,
 			},
-		}, nil
+		}
+	default:
+		if len(part.Data) == 0 {
+			return nil, fmt.Errorf("anthropic: document part has neither URI nor Data")
+		}
+		if part.MimeType == "" {
+			return nil, fmt.Errorf("anthropic: document part requires mime_type")
+		}
+		if len(part.Data) > inlinePDFLimit {
+			return nil, fmt.Errorf("anthropic: document part (%d bytes) exceeds inline limit; upload via Files API and set URI", len(part.Data))
+		}
+		block = map[string]any{
+			"type": "document",
+			"source": map[string]any{
+				"type":       "base64",
+				"media_type": part.MimeType,
+				"data":       base64.StdEncoding.EncodeToString(part.Data),
+			},
+		}
 	}
-	if len(part.Data) == 0 {
-		return nil, fmt.Errorf("anthropic: document part has neither URI nor Data")
+	if citationsEnabled {
+		block["citations"] = map[string]any{"enabled": true}
 	}
-	if part.MimeType == "" {
-		return nil, fmt.Errorf("anthropic: document part requires mime_type")
-	}
-	if len(part.Data) > inlinePDFLimit {
-		return nil, fmt.Errorf("anthropic: document part (%d bytes) exceeds inline limit; upload via Files API and set URI", len(part.Data))
-	}
-	return map[string]any{
-		"type": "document",
-		"source": map[string]any{
-			"type":       "base64",
-			"media_type": part.MimeType,
-			"data":       base64.StdEncoding.EncodeToString(part.Data),
-		},
-	}, nil
+	return block, nil
 }

--- a/plugins/providers/anthropic/multimodal.go
+++ b/plugins/providers/anthropic/multimodal.go
@@ -91,10 +91,20 @@ func buildContentBlocks(msg events.Message) ([]map[string]any, error) {
 }
 
 // buildImageBlock emits an Anthropic `image` content block from a MessagePart.
-// Prefers URI sources (no inline cap). Inline Data must be <=5MB and carry a
-// MimeType. Future plans (04) may add a file_id source via MessagePart.FileID;
-// not handled here.
+// Source-selection order: FileID > URI > inline Data. FileID maps to the
+// Files API file source (no inline cap, no token cost beyond the reference);
+// URI maps to a remote URL source; inline Data must be <=5MB and carry a
+// MimeType.
 func buildImageBlock(part events.MessagePart) (map[string]any, error) {
+	if part.FileID != "" {
+		return map[string]any{
+			"type": "image",
+			"source": map[string]any{
+				"type":    "file",
+				"file_id": part.FileID,
+			},
+		}, nil
+	}
 	if part.URI != "" {
 		return map[string]any{
 			"type": "image",
@@ -124,10 +134,20 @@ func buildImageBlock(part events.MessagePart) (map[string]any, error) {
 }
 
 // buildDocumentBlock emits an Anthropic `document` content block from a
-// MessagePart. Same source-selection rules as buildImageBlock but with a 32MB
-// inline cap. Plan 05 will add `citations: {enabled: true}` here behind a
-// config flag — not handled in this commit.
+// MessagePart. Same source-selection rules as buildImageBlock (FileID > URI >
+// inline Data) but with a 32MB inline cap. Plan 05 will add
+// `citations: {enabled: true}` here behind a config flag — not handled in
+// this commit.
 func buildDocumentBlock(part events.MessagePart) (map[string]any, error) {
+	if part.FileID != "" {
+		return map[string]any{
+			"type": "document",
+			"source": map[string]any{
+				"type":    "file",
+				"file_id": part.FileID,
+			},
+		}, nil
+	}
 	if part.URI != "" {
 		return map[string]any{
 			"type": "document",

--- a/plugins/providers/anthropic/multimodal.go
+++ b/plugins/providers/anthropic/multimodal.go
@@ -1,0 +1,157 @@
+package anthropic
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// Anthropic inline payload caps. URI sources sidestep these; oversize inline
+// payloads must be uploaded via the Files API (plan 04 will wire that up).
+const (
+	inlineImageLimit = 5 * 1024 * 1024  // 5 MB; Anthropic's documented inline cap
+	inlinePDFLimit   = 32 * 1024 * 1024 // 32 MB
+)
+
+// multimodalConfig controls Anthropic-specific multimodal request behavior.
+//
+//	multimodal:
+//	  pdf_beta: false  # default; Sonnet 3.5+ accepts PDFs natively
+//
+// When pdf_beta is true the request builder appends `pdfs-2024-09-25` to the
+// `anthropic-beta` header so legacy models accept document blocks.
+type multimodalConfig struct {
+	PDFBeta bool
+}
+
+// parseMultimodalConfig pulls multimodalConfig out of the plugin's raw config
+// map. Absent block returns a zero-value config.
+func parseMultimodalConfig(cfg map[string]any) multimodalConfig {
+	mc := multimodalConfig{}
+
+	raw, ok := cfg["multimodal"].(map[string]any)
+	if !ok {
+		return mc
+	}
+
+	if v, ok := raw["pdf_beta"].(bool); ok {
+		mc.PDFBeta = v
+	}
+
+	return mc
+}
+
+// buildContentBlocks converts an events.Message with Parts into Anthropic
+// content blocks. Returns nil when Parts is empty (caller falls back to the
+// string Content path). Returns an error for unsupported part types
+// (audio, video) and oversize inline payloads with no URI.
+//
+// When msg.Content is non-empty, it leads as a text block before any Parts —
+// matches the convention already used in Gemini's buildParts.
+func buildContentBlocks(msg events.Message) ([]map[string]any, error) {
+	if len(msg.Parts) == 0 {
+		return nil, nil
+	}
+
+	out := make([]map[string]any, 0, len(msg.Parts)+1)
+	if msg.Content != "" {
+		out = append(out, map[string]any{"type": "text", "text": msg.Content})
+	}
+
+	for _, part := range msg.Parts {
+		switch part.Type {
+		case "text":
+			out = append(out, map[string]any{"type": "text", "text": part.Text})
+
+		case "image":
+			block, err := buildImageBlock(part)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, block)
+
+		case "file":
+			// Treat any non-image binary part as a document. mime_type drives
+			// whether Anthropic interprets it as a PDF or another doc format.
+			block, err := buildDocumentBlock(part)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, block)
+
+		case "audio", "video":
+			return nil, fmt.Errorf("anthropic: %s parts are not supported (use Gemini or OpenAI for these modalities)", part.Type)
+
+		default:
+			return nil, fmt.Errorf("anthropic: unsupported part type %q", part.Type)
+		}
+	}
+	return out, nil
+}
+
+// buildImageBlock emits an Anthropic `image` content block from a MessagePart.
+// Prefers URI sources (no inline cap). Inline Data must be <=5MB and carry a
+// MimeType. Future plans (04) may add a file_id source via MessagePart.FileID;
+// not handled here.
+func buildImageBlock(part events.MessagePart) (map[string]any, error) {
+	if part.URI != "" {
+		return map[string]any{
+			"type": "image",
+			"source": map[string]any{
+				"type": "url",
+				"url":  part.URI,
+			},
+		}, nil
+	}
+	if len(part.Data) == 0 {
+		return nil, fmt.Errorf("anthropic: image part has neither URI nor Data")
+	}
+	if part.MimeType == "" {
+		return nil, fmt.Errorf("anthropic: image part requires mime_type")
+	}
+	if len(part.Data) > inlineImageLimit {
+		return nil, fmt.Errorf("anthropic: image part (%d bytes) exceeds inline limit; upload via Files API and set URI", len(part.Data))
+	}
+	return map[string]any{
+		"type": "image",
+		"source": map[string]any{
+			"type":       "base64",
+			"media_type": part.MimeType,
+			"data":       base64.StdEncoding.EncodeToString(part.Data),
+		},
+	}, nil
+}
+
+// buildDocumentBlock emits an Anthropic `document` content block from a
+// MessagePart. Same source-selection rules as buildImageBlock but with a 32MB
+// inline cap. Plan 05 will add `citations: {enabled: true}` here behind a
+// config flag — not handled in this commit.
+func buildDocumentBlock(part events.MessagePart) (map[string]any, error) {
+	if part.URI != "" {
+		return map[string]any{
+			"type": "document",
+			"source": map[string]any{
+				"type": "url",
+				"url":  part.URI,
+			},
+		}, nil
+	}
+	if len(part.Data) == 0 {
+		return nil, fmt.Errorf("anthropic: document part has neither URI nor Data")
+	}
+	if part.MimeType == "" {
+		return nil, fmt.Errorf("anthropic: document part requires mime_type")
+	}
+	if len(part.Data) > inlinePDFLimit {
+		return nil, fmt.Errorf("anthropic: document part (%d bytes) exceeds inline limit; upload via Files API and set URI", len(part.Data))
+	}
+	return map[string]any{
+		"type": "document",
+		"source": map[string]any{
+			"type":       "base64",
+			"media_type": part.MimeType,
+			"data":       base64.StdEncoding.EncodeToString(part.Data),
+		},
+	}, nil
+}

--- a/plugins/providers/anthropic/multimodal_test.go
+++ b/plugins/providers/anthropic/multimodal_test.go
@@ -1,0 +1,324 @@
+package anthropic
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// TestBuildContentBlocks_EmptyParts confirms that messages without Parts fall
+// through to the legacy string-content path (caller checks for nil to decide).
+func TestBuildContentBlocks_EmptyParts(t *testing.T) {
+	blocks, err := buildContentBlocks(events.Message{Role: "user", Content: "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if blocks != nil {
+		t.Fatalf("expected nil blocks for empty Parts, got %v", blocks)
+	}
+}
+
+// TestBuildContentBlocks_TextPart covers a single text Part with no Content
+// field, ensuring it serializes as a `text` block.
+func TestBuildContentBlocks_TextPart(t *testing.T) {
+	msg := events.Message{
+		Role:  "user",
+		Parts: []events.MessagePart{{Type: "text", Text: "describe this"}},
+	}
+	blocks, err := buildContentBlocks(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0]["type"] != "text" || blocks[0]["text"] != "describe this" {
+		t.Fatalf("unexpected block: %v", blocks[0])
+	}
+}
+
+// TestBuildContentBlocks_ImageInline encodes a small image inline and verifies
+// the base64 source shape (data + media_type).
+func TestBuildContentBlocks_ImageInline(t *testing.T) {
+	raw := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A} // PNG header
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", Data: raw},
+		},
+	}
+	blocks, err := buildContentBlocks(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0]["type"] != "image" {
+		t.Fatalf("expected image block, got %v", blocks[0]["type"])
+	}
+	source, ok := blocks[0]["source"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected source map, got %T", blocks[0]["source"])
+	}
+	if source["type"] != "base64" {
+		t.Fatalf("expected base64 source type, got %v", source["type"])
+	}
+	if source["media_type"] != "image/png" {
+		t.Fatalf("expected image/png media_type, got %v", source["media_type"])
+	}
+	expected := base64.StdEncoding.EncodeToString(raw)
+	if source["data"] != expected {
+		t.Fatalf("data mismatch: want %q, got %v", expected, source["data"])
+	}
+}
+
+// TestBuildContentBlocks_ImageURI verifies URI sources are passed through
+// unchanged (no inline cap applies, MimeType not strictly required by Anthropic).
+func TestBuildContentBlocks_ImageURI(t *testing.T) {
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "image", URI: "https://example.com/cat.png"},
+		},
+	}
+	blocks, err := buildContentBlocks(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	source := blocks[0]["source"].(map[string]any)
+	if source["type"] != "url" {
+		t.Fatalf("expected url source type, got %v", source["type"])
+	}
+	if source["url"] != "https://example.com/cat.png" {
+		t.Fatalf("url mismatch: %v", source["url"])
+	}
+}
+
+// TestBuildContentBlocks_ImageOversize confirms that an image >5MB without a
+// URI errors out (caller is expected to upload via Files API).
+func TestBuildContentBlocks_ImageOversize(t *testing.T) {
+	huge := make([]byte, inlineImageLimit+1)
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", Data: huge},
+		},
+	}
+	_, err := buildContentBlocks(msg)
+	if err == nil {
+		t.Fatal("expected error for oversize image")
+	}
+	if !strings.Contains(err.Error(), "exceeds inline limit") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestBuildContentBlocks_ImageMissingMimeType ensures inline data without
+// MimeType is rejected (Anthropic's base64 source requires media_type).
+func TestBuildContentBlocks_ImageMissingMimeType(t *testing.T) {
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "image", Data: []byte{0x01, 0x02}},
+		},
+	}
+	_, err := buildContentBlocks(msg)
+	if err == nil {
+		t.Fatal("expected error for missing mime_type")
+	}
+	if !strings.Contains(err.Error(), "mime_type") {
+		t.Fatalf("expected mime_type error, got: %v", err)
+	}
+}
+
+// TestBuildContentBlocks_PDFInline covers small PDF data → document base64
+// block with application/pdf media_type.
+func TestBuildContentBlocks_PDFInline(t *testing.T) {
+	raw := []byte("%PDF-1.4 fake pdf bytes")
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "file", MimeType: "application/pdf", Data: raw},
+		},
+	}
+	blocks, err := buildContentBlocks(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if blocks[0]["type"] != "document" {
+		t.Fatalf("expected document block, got %v", blocks[0]["type"])
+	}
+	source := blocks[0]["source"].(map[string]any)
+	if source["type"] != "base64" {
+		t.Fatalf("expected base64 source, got %v", source["type"])
+	}
+	if source["media_type"] != "application/pdf" {
+		t.Fatalf("expected application/pdf, got %v", source["media_type"])
+	}
+	if source["data"] != base64.StdEncoding.EncodeToString(raw) {
+		t.Fatal("data mismatch")
+	}
+}
+
+// TestBuildContentBlocks_PDFURI verifies URI document blocks.
+func TestBuildContentBlocks_PDFURI(t *testing.T) {
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "file", URI: "https://example.com/report.pdf"},
+		},
+	}
+	blocks, err := buildContentBlocks(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	source := blocks[0]["source"].(map[string]any)
+	if source["type"] != "url" || source["url"] != "https://example.com/report.pdf" {
+		t.Fatalf("unexpected source: %v", source)
+	}
+}
+
+// TestBuildContentBlocks_PDFOversize confirms the 32MB cap is enforced for
+// documents.
+func TestBuildContentBlocks_PDFOversize(t *testing.T) {
+	huge := make([]byte, inlinePDFLimit+1)
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "file", MimeType: "application/pdf", Data: huge},
+		},
+	}
+	_, err := buildContentBlocks(msg)
+	if err == nil {
+		t.Fatal("expected error for oversize PDF")
+	}
+	if !strings.Contains(err.Error(), "exceeds inline limit") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestBuildContentBlocks_AudioRejected ensures audio parts produce a clear
+// error (Anthropic's API does not accept audio).
+func TestBuildContentBlocks_AudioRejected(t *testing.T) {
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "audio", MimeType: "audio/wav", Data: []byte{0x00}},
+		},
+	}
+	_, err := buildContentBlocks(msg)
+	if err == nil {
+		t.Fatal("expected error for audio part")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("expected 'not supported' error, got: %v", err)
+	}
+}
+
+// TestBuildContentBlocks_VideoRejected mirrors the audio test for video.
+func TestBuildContentBlocks_VideoRejected(t *testing.T) {
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "video", MimeType: "video/mp4", Data: []byte{0x00}},
+		},
+	}
+	_, err := buildContentBlocks(msg)
+	if err == nil {
+		t.Fatal("expected error for video part")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("expected 'not supported' error, got: %v", err)
+	}
+}
+
+// TestBuildContentBlocks_UnknownTypeRejected covers the default switch arm.
+func TestBuildContentBlocks_UnknownTypeRejected(t *testing.T) {
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "hologram"},
+		},
+	}
+	_, err := buildContentBlocks(msg)
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+	if !strings.Contains(err.Error(), "unsupported part type") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestConvertMessage_UserWithImagePart round-trips a user message carrying
+// both a text Content and an image Part through convertMessage. The output
+// must be a blocks-array with text first, image second.
+func TestConvertMessage_UserWithImagePart(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+	msg := events.Message{
+		Role:    "user",
+		Content: "what is in this image?",
+		Parts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", Data: []byte{0x89, 0x50, 0x4E, 0x47}},
+		},
+	}
+	apiMsg := p.convertMessage(msg)
+	if apiMsg["role"] != "user" {
+		t.Fatalf("expected role=user, got %v", apiMsg["role"])
+	}
+	blocks, ok := apiMsg["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any content, got %T", apiMsg["content"])
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+	if blocks[0]["type"] != "text" || blocks[0]["text"] != "what is in this image?" {
+		t.Fatalf("expected leading text block, got %v", blocks[0])
+	}
+	if blocks[1]["type"] != "image" {
+		t.Fatalf("expected image block at index 1, got %v", blocks[1])
+	}
+}
+
+// TestConvertMessage_ToolResultWithImage covers a tool result message that
+// carries a screenshot Part — it should land inside the tool_result.content
+// array as a content-blocks slice.
+func TestConvertMessage_ToolResultWithImage(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+	msg := events.Message{
+		Role:       "tool",
+		ToolCallID: "toolu_123",
+		Content:    "screenshot attached",
+		Parts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", Data: []byte{0x01, 0x02, 0x03}},
+		},
+	}
+	apiMsg := p.convertMessage(msg)
+	if apiMsg["role"] != "user" {
+		t.Fatalf("expected role=user (Anthropic packs tool results as user), got %v", apiMsg["role"])
+	}
+	outer, ok := apiMsg["content"].([]map[string]any)
+	if !ok || len(outer) != 1 {
+		t.Fatalf("expected single tool_result envelope, got %v", apiMsg["content"])
+	}
+	tr := outer[0]
+	if tr["type"] != "tool_result" || tr["tool_use_id"] != "toolu_123" {
+		t.Fatalf("unexpected tool_result envelope: %v", tr)
+	}
+	inner, ok := tr["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected tool_result.content to be blocks array, got %T", tr["content"])
+	}
+	if len(inner) != 2 {
+		t.Fatalf("expected 2 inner blocks (text + image), got %d", len(inner))
+	}
+	if inner[0]["type"] != "text" {
+		t.Fatalf("expected leading text block, got %v", inner[0])
+	}
+	if inner[1]["type"] != "image" {
+		t.Fatalf("expected trailing image block, got %v", inner[1])
+	}
+}

--- a/plugins/providers/anthropic/multimodal_test.go
+++ b/plugins/providers/anthropic/multimodal_test.go
@@ -97,6 +97,42 @@ func TestBuildContentBlocks_ImageURI(t *testing.T) {
 	}
 }
 
+// TestBuildContentBlocks_ImageFileID verifies that a FileID-bearing part
+// emits a `file` source block (Files API path) and takes precedence over URI
+// and Data when set.
+func TestBuildContentBlocks_ImageFileID(t *testing.T) {
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "image", FileID: "file_abc123", URI: "https://example.com/ignored.png", Data: []byte{0xFF}},
+		},
+	}
+	blocks, err := buildContentBlocks(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if blocks[0]["type"] != "image" {
+		t.Fatalf("expected image block, got %v", blocks[0]["type"])
+	}
+	source, ok := blocks[0]["source"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected source map, got %T", blocks[0]["source"])
+	}
+	if source["type"] != "file" {
+		t.Fatalf("expected file source type, got %v", source["type"])
+	}
+	if source["file_id"] != "file_abc123" {
+		t.Fatalf("file_id mismatch: %v", source["file_id"])
+	}
+	// FileID precedence: URI/Data should be ignored on this path.
+	if _, hasURL := source["url"]; hasURL {
+		t.Fatalf("expected no url field when FileID set, got %v", source)
+	}
+	if _, hasData := source["data"]; hasData {
+		t.Fatalf("expected no inline data when FileID set, got %v", source)
+	}
+}
+
 // TestBuildContentBlocks_ImageOversize confirms that an image >5MB without a
 // URI errors out (caller is expected to upload via Files API).
 func TestBuildContentBlocks_ImageOversize(t *testing.T) {
@@ -178,6 +214,31 @@ func TestBuildContentBlocks_PDFURI(t *testing.T) {
 	source := blocks[0]["source"].(map[string]any)
 	if source["type"] != "url" || source["url"] != "https://example.com/report.pdf" {
 		t.Fatalf("unexpected source: %v", source)
+	}
+}
+
+// TestBuildContentBlocks_PDFFileID verifies the document branch honors FileID
+// and emits a `file` source block.
+func TestBuildContentBlocks_PDFFileID(t *testing.T) {
+	msg := events.Message{
+		Role: "user",
+		Parts: []events.MessagePart{
+			{Type: "file", FileID: "file_pdf999", MimeType: "application/pdf"},
+		},
+	}
+	blocks, err := buildContentBlocks(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if blocks[0]["type"] != "document" {
+		t.Fatalf("expected document block, got %v", blocks[0]["type"])
+	}
+	source := blocks[0]["source"].(map[string]any)
+	if source["type"] != "file" {
+		t.Fatalf("expected file source, got %v", source["type"])
+	}
+	if source["file_id"] != "file_pdf999" {
+		t.Fatalf("file_id mismatch: %v", source["file_id"])
 	}
 }
 

--- a/plugins/providers/anthropic/multimodal_test.go
+++ b/plugins/providers/anthropic/multimodal_test.go
@@ -11,7 +11,7 @@ import (
 // TestBuildContentBlocks_EmptyParts confirms that messages without Parts fall
 // through to the legacy string-content path (caller checks for nil to decide).
 func TestBuildContentBlocks_EmptyParts(t *testing.T) {
-	blocks, err := buildContentBlocks(events.Message{Role: "user", Content: "hello"})
+	blocks, err := buildContentBlocks(events.Message{Role: "user", Content: "hello"}, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestBuildContentBlocks_TextPart(t *testing.T) {
 		Role:  "user",
 		Parts: []events.MessagePart{{Type: "text", Text: "describe this"}},
 	}
-	blocks, err := buildContentBlocks(msg)
+	blocks, err := buildContentBlocks(msg, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestBuildContentBlocks_ImageInline(t *testing.T) {
 			{Type: "image", MimeType: "image/png", Data: raw},
 		},
 	}
-	blocks, err := buildContentBlocks(msg)
+	blocks, err := buildContentBlocks(msg, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBuildContentBlocks_ImageURI(t *testing.T) {
 			{Type: "image", URI: "https://example.com/cat.png"},
 		},
 	}
-	blocks, err := buildContentBlocks(msg)
+	blocks, err := buildContentBlocks(msg, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestBuildContentBlocks_ImageFileID(t *testing.T) {
 			{Type: "image", FileID: "file_abc123", URI: "https://example.com/ignored.png", Data: []byte{0xFF}},
 		},
 	}
-	blocks, err := buildContentBlocks(msg)
+	blocks, err := buildContentBlocks(msg, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestBuildContentBlocks_ImageOversize(t *testing.T) {
 			{Type: "image", MimeType: "image/png", Data: huge},
 		},
 	}
-	_, err := buildContentBlocks(msg)
+	_, err := buildContentBlocks(msg, false)
 	if err == nil {
 		t.Fatal("expected error for oversize image")
 	}
@@ -161,7 +161,7 @@ func TestBuildContentBlocks_ImageMissingMimeType(t *testing.T) {
 			{Type: "image", Data: []byte{0x01, 0x02}},
 		},
 	}
-	_, err := buildContentBlocks(msg)
+	_, err := buildContentBlocks(msg, false)
 	if err == nil {
 		t.Fatal("expected error for missing mime_type")
 	}
@@ -180,7 +180,7 @@ func TestBuildContentBlocks_PDFInline(t *testing.T) {
 			{Type: "file", MimeType: "application/pdf", Data: raw},
 		},
 	}
-	blocks, err := buildContentBlocks(msg)
+	blocks, err := buildContentBlocks(msg, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestBuildContentBlocks_PDFURI(t *testing.T) {
 			{Type: "file", URI: "https://example.com/report.pdf"},
 		},
 	}
-	blocks, err := buildContentBlocks(msg)
+	blocks, err := buildContentBlocks(msg, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,7 +226,7 @@ func TestBuildContentBlocks_PDFFileID(t *testing.T) {
 			{Type: "file", FileID: "file_pdf999", MimeType: "application/pdf"},
 		},
 	}
-	blocks, err := buildContentBlocks(msg)
+	blocks, err := buildContentBlocks(msg, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestBuildContentBlocks_PDFOversize(t *testing.T) {
 			{Type: "file", MimeType: "application/pdf", Data: huge},
 		},
 	}
-	_, err := buildContentBlocks(msg)
+	_, err := buildContentBlocks(msg, false)
 	if err == nil {
 		t.Fatal("expected error for oversize PDF")
 	}
@@ -270,7 +270,7 @@ func TestBuildContentBlocks_AudioRejected(t *testing.T) {
 			{Type: "audio", MimeType: "audio/wav", Data: []byte{0x00}},
 		},
 	}
-	_, err := buildContentBlocks(msg)
+	_, err := buildContentBlocks(msg, false)
 	if err == nil {
 		t.Fatal("expected error for audio part")
 	}
@@ -287,7 +287,7 @@ func TestBuildContentBlocks_VideoRejected(t *testing.T) {
 			{Type: "video", MimeType: "video/mp4", Data: []byte{0x00}},
 		},
 	}
-	_, err := buildContentBlocks(msg)
+	_, err := buildContentBlocks(msg, false)
 	if err == nil {
 		t.Fatal("expected error for video part")
 	}
@@ -304,7 +304,7 @@ func TestBuildContentBlocks_UnknownTypeRejected(t *testing.T) {
 			{Type: "hologram"},
 		},
 	}
-	_, err := buildContentBlocks(msg)
+	_, err := buildContentBlocks(msg, false)
 	if err == nil {
 		t.Fatal("expected error for unknown type")
 	}

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -89,12 +89,18 @@ type Plugin struct {
 	cache      cacheConfig
 	thinking   thinkingConfig
 	multimodal multimodalConfig
+	files      filesConfig
 	pricing    map[string]modelPricing // merged: config overrides + embedded defaults
+
+	// filesAPIURL is the production endpoint by default; tests override.
+	filesAPIURL string
+	fileCache   *fileCache
 
 	mu                 sync.Mutex
 	currentRequestMeta map[string]any
 	cancelFunc         context.CancelFunc // cancels the in-flight HTTP request
 	requestSeq         int                // monotonic counter for debug log filenames
+	sessionFileIDs     []string           // file_ids uploaded this session (for delete_on_shutdown)
 }
 
 // New creates a new Anthropic provider plugin.
@@ -163,6 +169,17 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.logger.Info("multimodal pdf_beta header enabled (pdfs-2024-09-25)")
 	}
 
+	p.files = parseFilesConfig(ctx.Config)
+	p.filesAPIURL = filesAPIBaseURL
+	if p.files.Enabled {
+		p.fileCache = newFileCache()
+		p.logger.Info("files API enabled",
+			"upload_threshold", p.files.UploadThreshold,
+			"cache_uploads", p.files.CacheUploads,
+			"delete_on_shutdown", p.files.DeleteOnShutdown,
+		)
+	}
+
 	p.retry = parseRetryConfig(ctx.Config)
 	if p.retry.Enabled {
 		p.logger.Info("retry enabled",
@@ -190,9 +207,19 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 
 func (p *Plugin) Ready() error { return nil }
 
-func (p *Plugin) Shutdown(_ context.Context) error {
+func (p *Plugin) Shutdown(ctx context.Context) error {
 	for _, unsub := range p.unsubs {
 		unsub()
+	}
+	if p.files.Enabled && p.files.DeleteOnShutdown {
+		ids := p.snapshotSessionFileIDs()
+		for _, id := range ids {
+			if err := p.deleteFile(ctx, id); err != nil {
+				// Best-effort: log and continue. The 30-day retention window
+				// makes leaked files a soft cost, not a correctness issue.
+				p.logger.Warn("anthropic: failed to delete session file", "file_id", id, "error", err)
+			}
+		}
 	}
 	p.client.CloseIdleConnections()
 	return nil
@@ -280,6 +307,25 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 
 	p.logger.Debug("resolving LLM request", "role", req.Role, "model", model, "max_tokens", maxTokens)
 
+	// Files API preflight: when enabled, swap oversize Data parts for file_ids
+	// before serializing the request body. We replace req.Messages locally
+	// (NOT via mutation) — the caller's slice is untouched.
+	preflightCtx, preflightCancel := context.WithCancel(context.Background())
+	if p.files.Enabled {
+		newMsgs, err := p.preuploadParts(preflightCtx, req.Messages)
+		if err != nil {
+			preflightCancel()
+			p.emitErrorInfo(events.ErrorInfo{
+				Err:         fmt.Errorf("anthropic: files preflight failed: %w", err),
+				Retryable:   false,
+				RequestMeta: req.Metadata,
+			})
+			return
+		}
+		req.Messages = newMsgs
+	}
+	preflightCancel()
+
 	body := p.buildRequestBody(model, maxTokens, req)
 
 	jsonBody, err := json.Marshal(body)
@@ -316,6 +362,14 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 		}
 		if p.multimodal.PDFBeta {
 			betaFlags = append(betaFlags, "pdfs-2024-09-25")
+		}
+		// Always send the files beta header when the feature is enabled —
+		// Anthropic accepts it regardless of whether a file_id is referenced
+		// on this particular request, and tracking per-request use would
+		// require threading state through buildRequestBody for a one-byte
+		// header savings that doesn't matter.
+		if p.files.Enabled {
+			betaFlags = append(betaFlags, filesAPIBetaHeader)
 		}
 		if len(betaFlags) > 0 {
 			httpReq.Header.Set("anthropic-beta", strings.Join(betaFlags, ","))

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -86,6 +86,7 @@ type Plugin struct {
 	unsubs  []func()
 	debug   bool
 	retry   retryConfig
+	cache   cacheConfig
 	pricing map[string]modelPricing // merged: config overrides + embedded defaults
 
 	mu                 sync.Mutex
@@ -136,6 +137,16 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.prompts = ctx.Prompts
 
 	p.pricing = parsePricingConfig(ctx.Config)
+
+	p.cache = parseCacheConfig(ctx.Config)
+	if p.cache.Enabled {
+		p.logger.Info("prompt caching enabled",
+			"system", p.cache.System,
+			"tools", p.cache.Tools,
+			"message_prefix", p.cache.MessagePrefix,
+			"ttl", p.cache.TTL,
+		)
+	}
 
 	p.retry = parseRetryConfig(ctx.Config)
 	if p.retry.Enabled {
@@ -281,6 +292,12 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 		httpReq.Header.Set("x-api-key", p.apiKey)
 		httpReq.Header.Set("anthropic-version", "2023-06-01")
 		httpReq.Header.Set("content-type", "application/json")
+		// 1h TTL caching is gated behind a beta header. Plan 06 will introduce
+		// a metadata-driven multi-header builder; for now this is the only
+		// beta flag the plugin emits, so a single Set is fine.
+		if p.cache.Enabled && p.cache.TTL == "1h" {
+			httpReq.Header.Set("anthropic-beta", "extended-cache-ttl-2025-04-11")
+		}
 		return httpReq, nil
 	}
 
@@ -426,6 +443,10 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 			body["tool_choice"] = tc
 		}
 	}
+
+	// Mark cacheable prefix segments (system, last tool, leading user msgs) per
+	// configured policy. No-op when caching is disabled.
+	applyCacheControl(body, p.cache, p.logger)
 
 	return body
 }

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -78,18 +78,19 @@ type Plugin struct {
 	models  *engine.ModelRegistry
 	session *engine.SessionWorkspace
 
-	auth       *authState
-	client     *http.Client
-	prompts    *engine.PromptRegistry
-	unsubs     []func()
-	debug      bool
-	retry      retryConfig
-	cache      cacheConfig
-	thinking   thinkingConfig
-	multimodal multimodalConfig
-	files      filesConfig
-	citations  citationsConfig
-	pricing    map[string]modelPricing // merged: config overrides + embedded defaults
+	auth              *authState
+	client            *http.Client
+	prompts           *engine.PromptRegistry
+	unsubs            []func()
+	debug             bool
+	retry             retryConfig
+	cache             cacheConfig
+	thinking          thinkingConfig
+	multimodal        multimodalConfig
+	files             filesConfig
+	citations         citationsConfig
+	structuredOutputs structuredOutputsConfig
+	pricing           map[string]modelPricing // merged: config overrides + embedded defaults
 
 	// filesAPIURL is the production endpoint by default; tests override.
 	filesAPIURL string
@@ -168,6 +169,13 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.citations = parseCitationsConfig(ctx.Config)
 	if p.citations.Enabled {
 		p.logger.Info("native citations enabled (document blocks will request citations)")
+	}
+
+	p.structuredOutputs = parseStructuredOutputsConfig(ctx.Config)
+	if p.structuredOutputs.Mode == "native" {
+		p.logger.Info("structured outputs using native response_format mode",
+			"beta_header", p.structuredOutputs.BetaHeader,
+		)
 	}
 
 	p.files = parseFilesConfig(ctx.Config)
@@ -505,9 +513,34 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 	// client-defined tools and the structured-output synthetic tool below.
 	p.appendExtraTools(body, req.Metadata)
 
-	// Structured output simulation via tool-use-as-schema.
-	// Inject synthetic tool and force tool choice to it.
-	if rf := req.ResponseFormat; rf != nil && rf.Type == "json_schema" && rf.Schema != nil {
+	// Structured output handling. Two modes:
+	//
+	//   - "tool" (default): simulate via a synthetic `_structured_output` tool
+	//     and force tool_choice on it. Compatible with every Claude model that
+	//     supports tool use, but clobbers the agent's tool_choice.
+	//   - "native": use Anthropic's top-level `response_format` field. The
+	//     model returns the JSON value as plain text, so tool_choice is left
+	//     untouched and parallel tool use stays available.
+	//
+	// When no json_schema response_format is set, both modes fall through to
+	// the normal tool_choice mapping below.
+	rf := req.ResponseFormat
+	hasJSONSchema := rf != nil && rf.Type == "json_schema" && rf.Schema != nil
+
+	switch {
+	case hasJSONSchema && p.structuredOutputs.Mode == "native":
+		body["response_format"] = map[string]any{
+			"type":   "json_schema",
+			"schema": rf.Schema,
+		}
+		// Native mode does not override tool_choice — preserve whatever the
+		// caller asked for so real tools remain usable in parallel.
+		if tc := resolveToolChoice(req.ToolChoice, filteredTools); tc != nil {
+			body["tool_choice"] = tc
+		}
+
+	case hasJSONSchema:
+		// Tool-as-schema simulation (default).
 		syntheticTool := map[string]any{
 			"name":         "_structured_output",
 			"description":  "Return structured output matching the required schema.",
@@ -522,7 +555,8 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 			"type": "tool",
 			"name": "_structured_output",
 		}
-	} else {
+
+	default:
 		// Map tool choice to Anthropic API format (only when not overridden by structured output).
 		if tc := resolveToolChoice(req.ToolChoice, filteredTools); tc != nil {
 			body["tool_choice"] = tc

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -80,14 +80,15 @@ type Plugin struct {
 	models  *engine.ModelRegistry
 	session *engine.SessionWorkspace
 
-	apiKey  string
-	client  *http.Client
-	prompts *engine.PromptRegistry
-	unsubs  []func()
-	debug   bool
-	retry   retryConfig
-	cache   cacheConfig
-	pricing map[string]modelPricing // merged: config overrides + embedded defaults
+	apiKey   string
+	client   *http.Client
+	prompts  *engine.PromptRegistry
+	unsubs   []func()
+	debug    bool
+	retry    retryConfig
+	cache    cacheConfig
+	thinking thinkingConfig
+	pricing  map[string]modelPricing // merged: config overrides + embedded defaults
 
 	mu                 sync.Mutex
 	currentRequestMeta map[string]any
@@ -148,6 +149,14 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		)
 	}
 
+	p.thinking = parseThinkingConfig(ctx.Config)
+	if p.thinking.Enabled {
+		p.logger.Info("extended thinking enabled",
+			"budget_tokens", p.thinking.BudgetTokens,
+			"include_thoughts", p.thinking.IncludeThoughts,
+		)
+	}
+
 	p.retry = parseRetryConfig(ctx.Config)
 	if p.retry.Enabled {
 		p.logger.Info("retry enabled",
@@ -195,6 +204,7 @@ func (p *Plugin) Emissions() []string {
 		"llm.response",
 		"llm.stream.chunk",
 		"llm.stream.end",
+		"thinking.step",
 		"before:core.error",
 		"core.error",
 	}
@@ -377,6 +387,10 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 		body["temperature"] = *req.Temperature
 	}
 
+	// Extended thinking. When enabled this strips any non-1 temperature
+	// (Anthropic requires temp=1) and adds the thinking object to body.
+	applyThinking(body, p.thinking, p.logger)
+
 	// Extract system prompt and build messages.
 	var systemPrompt string
 	var apiMessages []map[string]any
@@ -457,6 +471,14 @@ func (p *Plugin) convertMessage(msg events.Message) map[string]any {
 	case "assistant":
 		if len(msg.ToolCalls) > 0 {
 			var content []map[string]any
+
+			// Round-trip preservation: when extended thinking emitted blocks
+			// on the response that produced these tool calls, those blocks
+			// (with their cryptographic signatures) MUST be echoed back as
+			// the leading content on this assistant turn. Anthropic rejects
+			// the next request with HTTP 400 otherwise.
+			content = append(content, prependThinkingBlocks(msg.Metadata)...)
+
 			if msg.Content != "" {
 				content = append(content, map[string]any{
 					"type": "text",
@@ -528,6 +550,16 @@ type apiContentBlock struct {
 	ID    string          `json:"id,omitempty"`
 	Name  string          `json:"name,omitempty"`
 	Input json.RawMessage `json:"input,omitempty"`
+
+	// Extended thinking fields. Populated when Type is "thinking" or
+	// "redacted_thinking". The cryptographic Signature MUST be preserved and
+	// echoed back verbatim on the next assistant turn after a tool result, or
+	// the API rejects the request with HTTP 400. Data carries the encrypted
+	// payload of redacted_thinking blocks (the unencrypted Thinking field is
+	// empty in that case).
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
+	Data      string `json:"data,omitempty"`
 }
 
 type apiUsage struct {
@@ -546,9 +578,20 @@ func (p *Plugin) handleSyncResponse(body io.Reader) {
 
 	resp := p.convertAPIResponse(apiResp)
 
+	// Merge passthrough request metadata with any provider-attached fields
+	// (e.g. thinking_blocks). Passthrough wins on key collision so
+	// upstream-set flags like _structured_output aren't masked, but
+	// provider-attached keys are preserved.
 	p.mu.Lock()
-	resp.Metadata = p.currentRequestMeta
+	meta := p.currentRequestMeta
 	p.mu.Unlock()
+	if resp.Metadata == nil {
+		resp.Metadata = meta
+	} else if meta != nil {
+		for k, v := range meta {
+			resp.Metadata[k] = v
+		}
+	}
 
 	if err := p.bus.Emit("llm.response", resp); err != nil {
 		p.logger.Error("failed to emit llm.response", "error", err)
@@ -558,11 +601,46 @@ func (p *Plugin) handleSyncResponse(body io.Reader) {
 func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 	var content strings.Builder
 	var toolCalls []events.ToolCallRequest
+	var thinkingBlocks []map[string]any
+	thinkingIdx := 0
 
 	for _, block := range apiResp.Content {
 		switch block.Type {
 		case "text":
 			content.WriteString(block.Text)
+
+		case "thinking":
+			// Preserve the block verbatim (with signature) so the next
+			// assistant turn after a tool result can echo it back — Anthropic
+			// requires this or rejects with HTTP 400.
+			tb := map[string]any{
+				"type":      "thinking",
+				"thinking":  block.Thinking,
+				"signature": block.Signature,
+			}
+			thinkingBlocks = append(thinkingBlocks, tb)
+			if p.thinking.IncludeThoughts && block.Thinking != "" {
+				_ = p.bus.Emit("thinking.step", events.ThinkingStep{
+					TurnID:    apiResp.ID,
+					Source:    pluginID,
+					Content:   block.Thinking,
+					Phase:     "reasoning",
+					Timestamp: time.Now(),
+					Index:     thinkingIdx,
+				})
+				thinkingIdx++
+			}
+
+		case "redacted_thinking":
+			// Encrypted/redacted thinking. Pass through opaquely; we never
+			// surface contents on the bus but the block still has to be
+			// echoed back on tool-use turns.
+			tb := map[string]any{
+				"type": "redacted_thinking",
+				"data": block.Data,
+			}
+			thinkingBlocks = append(thinkingBlocks, tb)
+
 		case "tool_use":
 			args := string(block.Input)
 			// Unwrap synthetic structured output tool — put args into Content.
@@ -586,8 +664,13 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 		TotalTokens: apiResp.Usage.InputTokens + apiResp.Usage.OutputTokens +
 			apiResp.Usage.CacheReadInputTokens + apiResp.Usage.CacheCreationInputTokens,
 	}
+	// Anthropic bills thinking tokens as part of output_tokens; we surface a
+	// best-effort accounting via ReasoningTokens. The API doesn't (yet)
+	// separate the thinking portion from the visible output, so this stays at
+	// 0 for now — billing impact is captured in CompletionTokens. Plan 02
+	// reserves the field for when Anthropic exposes it.
 
-	return events.LLMResponse{
+	resp := events.LLMResponse{
 		Content:      content.String(),
 		ToolCalls:    toolCalls,
 		Usage:        usage,
@@ -595,6 +678,12 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 		Model:        apiResp.Model,
 		FinishReason: apiResp.StopReason,
 	}
+	if len(thinkingBlocks) > 0 {
+		resp.Metadata = map[string]any{
+			"thinking_blocks": thinkingBlocks,
+		}
+	}
+	return resp
 }
 
 // SSE streaming response handling.
@@ -604,20 +693,40 @@ type sseEvent struct {
 	Data  string
 }
 
+// streamState carries the mutable bookkeeping for a single SSE response. It
+// replaces a long parameter list on processSSEEvent and gives thinking-block
+// accumulation a natural home (one builder + signature per active block,
+// finalized into thinkingBlocks at content_block_stop).
+type streamState struct {
+	fullContent      strings.Builder
+	toolCalls        []events.ToolCallRequest
+	currentToolCall  *events.ToolCallRequest
+	currentToolInput strings.Builder
+
+	// Active thinking block (one at a time; Anthropic sends them serially).
+	// blockType is "thinking" or "redacted_thinking" when a thinking block is
+	// open, empty otherwise. signature/data fields are populated by
+	// signature_delta and the content_block_start event respectively.
+	thinkingBlockType string
+	thinkingBuilder   strings.Builder
+	thinkingSignature string
+	thinkingData      string
+	thinkingIdx       int
+	thinkingBlocks    []map[string]any
+
+	usage        apiUsage
+	model        string
+	finishReason string
+	turnID       string
+	chunkIndex   int
+}
+
 func (p *Plugin) handleStreamResponse(body io.Reader) {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 	var currentEvent sseEvent
-	var fullContent strings.Builder
-	var toolCalls []events.ToolCallRequest
-	var currentToolCall *events.ToolCallRequest
-	var currentToolInput strings.Builder
-	var usage apiUsage
-	var model string
-	var finishReason string
-	turnID := ""
-	chunkIndex := 0
+	st := &streamState{}
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -625,8 +734,7 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		if line == "" {
 			// Empty line means end of SSE event; process it.
 			if currentEvent.Event != "" {
-				p.processSSEEvent(currentEvent, &fullContent, &toolCalls, &currentToolCall,
-					&currentToolInput, &usage, &model, &finishReason, &turnID, &chunkIndex)
+				p.processSSEEvent(currentEvent, st)
 			}
 			currentEvent = sseEvent{}
 			continue
@@ -641,8 +749,7 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 
 	// Process any remaining event.
 	if currentEvent.Event != "" {
-		p.processSSEEvent(currentEvent, &fullContent, &toolCalls, &currentToolCall,
-			&currentToolInput, &usage, &model, &finishReason, &turnID, &chunkIndex)
+		p.processSSEEvent(currentEvent, st)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -651,49 +758,49 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 
 	// Build final usage.
 	finalUsage := events.Usage{
-		PromptTokens:     usage.InputTokens,
-		CompletionTokens: usage.OutputTokens,
-		CachedTokens:     usage.CacheReadInputTokens,
-		CacheWriteTokens: usage.CacheCreationInputTokens,
-		TotalTokens: usage.InputTokens + usage.OutputTokens +
-			usage.CacheReadInputTokens + usage.CacheCreationInputTokens,
+		PromptTokens:     st.usage.InputTokens,
+		CompletionTokens: st.usage.OutputTokens,
+		CachedTokens:     st.usage.CacheReadInputTokens,
+		CacheWriteTokens: st.usage.CacheCreationInputTokens,
+		TotalTokens: st.usage.InputTokens + st.usage.OutputTokens +
+			st.usage.CacheReadInputTokens + st.usage.CacheCreationInputTokens,
 	}
 
 	// Emit stream end.
 	_ = p.bus.Emit("llm.stream.end", events.StreamEnd{
-		TurnID:       turnID,
-		FinishReason: finishReason,
+		TurnID:       st.turnID,
+		FinishReason: st.finishReason,
 		Usage:        finalUsage,
 	})
 
-	// Also emit the complete llm.response for downstream consumers.
+	// Also emit the complete llm.response for downstream consumers. Merge
+	// passthrough request metadata with thinking_blocks captured from the
+	// stream — round-trip preservation requires both to coexist.
 	p.mu.Lock()
 	meta := p.currentRequestMeta
 	p.mu.Unlock()
 
+	respMeta := meta
+	if len(st.thinkingBlocks) > 0 {
+		respMeta = make(map[string]any, len(meta)+1)
+		for k, v := range meta {
+			respMeta[k] = v
+		}
+		respMeta["thinking_blocks"] = st.thinkingBlocks
+	}
+
 	_ = p.bus.Emit("llm.response", events.LLMResponse{
-		Content:      fullContent.String(),
-		ToolCalls:    toolCalls,
+		Content:      st.fullContent.String(),
+		ToolCalls:    st.toolCalls,
 		Usage:        finalUsage,
-		CostUSD:      p.costForModel(model, finalUsage),
-		Model:        model,
-		FinishReason: finishReason,
-		Metadata:     meta,
+		CostUSD:      p.costForModel(st.model, finalUsage),
+		Model:        st.model,
+		FinishReason: st.finishReason,
+		Metadata:     respMeta,
 	})
 }
 
-func (p *Plugin) processSSEEvent(
-	sse sseEvent,
-	fullContent *strings.Builder,
-	toolCalls *[]events.ToolCallRequest,
-	currentToolCall **events.ToolCallRequest,
-	currentToolInput *strings.Builder,
-	usage *apiUsage,
-	model *string,
-	finishReason *string,
-	turnID *string,
-	chunkIndex *int,
-) {
+func (p *Plugin) processSSEEvent(sse sseEvent, st *streamState) {
 	switch sse.Event {
 	case "message_start":
 		var data struct {
@@ -704,11 +811,11 @@ func (p *Plugin) processSSEEvent(
 			} `json:"message"`
 		}
 		if json.Unmarshal([]byte(sse.Data), &data) == nil {
-			*turnID = data.Message.ID
-			*model = data.Message.Model
-			usage.InputTokens = data.Message.Usage.InputTokens
-			usage.CacheCreationInputTokens = data.Message.Usage.CacheCreationInputTokens
-			usage.CacheReadInputTokens = data.Message.Usage.CacheReadInputTokens
+			st.turnID = data.Message.ID
+			st.model = data.Message.Model
+			st.usage.InputTokens = data.Message.Usage.InputTokens
+			st.usage.CacheCreationInputTokens = data.Message.Usage.CacheCreationInputTokens
+			st.usage.CacheReadInputTokens = data.Message.Usage.CacheReadInputTokens
 		}
 
 	case "content_block_start":
@@ -717,12 +824,27 @@ func (p *Plugin) processSSEEvent(
 			ContentBlock apiContentBlock `json:"content_block"`
 		}
 		if json.Unmarshal([]byte(sse.Data), &data) == nil {
-			if data.ContentBlock.Type == "tool_use" {
-				*currentToolCall = &events.ToolCallRequest{
+			switch data.ContentBlock.Type {
+			case "tool_use":
+				st.currentToolCall = &events.ToolCallRequest{
 					ID:   data.ContentBlock.ID,
 					Name: data.ContentBlock.Name,
 				}
-				currentToolInput.Reset()
+				st.currentToolInput.Reset()
+			case "thinking", "redacted_thinking":
+				st.thinkingBlockType = data.ContentBlock.Type
+				st.thinkingBuilder.Reset()
+				st.thinkingSignature = ""
+				// redacted_thinking arrives with its full encrypted payload on
+				// content_block_start (no deltas); thinking gets streamed via
+				// thinking_delta + signature_delta until content_block_stop.
+				st.thinkingData = data.ContentBlock.Data
+				if data.ContentBlock.Thinking != "" {
+					st.thinkingBuilder.WriteString(data.ContentBlock.Thinking)
+				}
+				if data.ContentBlock.Signature != "" {
+					st.thinkingSignature = data.ContentBlock.Signature
+				}
 			}
 		}
 
@@ -733,54 +855,94 @@ func (p *Plugin) processSSEEvent(
 				Type        string `json:"type"`
 				Text        string `json:"text,omitempty"`
 				PartialJSON string `json:"partial_json,omitempty"`
+				Thinking    string `json:"thinking,omitempty"`
+				Signature   string `json:"signature,omitempty"`
 			} `json:"delta"`
 		}
 		if json.Unmarshal([]byte(sse.Data), &data) == nil {
 			switch data.Delta.Type {
 			case "text_delta":
-				fullContent.WriteString(data.Delta.Text)
+				st.fullContent.WriteString(data.Delta.Text)
 				_ = p.bus.Emit("llm.stream.chunk", events.StreamChunk{
 					Content: data.Delta.Text,
-					Index:   *chunkIndex,
-					TurnID:  *turnID,
+					Index:   st.chunkIndex,
+					TurnID:  st.turnID,
 				})
-				*chunkIndex++
+				st.chunkIndex++
+
+			case "thinking_delta":
+				st.thinkingBuilder.WriteString(data.Delta.Thinking)
+				if p.thinking.IncludeThoughts && data.Delta.Thinking != "" {
+					_ = p.bus.Emit("thinking.step", events.ThinkingStep{
+						TurnID:    st.turnID,
+						Source:    pluginID,
+						Content:   data.Delta.Thinking,
+						Phase:     "reasoning",
+						Timestamp: time.Now(),
+						Index:     st.thinkingIdx,
+					})
+					st.thinkingIdx++
+				}
+
+			case "signature_delta":
+				// Signatures aren't chunked semantically (a single delta
+				// carries the full signature for the active block) but
+				// concatenate defensively in case Anthropic ever splits them.
+				st.thinkingSignature += data.Delta.Signature
 
 			case "input_json_delta":
-				if *currentToolCall != nil {
-					currentToolInput.WriteString(data.Delta.PartialJSON)
+				if st.currentToolCall != nil {
+					st.currentToolInput.WriteString(data.Delta.PartialJSON)
 					// Stream structured output tool input as content chunks.
-					if (*currentToolCall).Name == "_structured_output" {
+					if st.currentToolCall.Name == "_structured_output" {
 						_ = p.bus.Emit("llm.stream.chunk", events.StreamChunk{
 							Content: data.Delta.PartialJSON,
-							Index:   *chunkIndex,
-							TurnID:  *turnID,
+							Index:   st.chunkIndex,
+							TurnID:  st.turnID,
 						})
-						*chunkIndex++
+						st.chunkIndex++
 					}
 				}
 			}
 		}
 
 	case "content_block_stop":
-		if *currentToolCall != nil {
-			(*currentToolCall).Arguments = currentToolInput.String()
+		switch {
+		case st.currentToolCall != nil:
+			st.currentToolCall.Arguments = st.currentToolInput.String()
 
-			if (*currentToolCall).Name == "_structured_output" {
+			if st.currentToolCall.Name == "_structured_output" {
 				// Unwrap synthetic tool — accumulate into content, not tool calls.
-				fullContent.WriteString(currentToolInput.String())
+				st.fullContent.WriteString(st.currentToolInput.String())
 			} else {
-				*toolCalls = append(*toolCalls, **currentToolCall)
+				st.toolCalls = append(st.toolCalls, *st.currentToolCall)
 				_ = p.bus.Emit("llm.stream.chunk", events.StreamChunk{
-					ToolCall: *currentToolCall,
-					Index:    *chunkIndex,
-					TurnID:   *turnID,
+					ToolCall: st.currentToolCall,
+					Index:    st.chunkIndex,
+					TurnID:   st.turnID,
 				})
-				*chunkIndex++
+				st.chunkIndex++
 			}
 
-			*currentToolCall = nil
-			currentToolInput.Reset()
+			st.currentToolCall = nil
+			st.currentToolInput.Reset()
+
+		case st.thinkingBlockType != "":
+			// Finalize the active thinking block. We retain the signature
+			// verbatim — Anthropic rejects HTTP 400 on the next assistant
+			// turn (after a tool result) if it's missing or modified.
+			block := map[string]any{"type": st.thinkingBlockType}
+			if st.thinkingBlockType == "redacted_thinking" {
+				block["data"] = st.thinkingData
+			} else {
+				block["thinking"] = st.thinkingBuilder.String()
+				block["signature"] = st.thinkingSignature
+			}
+			st.thinkingBlocks = append(st.thinkingBlocks, block)
+			st.thinkingBlockType = ""
+			st.thinkingBuilder.Reset()
+			st.thinkingSignature = ""
+			st.thinkingData = ""
 		}
 
 	case "message_delta":
@@ -791,18 +953,18 @@ func (p *Plugin) processSSEEvent(
 			Usage apiUsage `json:"usage"`
 		}
 		if json.Unmarshal([]byte(sse.Data), &data) == nil {
-			*finishReason = data.Delta.StopReason
+			st.finishReason = data.Delta.StopReason
 			if data.Usage.OutputTokens > 0 {
-				usage.OutputTokens = data.Usage.OutputTokens
+				st.usage.OutputTokens = data.Usage.OutputTokens
 			}
 			// message_delta may carry an updated cache snapshot (Anthropic
 			// sometimes finalizes counts here). Prefer the larger value so
 			// we don't regress message_start totals.
-			if data.Usage.CacheCreationInputTokens > usage.CacheCreationInputTokens {
-				usage.CacheCreationInputTokens = data.Usage.CacheCreationInputTokens
+			if data.Usage.CacheCreationInputTokens > st.usage.CacheCreationInputTokens {
+				st.usage.CacheCreationInputTokens = data.Usage.CacheCreationInputTokens
 			}
-			if data.Usage.CacheReadInputTokens > usage.CacheReadInputTokens {
-				usage.CacheReadInputTokens = data.Usage.CacheReadInputTokens
+			if data.Usage.CacheReadInputTokens > st.usage.CacheReadInputTokens {
+				st.usage.CacheReadInputTokens = data.Usage.CacheReadInputTokens
 			}
 		}
 

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -26,9 +26,16 @@ const (
 )
 
 // modelPricing holds per-model token rates in USD per million tokens.
+//
+// Cache rates are optional: when zero, calculateCost falls back to derived
+// multiples of InputPerMillion (read = 0.10×, write_5m = 1.25×, write_1h = 2.0×)
+// per Anthropic's published cache pricing.
 type modelPricing struct {
-	InputPerMillion  float64
-	OutputPerMillion float64
+	InputPerMillion        float64
+	OutputPerMillion       float64
+	CacheReadPerMillion    float64 // 0 → InputPerMillion * 0.10
+	CacheWrite5mPerMillion float64 // 0 → InputPerMillion * 1.25
+	CacheWrite1hPerMillion float64 // 0 → InputPerMillion * 2.0
 }
 
 // defaultPricing is the embedded fallback pricing table. Updated via patch
@@ -44,8 +51,25 @@ var defaultPricing = map[string]modelPricing{
 }
 
 // calculateCost computes the USD cost for a single LLM call.
+//
+// Anthropic's `input_tokens` already excludes cache-creation and cache-read
+// portions, so usage.PromptTokens is the cache-miss (plain input) count and
+// CachedTokens / CacheWriteTokens are billed separately at their own rates.
+//
+// We currently treat all CacheWriteTokens as 5-minute-TTL writes; per-request
+// TTL selection (cf. plan 01) will route writes to the 1h rate when needed.
 func calculateCost(usage events.Usage, rates modelPricing) float64 {
+	cacheReadRate := rates.CacheReadPerMillion
+	if cacheReadRate == 0 {
+		cacheReadRate = rates.InputPerMillion * 0.10
+	}
+	cacheWriteRate := rates.CacheWrite5mPerMillion
+	if cacheWriteRate == 0 {
+		cacheWriteRate = rates.InputPerMillion * 1.25
+	}
 	return float64(usage.PromptTokens)/1_000_000*rates.InputPerMillion +
+		float64(usage.CacheWriteTokens)/1_000_000*cacheWriteRate +
+		float64(usage.CachedTokens)/1_000_000*cacheReadRate +
 		float64(usage.CompletionTokens)/1_000_000*rates.OutputPerMillion
 }
 
@@ -486,8 +510,10 @@ type apiContentBlock struct {
 }
 
 type apiUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }
 
 func (p *Plugin) handleSyncResponse(body io.Reader) {
@@ -534,7 +560,10 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 	usage := events.Usage{
 		PromptTokens:     apiResp.Usage.InputTokens,
 		CompletionTokens: apiResp.Usage.OutputTokens,
-		TotalTokens:      apiResp.Usage.InputTokens + apiResp.Usage.OutputTokens,
+		CachedTokens:     apiResp.Usage.CacheReadInputTokens,
+		CacheWriteTokens: apiResp.Usage.CacheCreationInputTokens,
+		TotalTokens: apiResp.Usage.InputTokens + apiResp.Usage.OutputTokens +
+			apiResp.Usage.CacheReadInputTokens + apiResp.Usage.CacheCreationInputTokens,
 	}
 
 	return events.LLMResponse{
@@ -603,7 +632,10 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 	finalUsage := events.Usage{
 		PromptTokens:     usage.InputTokens,
 		CompletionTokens: usage.OutputTokens,
-		TotalTokens:      usage.InputTokens + usage.OutputTokens,
+		CachedTokens:     usage.CacheReadInputTokens,
+		CacheWriteTokens: usage.CacheCreationInputTokens,
+		TotalTokens: usage.InputTokens + usage.OutputTokens +
+			usage.CacheReadInputTokens + usage.CacheCreationInputTokens,
 	}
 
 	// Emit stream end.
@@ -654,6 +686,8 @@ func (p *Plugin) processSSEEvent(
 			*turnID = data.Message.ID
 			*model = data.Message.Model
 			usage.InputTokens = data.Message.Usage.InputTokens
+			usage.CacheCreationInputTokens = data.Message.Usage.CacheCreationInputTokens
+			usage.CacheReadInputTokens = data.Message.Usage.CacheReadInputTokens
 		}
 
 	case "content_block_start":
@@ -740,6 +774,15 @@ func (p *Plugin) processSSEEvent(
 			if data.Usage.OutputTokens > 0 {
 				usage.OutputTokens = data.Usage.OutputTokens
 			}
+			// message_delta may carry an updated cache snapshot (Anthropic
+			// sometimes finalizes counts here). Prefer the larger value so
+			// we don't regress message_start totals.
+			if data.Usage.CacheCreationInputTokens > usage.CacheCreationInputTokens {
+				usage.CacheCreationInputTokens = data.Usage.CacheCreationInputTokens
+			}
+			if data.Usage.CacheReadInputTokens > usage.CacheReadInputTokens {
+				usage.CacheReadInputTokens = data.Usage.CacheReadInputTokens
+			}
 		}
 
 	case "message_stop":
@@ -768,6 +811,12 @@ func (p *Plugin) processSSEEvent(
 //	  claude-sonnet-4-6-20250514:
 //	    input_per_million: 3.0
 //	    output_per_million: 15.0
+//	    cache_read_per_million: 0.30
+//	    cache_write_5m_per_million: 3.75
+//	    cache_write_1h_per_million: 6.0
+//
+// Cache rates are optional; calculateCost derives them from input rate when
+// unset (read = 0.10×, write 5m = 1.25×, write 1h = 2.0×).
 func parsePricingConfig(cfg map[string]any) map[string]modelPricing {
 	merged := make(map[string]modelPricing, len(defaultPricing))
 	for k, v := range defaultPricing {
@@ -790,6 +839,15 @@ func parsePricingConfig(cfg map[string]any) map[string]modelPricing {
 		}
 		if v, ok := entry["output_per_million"].(float64); ok {
 			p.OutputPerMillion = v
+		}
+		if v, ok := entry["cache_read_per_million"].(float64); ok {
+			p.CacheReadPerMillion = v
+		}
+		if v, ok := entry["cache_write_5m_per_million"].(float64); ok {
+			p.CacheWrite5mPerMillion = v
+		}
+		if v, ok := entry["cache_write_1h_per_million"].(float64); ok {
+			p.CacheWrite1hPerMillion = v
 		}
 		merged[model] = p
 	}

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -22,7 +21,6 @@ const (
 	pluginID   = "nexus.llm.anthropic"
 	pluginName = "Anthropic LLM Provider"
 	version    = "0.1.0"
-	apiURL     = "https://api.anthropic.com/v1/messages"
 )
 
 // modelPricing holds per-model token rates in USD per million tokens.
@@ -80,7 +78,7 @@ type Plugin struct {
 	models  *engine.ModelRegistry
 	session *engine.SessionWorkspace
 
-	apiKey     string
+	auth       *authState
 	client     *http.Client
 	prompts    *engine.PromptRegistry
 	unsubs     []func()
@@ -126,19 +124,16 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.debug = debug
 	}
 
-	// Read API key: direct config value takes priority over env var.
-	if key, ok := ctx.Config["api_key"].(string); ok && key != "" {
-		p.apiKey = key
-	} else {
-		apiKeyEnv, _ := ctx.Config["api_key_env"].(string)
-		if apiKeyEnv == "" {
-			apiKeyEnv = "ANTHROPIC_API_KEY"
-		}
-		p.apiKey = os.Getenv(apiKeyEnv)
+	// Resolve auth mode: api_key (default), bedrock, or vertex. Backwards
+	// compatible with the legacy api_key / api_key_env top-level keys; the
+	// authState struct centralizes URL construction, body version markers,
+	// and per-request signing.
+	auth, err := parseAuthConfig(ctx.Config)
+	if err != nil {
+		return err
 	}
-	if p.apiKey == "" {
-		return fmt.Errorf("anthropic: no API key configured (set api_key in config or %s env var)", "ANTHROPIC_API_KEY")
-	}
+	p.auth = auth
+	p.logger.Info("anthropic auth resolved", "mode", string(auth.mode))
 
 	p.client = &http.Client{
 		Timeout: 5 * time.Minute,
@@ -352,17 +347,28 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 	p.cancelFunc = cancel
 	p.mu.Unlock()
 
+	requestURL := p.auth.buildURL(model, req.Stream)
+
 	makeReq := func() (*http.Request, error) {
-		httpReq, err := http.NewRequestWithContext(reqCtx, "POST", apiURL, bytes.NewReader(jsonBody))
+		httpReq, err := http.NewRequestWithContext(reqCtx, "POST", requestURL, bytes.NewReader(jsonBody))
 		if err != nil {
 			return nil, err
 		}
-		httpReq.Header.Set("x-api-key", p.apiKey)
-		httpReq.Header.Set("anthropic-version", "2023-06-01")
 		httpReq.Header.Set("content-type", "application/json")
+		// applyAuth attaches the right credential headers per mode (and signs
+		// the body for Bedrock SigV4). Bedrock signatures depend on the
+		// timestamp, so the closure recomputes them on every retry.
+		if err := p.auth.applyAuth(reqCtx, httpReq, jsonBody, p.client); err != nil {
+			return nil, err
+		}
 		// Beta-flag aggregation merges the plugin's standing flags (cache 1h,
 		// files API, pdf_beta) with any per-request flags stamped by
 		// server-tool plugins via req.Metadata["_anthropic_beta_headers"].
+		// Sent verbatim regardless of mode — Bedrock and Vertex gate beta
+		// features independently of the direct API, so a flag this plugin
+		// considers active may be rejected (or silently ignored) by the
+		// chosen backend. Surface those mismatches as explicit 400s rather
+		// than trying to predict per-feature parity here.
 		if flags := p.betaFlags(req.Metadata); flags != "" {
 			httpReq.Header.Set("anthropic-beta", flags)
 		}
@@ -526,6 +532,18 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 	// Mark cacheable prefix segments (system, last tool, leading user msgs) per
 	// configured policy. No-op when caching is disabled.
 	applyCacheControl(body, p.cache, p.logger)
+
+	// Bedrock/Vertex want anthropic_version inside the body (the direct API
+	// uses an HTTP header instead). Bedrock additionally rejects bodies that
+	// carry the model field — the model id lives in the URL path there.
+	if p.auth != nil {
+		if v := p.auth.bodyVersionField(); v != "" {
+			body["anthropic_version"] = v
+		}
+		if p.auth.stripModelFromBody() {
+			delete(body, "model")
+		}
+	}
 
 	return body
 }

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -760,7 +760,7 @@ func (p *Plugin) handleSyncResponse(body io.Reader) {
 	p.mu.Unlock()
 	if resp.Metadata == nil {
 		resp.Metadata = meta
-	} else if meta != nil {
+	} else {
 		for k, v := range meta {
 			resp.Metadata[k] = v
 		}

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -360,25 +360,11 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 		httpReq.Header.Set("x-api-key", p.apiKey)
 		httpReq.Header.Set("anthropic-version", "2023-06-01")
 		httpReq.Header.Set("content-type", "application/json")
-		// Beta-flag aggregation. Plan 06 will hoist this into a metadata-driven
-		// builder; for now it joins the small set of flags the plugin emits.
-		var betaFlags []string
-		if p.cache.Enabled && p.cache.TTL == "1h" {
-			betaFlags = append(betaFlags, "extended-cache-ttl-2025-04-11")
-		}
-		if p.multimodal.PDFBeta {
-			betaFlags = append(betaFlags, "pdfs-2024-09-25")
-		}
-		// Always send the files beta header when the feature is enabled —
-		// Anthropic accepts it regardless of whether a file_id is referenced
-		// on this particular request, and tracking per-request use would
-		// require threading state through buildRequestBody for a one-byte
-		// header savings that doesn't matter.
-		if p.files.Enabled {
-			betaFlags = append(betaFlags, filesAPIBetaHeader)
-		}
-		if len(betaFlags) > 0 {
-			httpReq.Header.Set("anthropic-beta", strings.Join(betaFlags, ","))
+		// Beta-flag aggregation merges the plugin's standing flags (cache 1h,
+		// files API, pdf_beta) with any per-request flags stamped by
+		// server-tool plugins via req.Metadata["_anthropic_beta_headers"].
+		if flags := p.betaFlags(req.Metadata); flags != "" {
+			httpReq.Header.Set("anthropic-beta", flags)
 		}
 		return httpReq, nil
 	}
@@ -505,6 +491,13 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 		}
 		body["tools"] = tools
 	}
+
+	// Server-tool injection hook. Plugins like nexus.tool.anthropic_native.bash
+	// stamp `req.Metadata["_anthropic_extra_tools"]` with already-Anthropic-shaped
+	// tool entries (e.g. {"type":"bash_20250124","name":"bash"}). They're
+	// passed through verbatim — no schema conversion. Coexists with both
+	// client-defined tools and the structured-output synthetic tool below.
+	p.appendExtraTools(body, req.Metadata)
 
 	// Structured output simulation via tool-use-as-schema.
 	// Inject synthetic tool and force tool choice to it.
@@ -666,6 +659,28 @@ type apiContentBlock struct {
 	// Native citations. Anthropic populates this on `text` blocks when the
 	// originating request included document blocks with citations enabled.
 	Citations []apiCitation `json:"citations,omitempty"`
+
+	// Server-side tool result blocks (e.g. `code_execution_tool_result`). These
+	// are tool _results_ embedded in the assistant message — Anthropic ran the
+	// tool server-side, so there's no client-side execution required. ToolUseID
+	// references the matching server-side tool_use ID; Content carries the
+	// inner result block (e.g. {"type":"code_execution_result","stdout":"…",
+	// "stderr":"…","return_code":0}) as raw JSON so we don't have to model
+	// every server-tool's inner shape exhaustively.
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+}
+
+// isServerToolResultBlock reports whether the block type is a server-side
+// tool result (currently only `code_execution_tool_result`, but Anthropic
+// will likely add more — keep this central so we surface them uniformly).
+func isServerToolResultBlock(blockType string) bool {
+	switch blockType {
+	case "code_execution_tool_result":
+		return true
+	default:
+		return false
+	}
 }
 
 type apiUsage struct {
@@ -709,9 +724,23 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 	var toolCalls []events.ToolCallRequest
 	var thinkingBlocks []map[string]any
 	var citations []events.Citation
+	var serverResults []map[string]any
 	thinkingIdx := 0
 
 	for _, block := range apiResp.Content {
+		if isServerToolResultBlock(block.Type) {
+			// Preserve content verbatim — downstream consumers (e.g. the
+			// per-server-tool plugins) decode the inner shape themselves so
+			// we don't have to track every Anthropic server tool's wire format
+			// here.
+			serverResults = append(serverResults, map[string]any{
+				"type":        block.Type,
+				"tool_use_id": block.ToolUseID,
+				"content":     json.RawMessage(block.Content),
+			})
+			continue
+		}
+
 		switch block.Type {
 		case "text":
 			content.WriteString(block.Text)
@@ -789,9 +818,13 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 		FinishReason: apiResp.StopReason,
 		Citations:    citations,
 	}
-	if len(thinkingBlocks) > 0 {
-		resp.Metadata = map[string]any{
-			"thinking_blocks": thinkingBlocks,
+	if len(thinkingBlocks) > 0 || len(serverResults) > 0 {
+		resp.Metadata = map[string]any{}
+		if len(thinkingBlocks) > 0 {
+			resp.Metadata["thinking_blocks"] = thinkingBlocks
+		}
+		if len(serverResults) > 0 {
+			resp.Metadata["server_tool_results"] = serverResults
 		}
 	}
 	return resp
@@ -831,6 +864,18 @@ type streamState struct {
 	// blocks via citations_delta deltas.
 	currentCitations []apiCitation
 	citations        []events.Citation
+
+	// Active server-side tool result block (e.g. code_execution_tool_result).
+	// serverToolBlockType is set when one is open, empty otherwise. Anthropic's
+	// streaming wire shape for these blocks is still in flux at the time of
+	// writing (the plugin parses defensively): content_block_start carries
+	// type + tool_use_id, deltas accumulate the inner content as raw JSON
+	// (likely via input_json_delta or a similarly-shaped delta), and
+	// content_block_stop finalizes the entry into serverToolResults.
+	serverToolBlockType string
+	serverToolUseID     string
+	serverToolBuffer    strings.Builder
+	serverToolResults   []map[string]any
 
 	usage        apiUsage
 	model        string
@@ -899,12 +944,17 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 	p.mu.Unlock()
 
 	respMeta := meta
-	if len(st.thinkingBlocks) > 0 {
-		respMeta = make(map[string]any, len(meta)+1)
+	if len(st.thinkingBlocks) > 0 || len(st.serverToolResults) > 0 {
+		respMeta = make(map[string]any, len(meta)+2)
 		for k, v := range meta {
 			respMeta[k] = v
 		}
-		respMeta["thinking_blocks"] = st.thinkingBlocks
+		if len(st.thinkingBlocks) > 0 {
+			respMeta["thinking_blocks"] = st.thinkingBlocks
+		}
+		if len(st.serverToolResults) > 0 {
+			respMeta["server_tool_results"] = st.serverToolResults
+		}
 	}
 
 	_ = p.bus.Emit("llm.response", events.LLMResponse{
@@ -943,14 +993,25 @@ func (p *Plugin) processSSEEvent(sse sseEvent, st *streamState) {
 			ContentBlock apiContentBlock `json:"content_block"`
 		}
 		if json.Unmarshal([]byte(sse.Data), &data) == nil {
-			switch data.ContentBlock.Type {
-			case "tool_use":
+			switch {
+			case data.ContentBlock.Type == "tool_use":
 				st.currentToolCall = &events.ToolCallRequest{
 					ID:   data.ContentBlock.ID,
 					Name: data.ContentBlock.Name,
 				}
 				st.currentToolInput.Reset()
-			case "thinking", "redacted_thinking":
+			case isServerToolResultBlock(data.ContentBlock.Type):
+				// Anthropic may include the full inner content on the
+				// content_block_start event itself, or stream it via deltas.
+				// Capture whatever's already present and let deltas append to
+				// the buffer until content_block_stop.
+				st.serverToolBlockType = data.ContentBlock.Type
+				st.serverToolUseID = data.ContentBlock.ToolUseID
+				st.serverToolBuffer.Reset()
+				if len(data.ContentBlock.Content) > 0 {
+					st.serverToolBuffer.Write(data.ContentBlock.Content)
+				}
+			case data.ContentBlock.Type == "thinking" || data.ContentBlock.Type == "redacted_thinking":
 				st.thinkingBlockType = data.ContentBlock.Type
 				st.thinkingBuilder.Reset()
 				st.thinkingSignature = ""
@@ -1017,7 +1078,8 @@ func (p *Plugin) processSSEEvent(sse sseEvent, st *streamState) {
 				st.thinkingSignature += data.Delta.Signature
 
 			case "input_json_delta":
-				if st.currentToolCall != nil {
+				switch {
+				case st.currentToolCall != nil:
 					st.currentToolInput.WriteString(data.Delta.PartialJSON)
 					// Stream structured output tool input as content chunks.
 					if st.currentToolCall.Name == "_structured_output" {
@@ -1028,6 +1090,12 @@ func (p *Plugin) processSSEEvent(sse sseEvent, st *streamState) {
 						})
 						st.chunkIndex++
 					}
+				case st.serverToolBlockType != "":
+					// Best-effort accumulation: Anthropic's exact streaming
+					// shape for server-tool result blocks is still in flux.
+					// We assume input_json_delta-style chunks until proven
+					// otherwise; the inner content is preserved verbatim.
+					st.serverToolBuffer.WriteString(data.Delta.PartialJSON)
 				}
 			}
 		}
@@ -1069,6 +1137,21 @@ func (p *Plugin) processSSEEvent(sse sseEvent, st *streamState) {
 			st.thinkingBuilder.Reset()
 			st.thinkingSignature = ""
 			st.thinkingData = ""
+
+		case st.serverToolBlockType != "":
+			// Finalize the server-side tool result block. Content is preserved
+			// as raw JSON for downstream consumers (per-server-tool plugins
+			// decode it). The buffer holds whatever shape Anthropic streamed
+			// — we don't validate inner fields here.
+			buf := []byte(st.serverToolBuffer.String())
+			st.serverToolResults = append(st.serverToolResults, map[string]any{
+				"type":        st.serverToolBlockType,
+				"tool_use_id": st.serverToolUseID,
+				"content":     json.RawMessage(buf),
+			})
+			st.serverToolBlockType = ""
+			st.serverToolUseID = ""
+			st.serverToolBuffer.Reset()
 
 		default:
 			// Text block (or any other non-tool, non-thinking block): flush

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -80,15 +80,16 @@ type Plugin struct {
 	models  *engine.ModelRegistry
 	session *engine.SessionWorkspace
 
-	apiKey   string
-	client   *http.Client
-	prompts  *engine.PromptRegistry
-	unsubs   []func()
-	debug    bool
-	retry    retryConfig
-	cache    cacheConfig
-	thinking thinkingConfig
-	pricing  map[string]modelPricing // merged: config overrides + embedded defaults
+	apiKey     string
+	client     *http.Client
+	prompts    *engine.PromptRegistry
+	unsubs     []func()
+	debug      bool
+	retry      retryConfig
+	cache      cacheConfig
+	thinking   thinkingConfig
+	multimodal multimodalConfig
+	pricing    map[string]modelPricing // merged: config overrides + embedded defaults
 
 	mu                 sync.Mutex
 	currentRequestMeta map[string]any
@@ -155,6 +156,11 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 			"budget_tokens", p.thinking.BudgetTokens,
 			"include_thoughts", p.thinking.IncludeThoughts,
 		)
+	}
+
+	p.multimodal = parseMultimodalConfig(ctx.Config)
+	if p.multimodal.PDFBeta {
+		p.logger.Info("multimodal pdf_beta header enabled (pdfs-2024-09-25)")
 	}
 
 	p.retry = parseRetryConfig(ctx.Config)
@@ -302,11 +308,17 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 		httpReq.Header.Set("x-api-key", p.apiKey)
 		httpReq.Header.Set("anthropic-version", "2023-06-01")
 		httpReq.Header.Set("content-type", "application/json")
-		// 1h TTL caching is gated behind a beta header. Plan 06 will introduce
-		// a metadata-driven multi-header builder; for now this is the only
-		// beta flag the plugin emits, so a single Set is fine.
+		// Beta-flag aggregation. Plan 06 will hoist this into a metadata-driven
+		// builder; for now it joins the small set of flags the plugin emits.
+		var betaFlags []string
 		if p.cache.Enabled && p.cache.TTL == "1h" {
-			httpReq.Header.Set("anthropic-beta", "extended-cache-ttl-2025-04-11")
+			betaFlags = append(betaFlags, "extended-cache-ttl-2025-04-11")
+		}
+		if p.multimodal.PDFBeta {
+			betaFlags = append(betaFlags, "pdfs-2024-09-25")
+		}
+		if len(betaFlags) > 0 {
+			httpReq.Header.Set("anthropic-beta", strings.Join(betaFlags, ","))
 		}
 		return httpReq, nil
 	}
@@ -508,18 +520,48 @@ func (p *Plugin) convertMessage(msg events.Message) map[string]any {
 		}
 
 	case "tool":
+		// Anthropic accepts content blocks inside tool_result.content, so a
+		// tool that produced an image (e.g. a screenshot) can pass it inline.
+		// On error we log and fall back to the text Content.
+		var toolResultContent any = msg.Content
+		if len(msg.Parts) > 0 {
+			blocks, err := buildContentBlocks(msg)
+			if err != nil {
+				p.logger.Error("anthropic: dropping tool-result multimodal parts", "error", err)
+			} else {
+				toolResultContent = blocks
+			}
+		}
 		return map[string]any{
 			"role": "user",
 			"content": []map[string]any{
 				{
 					"type":        "tool_result",
 					"tool_use_id": msg.ToolCallID,
-					"content":     msg.Content,
+					"content":     toolResultContent,
 				},
 			},
 		}
 
 	case "user":
+		if len(msg.Parts) > 0 {
+			blocks, err := buildContentBlocks(msg)
+			if err != nil {
+				// Multimodal serialization failed (e.g. oversize image, audio
+				// part). Surface the failure via slog and fall back to the
+				// text-only path so the request still goes out — silently
+				// dropping is worse than a partial send the user can debug.
+				p.logger.Error("anthropic: dropping multimodal parts", "error", err)
+				return map[string]any{
+					"role":    "user",
+					"content": msg.Content,
+				}
+			}
+			return map[string]any{
+				"role":    "user",
+				"content": blocks,
+			}
+		}
 		return map[string]any{
 			"role":    "user",
 			"content": msg.Content,

--- a/plugins/providers/anthropic/plugin.go
+++ b/plugins/providers/anthropic/plugin.go
@@ -90,6 +90,7 @@ type Plugin struct {
 	thinking   thinkingConfig
 	multimodal multimodalConfig
 	files      filesConfig
+	citations  citationsConfig
 	pricing    map[string]modelPricing // merged: config overrides + embedded defaults
 
 	// filesAPIURL is the production endpoint by default; tests override.
@@ -167,6 +168,11 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.multimodal = parseMultimodalConfig(ctx.Config)
 	if p.multimodal.PDFBeta {
 		p.logger.Info("multimodal pdf_beta header enabled (pdfs-2024-09-25)")
+	}
+
+	p.citations = parseCitationsConfig(ctx.Config)
+	if p.citations.Enabled {
+		p.logger.Info("native citations enabled (document blocks will request citations)")
 	}
 
 	p.files = parseFilesConfig(ctx.Config)
@@ -579,7 +585,7 @@ func (p *Plugin) convertMessage(msg events.Message) map[string]any {
 		// On error we log and fall back to the text Content.
 		var toolResultContent any = msg.Content
 		if len(msg.Parts) > 0 {
-			blocks, err := buildContentBlocks(msg)
+			blocks, err := buildContentBlocks(msg, p.citations.Enabled)
 			if err != nil {
 				p.logger.Error("anthropic: dropping tool-result multimodal parts", "error", err)
 			} else {
@@ -599,7 +605,7 @@ func (p *Plugin) convertMessage(msg events.Message) map[string]any {
 
 	case "user":
 		if len(msg.Parts) > 0 {
-			blocks, err := buildContentBlocks(msg)
+			blocks, err := buildContentBlocks(msg, p.citations.Enabled)
 			if err != nil {
 				// Multimodal serialization failed (e.g. oversize image, audio
 				// part). Surface the failure via slog and fall back to the
@@ -656,6 +662,10 @@ type apiContentBlock struct {
 	Thinking  string `json:"thinking,omitempty"`
 	Signature string `json:"signature,omitempty"`
 	Data      string `json:"data,omitempty"`
+
+	// Native citations. Anthropic populates this on `text` blocks when the
+	// originating request included document blocks with citations enabled.
+	Citations []apiCitation `json:"citations,omitempty"`
 }
 
 type apiUsage struct {
@@ -698,12 +708,16 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 	var content strings.Builder
 	var toolCalls []events.ToolCallRequest
 	var thinkingBlocks []map[string]any
+	var citations []events.Citation
 	thinkingIdx := 0
 
 	for _, block := range apiResp.Content {
 		switch block.Type {
 		case "text":
 			content.WriteString(block.Text)
+			for _, c := range block.Citations {
+				citations = append(citations, c.toEvent())
+			}
 
 		case "thinking":
 			// Preserve the block verbatim (with signature) so the next
@@ -773,6 +787,7 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 		CostUSD:      p.costForModel(apiResp.Model, usage),
 		Model:        apiResp.Model,
 		FinishReason: apiResp.StopReason,
+		Citations:    citations,
 	}
 	if len(thinkingBlocks) > 0 {
 		resp.Metadata = map[string]any{
@@ -809,6 +824,13 @@ type streamState struct {
 	thinkingData      string
 	thinkingIdx       int
 	thinkingBlocks    []map[string]any
+
+	// Citations accumulated during the active text block (flushed to
+	// citations on content_block_stop) and the running list across all
+	// blocks for the response. Anthropic emits citations only on `text`
+	// blocks via citations_delta deltas.
+	currentCitations []apiCitation
+	citations        []events.Citation
 
 	usage        apiUsage
 	model        string
@@ -892,6 +914,7 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		CostUSD:      p.costForModel(st.model, finalUsage),
 		Model:        st.model,
 		FinishReason: st.finishReason,
+		Citations:    st.citations,
 		Metadata:     respMeta,
 	})
 }
@@ -948,11 +971,12 @@ func (p *Plugin) processSSEEvent(sse sseEvent, st *streamState) {
 		var data struct {
 			Index int `json:"index"`
 			Delta struct {
-				Type        string `json:"type"`
-				Text        string `json:"text,omitempty"`
-				PartialJSON string `json:"partial_json,omitempty"`
-				Thinking    string `json:"thinking,omitempty"`
-				Signature   string `json:"signature,omitempty"`
+				Type        string      `json:"type"`
+				Text        string      `json:"text,omitempty"`
+				PartialJSON string      `json:"partial_json,omitempty"`
+				Thinking    string      `json:"thinking,omitempty"`
+				Signature   string      `json:"signature,omitempty"`
+				Citation    apiCitation `json:"citation,omitempty"`
 			} `json:"delta"`
 		}
 		if json.Unmarshal([]byte(sse.Data), &data) == nil {
@@ -965,6 +989,12 @@ func (p *Plugin) processSSEEvent(sse sseEvent, st *streamState) {
 					TurnID:  st.turnID,
 				})
 				st.chunkIndex++
+
+			case "citations_delta":
+				// Accumulate per-block; flushed into st.citations at
+				// content_block_stop so ordering across multiple text
+				// blocks is preserved.
+				st.currentCitations = append(st.currentCitations, data.Delta.Citation)
 
 			case "thinking_delta":
 				st.thinkingBuilder.WriteString(data.Delta.Thinking)
@@ -1039,6 +1069,16 @@ func (p *Plugin) processSSEEvent(sse sseEvent, st *streamState) {
 			st.thinkingBuilder.Reset()
 			st.thinkingSignature = ""
 			st.thinkingData = ""
+
+		default:
+			// Text block (or any other non-tool, non-thinking block): flush
+			// any citations accumulated during its content_block_delta runs.
+			if len(st.currentCitations) > 0 {
+				for _, c := range st.currentCitations {
+					st.citations = append(st.citations, c.toEvent())
+				}
+				st.currentCitations = nil
+			}
 		}
 
 	case "message_delta":

--- a/plugins/providers/anthropic/server_tools_test.go
+++ b/plugins/providers/anthropic/server_tools_test.go
@@ -1,0 +1,310 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestBetaFlags_StandingOnly checks that the helper joins standing plugin
+// flags (cache 1h, files API, pdf_beta) without any per-request additions.
+// The order is deterministic: cache → files → pdf_beta.
+func TestBetaFlags_StandingOnly(t *testing.T) {
+	p := &Plugin{
+		logger: silentLogger(),
+		cache:  cacheConfig{Enabled: true, TTL: "1h"},
+		files:  filesConfig{Enabled: true},
+		multimodal: multimodalConfig{
+			PDFBeta: true,
+		},
+	}
+
+	got := p.betaFlags(nil)
+	want := "extended-cache-ttl-2025-04-11," + filesAPIBetaHeader + ",pdfs-2024-09-25"
+	if got != want {
+		t.Errorf("betaFlags(nil) = %q, want %q", got, want)
+	}
+}
+
+// TestBetaFlags_MetadataOnly checks the per-request additions path with no
+// standing flags active.
+func TestBetaFlags_MetadataOnly(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+
+	meta := map[string]any{
+		"_anthropic_beta_headers": []string{
+			"computer-use-2025-01-24",
+			"code-execution-2025-05-22",
+		},
+	}
+	got := p.betaFlags(meta)
+	want := "computer-use-2025-01-24,code-execution-2025-05-22"
+	if got != want {
+		t.Errorf("betaFlags(meta) = %q, want %q", got, want)
+	}
+}
+
+// TestBetaFlags_BothMerged covers the production case: the plugin has
+// standing flags and a server-tool plugin contributes per-request ones.
+// Standing flags lead, additions follow.
+func TestBetaFlags_BothMerged(t *testing.T) {
+	p := &Plugin{
+		logger: silentLogger(),
+		files:  filesConfig{Enabled: true},
+	}
+	meta := map[string]any{
+		"_anthropic_beta_headers": []string{"code-execution-2025-05-22"},
+	}
+
+	got := p.betaFlags(meta)
+	want := filesAPIBetaHeader + ",code-execution-2025-05-22"
+	if got != want {
+		t.Errorf("betaFlags = %q, want %q", got, want)
+	}
+}
+
+// TestBetaFlags_Deduplicates checks that a flag appearing as both a standing
+// flag and a per-request flag (or twice in the per-request list) only emits
+// once. Duplicates would inflate the header value silently.
+func TestBetaFlags_Deduplicates(t *testing.T) {
+	p := &Plugin{
+		logger: silentLogger(),
+		files:  filesConfig{Enabled: true},
+	}
+	meta := map[string]any{
+		"_anthropic_beta_headers": []string{
+			filesAPIBetaHeader, // duplicate of the standing files flag
+			"code-execution-2025-05-22",
+			"code-execution-2025-05-22", // duplicate of the previous
+		},
+	}
+
+	got := p.betaFlags(meta)
+	want := filesAPIBetaHeader + ",code-execution-2025-05-22"
+	if got != want {
+		t.Errorf("betaFlags = %q, want %q", got, want)
+	}
+}
+
+// TestBetaFlags_Empty: no standing, no metadata → empty string so callers
+// can omit the header entirely.
+func TestBetaFlags_Empty(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+	if got := p.betaFlags(nil); got != "" {
+		t.Errorf("betaFlags(nil) = %q, want \"\"", got)
+	}
+	if got := p.betaFlags(map[string]any{}); got != "" {
+		t.Errorf("betaFlags(empty) = %q, want \"\"", got)
+	}
+}
+
+// TestBetaFlags_AnyTyped covers the post-JSON-unmarshal path where the
+// metadata array decodes as []any of strings rather than []string.
+func TestBetaFlags_AnyTyped(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+
+	meta := map[string]any{
+		"_anthropic_beta_headers": []any{
+			"bash-2025-01-24",
+			"text-editor-2025-07-28",
+			42, // non-string element should be silently skipped
+		},
+	}
+	got := p.betaFlags(meta)
+	want := "bash-2025-01-24,text-editor-2025-07-28"
+	if got != want {
+		t.Errorf("betaFlags = %q, want %q", got, want)
+	}
+}
+
+// TestAppendExtraTools_Typed verifies the in-process []map[string]any path
+// — what server-tool plugins write directly when they construct request
+// metadata in Go code.
+func TestAppendExtraTools_Typed(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+
+	body := map[string]any{
+		"tools": []map[string]any{
+			{"name": "client_tool", "description": "x", "input_schema": map[string]any{}},
+		},
+	}
+	meta := map[string]any{
+		"_anthropic_extra_tools": []map[string]any{
+			{"type": "bash_20250124", "name": "bash"},
+			{"type": "text_editor_20250728", "name": "str_replace_based_edit_tool"},
+		},
+	}
+
+	p.appendExtraTools(body, meta)
+
+	tools, ok := body["tools"].([]map[string]any)
+	if !ok {
+		t.Fatalf("body[\"tools\"] = %T, want []map[string]any", body["tools"])
+	}
+	if len(tools) != 3 {
+		t.Fatalf("tools len = %d, want 3", len(tools))
+	}
+	if tools[1]["type"] != "bash_20250124" {
+		t.Errorf("tools[1][type] = %v, want bash_20250124", tools[1]["type"])
+	}
+	if tools[2]["name"] != "str_replace_based_edit_tool" {
+		t.Errorf("tools[2][name] = %v, want str_replace_based_edit_tool", tools[2]["name"])
+	}
+}
+
+// TestAppendExtraTools_AnyTyped covers the post-JSON case: metadata round-
+// tripped through json.Marshal/Unmarshal yields []any of map[string]any
+// elements rather than the typed slice.
+func TestAppendExtraTools_AnyTyped(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+
+	body := map[string]any{}
+	meta := map[string]any{
+		"_anthropic_extra_tools": []any{
+			map[string]any{"type": "code_execution_20250522", "name": "code_execution"},
+		},
+	}
+
+	p.appendExtraTools(body, meta)
+
+	tools, ok := body["tools"].([]map[string]any)
+	if !ok {
+		t.Fatalf("body[\"tools\"] = %T, want []map[string]any", body["tools"])
+	}
+	if len(tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(tools))
+	}
+	if tools[0]["type"] != "code_execution_20250522" {
+		t.Errorf("tools[0][type] = %v, want code_execution_20250522", tools[0]["type"])
+	}
+}
+
+// TestAppendExtraTools_MixedTypes confirms non-map elements in the []any
+// case are skipped and a warn log is recorded so operators can debug.
+func TestAppendExtraTools_MixedTypes(t *testing.T) {
+	logBuf := new(bytes.Buffer)
+	p := &Plugin{
+		logger: slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+
+	body := map[string]any{}
+	meta := map[string]any{
+		"_anthropic_extra_tools": []any{
+			"this-is-not-a-map",
+			map[string]any{"type": "bash_20250124", "name": "bash"},
+			42,
+		},
+	}
+
+	p.appendExtraTools(body, meta)
+
+	tools, ok := body["tools"].([]map[string]any)
+	if !ok {
+		t.Fatalf("body[\"tools\"] = %T, want []map[string]any", body["tools"])
+	}
+	if len(tools) != 1 {
+		t.Fatalf("tools len = %d, want 1 (only the map should be appended)", len(tools))
+	}
+	if !strings.Contains(logBuf.String(), "skipping non-map entry") {
+		t.Errorf("expected warn log for non-map entries; got: %s", logBuf.String())
+	}
+}
+
+// TestAppendExtraTools_Absent verifies the no-op path: nothing in metadata,
+// so body[\"tools\"] stays untouched.
+func TestAppendExtraTools_Absent(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+
+	body := map[string]any{
+		"tools": []map[string]any{
+			{"name": "client_tool", "description": "x", "input_schema": map[string]any{}},
+		},
+	}
+	p.appendExtraTools(body, nil)
+	p.appendExtraTools(body, map[string]any{})
+
+	tools := body["tools"].([]map[string]any)
+	if len(tools) != 1 {
+		t.Errorf("tools len = %d, want 1 (untouched)", len(tools))
+	}
+}
+
+// TestConvertAPIResponse_CodeExecutionToolResult verifies that a sync
+// response containing a code_execution_tool_result block lands on the
+// response Metadata as a server_tool_results entry, with the inner content
+// preserved verbatim (json.RawMessage) so per-server-tool plugins can decode
+// it without us having to model every wire shape.
+func TestConvertAPIResponse_CodeExecutionToolResult(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+
+	innerContent := `{"type":"code_execution_result","stdout":"hello\n","stderr":"","return_code":0}`
+	apiResp := apiResponse{
+		ID:    "msg_test",
+		Model: "claude-sonnet-4-5-20250514",
+		Content: []apiContentBlock{
+			{Type: "text", Text: "Running:"},
+			{
+				Type:      "code_execution_tool_result",
+				ToolUseID: "srvtoolu_abc123",
+				Content:   json.RawMessage(innerContent),
+			},
+		},
+		StopReason: "end_turn",
+	}
+
+	resp := p.convertAPIResponse(apiResp)
+
+	if resp.Content != "Running:" {
+		t.Errorf("Content = %q, want %q", resp.Content, "Running:")
+	}
+
+	if resp.Metadata == nil {
+		t.Fatal("Metadata is nil; expected server_tool_results entry")
+	}
+	results, ok := resp.Metadata["server_tool_results"].([]map[string]any)
+	if !ok {
+		t.Fatalf("server_tool_results type = %T, want []map[string]any", resp.Metadata["server_tool_results"])
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	if results[0]["type"] != "code_execution_tool_result" {
+		t.Errorf("type = %v, want code_execution_tool_result", results[0]["type"])
+	}
+	if results[0]["tool_use_id"] != "srvtoolu_abc123" {
+		t.Errorf("tool_use_id = %v, want srvtoolu_abc123", results[0]["tool_use_id"])
+	}
+	gotContent, ok := results[0]["content"].(json.RawMessage)
+	if !ok {
+		t.Fatalf("content type = %T, want json.RawMessage", results[0]["content"])
+	}
+	if string(gotContent) != innerContent {
+		t.Errorf("content = %q, want %q", string(gotContent), innerContent)
+	}
+}
+
+// TestConvertAPIResponse_NoServerToolResults makes sure the non-server-tool
+// path doesn't accidentally introduce a server_tool_results key when there
+// were no such blocks. Belt-and-suspenders against future regressions.
+func TestConvertAPIResponse_NoServerToolResults(t *testing.T) {
+	p := &Plugin{logger: silentLogger()}
+
+	apiResp := apiResponse{
+		ID:    "msg_plain",
+		Model: "claude-sonnet-4-5-20250514",
+		Content: []apiContentBlock{
+			{Type: "text", Text: "hello"},
+		},
+		StopReason: "end_turn",
+	}
+
+	resp := p.convertAPIResponse(apiResp)
+	if resp.Metadata != nil {
+		if _, present := resp.Metadata["server_tool_results"]; present {
+			t.Errorf("server_tool_results should be absent when no server-tool blocks are present")
+		}
+	}
+}
+

--- a/plugins/providers/anthropic/structured.go
+++ b/plugins/providers/anthropic/structured.go
@@ -1,0 +1,40 @@
+package anthropic
+
+// structuredOutputsConfig controls how json_schema response formats map onto
+// the Anthropic Messages API.
+//
+// Two modes are supported:
+//
+//   - "tool" (default): inject a synthetic `_structured_output` tool whose
+//     input_schema mirrors the requested schema and force tool_choice on it.
+//     This works on every Claude model that supports tool use, but conflicts
+//     with the agent's real tools (tool_choice is overridden).
+//   - "native": send the schema via the top-level `response_format` field
+//     Anthropic added once `output_format` shipped. The model returns the JSON
+//     value as a single text block; tool_choice is left untouched. Anthropic's
+//     exact field naming and beta gating was in flux at the time of writing,
+//     so this stays opt-in until operators confirm their target model accepts
+//     it. The optional BetaHeader lets operators opt into the beta string when
+//     Anthropic publishes one without us shipping a stale guess.
+type structuredOutputsConfig struct {
+	Mode       string // "tool" (default) | "native"
+	BetaHeader string // optional; appended to anthropic-beta when Mode == "native"
+}
+
+// parseStructuredOutputsConfig reads the optional `structured_outputs:` block
+// from the plugin config. Unknown or invalid `mode` values fall back to the
+// safe "tool" default — operators have to explicitly opt into "native".
+func parseStructuredOutputsConfig(cfg map[string]any) structuredOutputsConfig {
+	out := structuredOutputsConfig{Mode: "tool"}
+	raw, ok := cfg["structured_outputs"].(map[string]any)
+	if !ok {
+		return out
+	}
+	if v, ok := raw["mode"].(string); ok && (v == "tool" || v == "native") {
+		out.Mode = v
+	}
+	if v, ok := raw["beta_header"].(string); ok {
+		out.BetaHeader = v
+	}
+	return out
+}

--- a/plugins/providers/anthropic/structured_test.go
+++ b/plugins/providers/anthropic/structured_test.go
@@ -1,0 +1,263 @@
+package anthropic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// TestParseStructuredOutputsConfig_Defaults verifies that an absent
+// `structured_outputs` block yields the safe "tool" simulation default with no
+// beta header.
+func TestParseStructuredOutputsConfig_Defaults(t *testing.T) {
+	cfg := map[string]any{}
+
+	out := parseStructuredOutputsConfig(cfg)
+
+	if out.Mode != "tool" {
+		t.Errorf("Mode: got %q, want %q", out.Mode, "tool")
+	}
+	if out.BetaHeader != "" {
+		t.Errorf("BetaHeader: got %q, want empty", out.BetaHeader)
+	}
+}
+
+// TestParseStructuredOutputsConfig_ExplicitTool verifies an explicit
+// `mode: tool` setting parses cleanly (no fallback noise).
+func TestParseStructuredOutputsConfig_ExplicitTool(t *testing.T) {
+	cfg := map[string]any{
+		"structured_outputs": map[string]any{
+			"mode": "tool",
+		},
+	}
+
+	out := parseStructuredOutputsConfig(cfg)
+
+	if out.Mode != "tool" {
+		t.Errorf("Mode: got %q, want %q", out.Mode, "tool")
+	}
+}
+
+// TestParseStructuredOutputsConfig_ExplicitNative verifies the native opt-in.
+func TestParseStructuredOutputsConfig_ExplicitNative(t *testing.T) {
+	cfg := map[string]any{
+		"structured_outputs": map[string]any{
+			"mode": "native",
+		},
+	}
+
+	out := parseStructuredOutputsConfig(cfg)
+
+	if out.Mode != "native" {
+		t.Errorf("Mode: got %q, want %q", out.Mode, "native")
+	}
+}
+
+// TestParseStructuredOutputsConfig_InvalidModeFallsBack verifies that an
+// unrecognized mode value falls back to "tool" rather than silently enabling
+// native (operators have to spell it correctly to opt in).
+func TestParseStructuredOutputsConfig_InvalidModeFallsBack(t *testing.T) {
+	cfg := map[string]any{
+		"structured_outputs": map[string]any{
+			"mode": "bogus",
+		},
+	}
+
+	out := parseStructuredOutputsConfig(cfg)
+
+	if out.Mode != "tool" {
+		t.Errorf("Mode: got %q, want fallback %q", out.Mode, "tool")
+	}
+}
+
+// TestParseStructuredOutputsConfig_BetaHeader verifies the optional beta
+// header parses and round-trips.
+func TestParseStructuredOutputsConfig_BetaHeader(t *testing.T) {
+	cfg := map[string]any{
+		"structured_outputs": map[string]any{
+			"mode":        "native",
+			"beta_header": "output-format-2025-12-01",
+		},
+	}
+
+	out := parseStructuredOutputsConfig(cfg)
+
+	if out.Mode != "native" {
+		t.Errorf("Mode: got %q, want %q", out.Mode, "native")
+	}
+	if out.BetaHeader != "output-format-2025-12-01" {
+		t.Errorf("BetaHeader: got %q, want %q", out.BetaHeader, "output-format-2025-12-01")
+	}
+}
+
+// TestBuildRequestBody_StructuredOutput_ToolMode verifies the legacy
+// simulation behavior is preserved when mode == "tool" (default): a synthetic
+// `_structured_output` tool is appended and tool_choice is forced to it.
+func TestBuildRequestBody_StructuredOutput_ToolMode(t *testing.T) {
+	p := &Plugin{
+		logger:            silentLogger(),
+		structuredOutputs: structuredOutputsConfig{Mode: "tool"},
+	}
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"answer": map[string]any{"type": "string"},
+		},
+	}
+
+	req := events.LLMRequest{
+		Messages: []events.Message{{Role: "user", Content: "hi"}},
+		ResponseFormat: &events.ResponseFormat{
+			Type:   "json_schema",
+			Schema: schema,
+		},
+	}
+
+	body := p.buildRequestBody("claude-sonnet-4-5-20250514", 1024, req)
+
+	if _, ok := body["response_format"]; ok {
+		t.Errorf("tool mode should NOT set response_format on body, got %+v", body["response_format"])
+	}
+
+	tools, ok := body["tools"].([]map[string]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected 1 synthetic tool, got %+v", body["tools"])
+	}
+	if tools[0]["name"] != "_structured_output" {
+		t.Errorf("tool name: got %v, want %q", tools[0]["name"], "_structured_output")
+	}
+
+	tc, ok := body["tool_choice"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tool_choice map, got %+v", body["tool_choice"])
+	}
+	if tc["type"] != "tool" || tc["name"] != "_structured_output" {
+		t.Errorf("tool_choice: got %+v, want forced _structured_output", tc)
+	}
+}
+
+// TestBuildRequestBody_StructuredOutput_NativeMode verifies the native path:
+// response_format set, no synthetic tool, no forced tool_choice.
+func TestBuildRequestBody_StructuredOutput_NativeMode(t *testing.T) {
+	p := &Plugin{
+		logger:            silentLogger(),
+		structuredOutputs: structuredOutputsConfig{Mode: "native"},
+	}
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"answer": map[string]any{"type": "string"},
+		},
+	}
+
+	req := events.LLMRequest{
+		Messages: []events.Message{{Role: "user", Content: "hi"}},
+		ResponseFormat: &events.ResponseFormat{
+			Type:   "json_schema",
+			Schema: schema,
+		},
+	}
+
+	body := p.buildRequestBody("claude-sonnet-4-5-20250514", 1024, req)
+
+	rf, ok := body["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response_format map, got %+v", body["response_format"])
+	}
+	if rf["type"] != "json_schema" {
+		t.Errorf("response_format.type: got %v, want %q", rf["type"], "json_schema")
+	}
+	if _, ok := rf["schema"].(map[string]any); !ok {
+		t.Errorf("response_format.schema: got %T, want map[string]any", rf["schema"])
+	}
+
+	if tools, ok := body["tools"].([]map[string]any); ok {
+		for _, tool := range tools {
+			if tool["name"] == "_structured_output" {
+				t.Errorf("native mode should NOT inject synthetic tool, found %+v", tool)
+			}
+		}
+	}
+
+	if tc, ok := body["tool_choice"]; ok {
+		t.Errorf("native mode should not force tool_choice when caller didn't ask, got %+v", tc)
+	}
+}
+
+// TestBuildRequestBody_StructuredOutput_NativeMode_PreservesToolChoice
+// verifies the native path leaves a caller-supplied tool_choice intact rather
+// than overriding it with the synthetic tool selection.
+func TestBuildRequestBody_StructuredOutput_NativeMode_PreservesToolChoice(t *testing.T) {
+	p := &Plugin{
+		logger:            silentLogger(),
+		structuredOutputs: structuredOutputsConfig{Mode: "native"},
+	}
+
+	schema := map[string]any{"type": "object"}
+
+	req := events.LLMRequest{
+		Messages: []events.Message{{Role: "user", Content: "hi"}},
+		Tools:    []events.ToolDef{{Name: "shell", Description: "run a command"}},
+		ToolChoice: &events.ToolChoice{
+			Mode: "tool",
+			Name: "shell",
+		},
+		ResponseFormat: &events.ResponseFormat{
+			Type:   "json_schema",
+			Schema: schema,
+		},
+	}
+
+	body := p.buildRequestBody("claude-sonnet-4-5-20250514", 1024, req)
+
+	tc, ok := body["tool_choice"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tool_choice map, got %+v", body["tool_choice"])
+	}
+	if tc["type"] != "tool" || tc["name"] != "shell" {
+		t.Errorf("tool_choice: got %+v, want caller's {type:tool, name:shell}", tc)
+	}
+
+	if rf, ok := body["response_format"].(map[string]any); !ok || rf["type"] != "json_schema" {
+		t.Errorf("response_format should still be set in native mode, got %+v", body["response_format"])
+	}
+}
+
+// TestBetaFlags_NativeStructuredOutputsHeader verifies the operator-supplied
+// beta header is appended to anthropic-beta only when native mode is active.
+func TestBetaFlags_NativeStructuredOutputsHeader(t *testing.T) {
+	p := &Plugin{
+		logger: silentLogger(),
+		structuredOutputs: structuredOutputsConfig{
+			Mode:       "native",
+			BetaHeader: "output-format-2025-12-01",
+		},
+	}
+
+	got := p.betaFlags(nil)
+
+	if !strings.Contains(got, "output-format-2025-12-01") {
+		t.Errorf("betaFlags: got %q, want it to contain %q", got, "output-format-2025-12-01")
+	}
+}
+
+// TestBetaFlags_ToolModeOmitsHeader verifies the beta header is suppressed in
+// tool mode even when the operator left a stale value in config.
+func TestBetaFlags_ToolModeOmitsHeader(t *testing.T) {
+	p := &Plugin{
+		logger: silentLogger(),
+		structuredOutputs: structuredOutputsConfig{
+			Mode:       "tool",
+			BetaHeader: "output-format-2025-12-01",
+		},
+	}
+
+	got := p.betaFlags(nil)
+
+	if strings.Contains(got, "output-format-2025-12-01") {
+		t.Errorf("betaFlags: got %q, expected no native header in tool mode", got)
+	}
+}

--- a/plugins/providers/anthropic/thinking.go
+++ b/plugins/providers/anthropic/thinking.go
@@ -1,0 +1,118 @@
+package anthropic
+
+import "log/slog"
+
+// thinkingConfig controls Anthropic's extended-thinking feature (Sonnet 4+,
+// Opus 4+). When enabled the API emits `thinking` (and possibly
+// `redacted_thinking`) content blocks that carry the model's internal
+// reasoning along with a cryptographic signature.
+//
+//	thinking:
+//	  enabled: true
+//	  budget_tokens: 8192     # -1 dynamic, 0 disabled (default 8192)
+//	  include_thoughts: true  # surface human-readable thinking via thinking.step
+//
+// Constraints enforced by the API:
+//   - budget_tokens >= 1024 and < max_tokens (caller's responsibility).
+//   - temperature must be unset or 1.0; applyThinking strips non-1 values.
+type thinkingConfig struct {
+	Enabled         bool
+	BudgetTokens    int  // -1 dynamic, 0 disabled (default 8192 when Enabled)
+	IncludeThoughts bool // default true
+}
+
+// parseThinkingConfig pulls thinkingConfig out of the plugin's raw config map.
+// Absent block returns a zero-value config (a no-op for applyThinking and the
+// stream/sync handlers). Defaults BudgetTokens=8192 and IncludeThoughts=true
+// when the block is present so users only have to set `enabled: true`.
+func parseThinkingConfig(cfg map[string]any) thinkingConfig {
+	tc := thinkingConfig{BudgetTokens: 8192, IncludeThoughts: true}
+
+	raw, ok := cfg["thinking"].(map[string]any)
+	if !ok {
+		return thinkingConfig{}
+	}
+
+	if v, ok := raw["enabled"].(bool); ok {
+		tc.Enabled = v
+	}
+	if v, ok := raw["budget_tokens"].(int); ok {
+		tc.BudgetTokens = v
+	} else if v, ok := raw["budget_tokens"].(float64); ok {
+		// YAML decoders surface integers as float64 on some paths.
+		tc.BudgetTokens = int(v)
+	}
+	if v, ok := raw["include_thoughts"].(bool); ok {
+		tc.IncludeThoughts = v
+	}
+
+	return tc
+}
+
+// prependThinkingBlocks pulls a stashed []map[string]any of thinking blocks
+// out of msg.Metadata["thinking_blocks"] and returns a fresh slice ready to
+// be prepended to an assistant message's content array. Returns nil when no
+// blocks are present or the value isn't the expected shape.
+//
+// Anthropic emits these blocks (with cryptographic signatures) as part of the
+// response when extended thinking is on. On the NEXT assistant turn — the
+// one that follows the tool result a tool_use produced — those exact blocks
+// must be echoed back at the head of the content array, before the new
+// tool_use blocks, with signatures intact. The API rejects with HTTP 400
+// otherwise.
+//
+// We accept both []map[string]any (the in-memory shape providers use) and
+// []any (post-JSON-roundtrip shape after the memory plugin persists +
+// reloads via JSONL). The latter is best-effort: each element must itself
+// be a map[string]any once Go decodes the JSON, which the standard library
+// guarantees for object values.
+func prependThinkingBlocks(meta map[string]any) []map[string]any {
+	if meta == nil {
+		return nil
+	}
+	raw, ok := meta["thinking_blocks"]
+	if !ok {
+		return nil
+	}
+	switch blocks := raw.(type) {
+	case []map[string]any:
+		// Defensive copy so callers can't mutate the cached slice.
+		out := make([]map[string]any, len(blocks))
+		copy(out, blocks)
+		return out
+	case []any:
+		out := make([]map[string]any, 0, len(blocks))
+		for _, b := range blocks {
+			if m, ok := b.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// applyThinking sets the request body's "thinking" field. When enabled it also
+// strips temperature (Anthropic requires temp=1 with thinking; the cleanest
+// path is to omit it). Logs a warning when stripping a user-set non-1 temp.
+func applyThinking(body map[string]any, cfg thinkingConfig, logger *slog.Logger) {
+	if !cfg.Enabled || cfg.BudgetTokens == 0 {
+		return
+	}
+	body["thinking"] = map[string]any{
+		"type":          "enabled",
+		"budget_tokens": cfg.BudgetTokens,
+	}
+	if temp, ok := body["temperature"]; ok {
+		// Only warn when the user set a value that conflicts with the
+		// thinking-required temp=1. An exact 1.0 is silently dropped.
+		if f, isFloat := temp.(float64); isFloat && f != 1.0 && logger != nil {
+			logger.Warn("anthropic: stripping temperature for thinking-enabled request", "had", temp)
+		}
+		delete(body, "temperature")
+	}
+}

--- a/plugins/providers/anthropic/thinking_test.go
+++ b/plugins/providers/anthropic/thinking_test.go
@@ -1,0 +1,490 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// --- parseThinkingConfig ----------------------------------------------------
+
+// TestParseThinkingConfig_Absent verifies that omitting the `thinking` block
+// produces a zero-value config so applyThinking is a no-op and no event is
+// emitted on the bus.
+func TestParseThinkingConfig_Absent(t *testing.T) {
+	tc := parseThinkingConfig(map[string]any{})
+	if tc.Enabled || tc.BudgetTokens != 0 || tc.IncludeThoughts {
+		t.Fatalf("expected zero config, got %+v", tc)
+	}
+}
+
+// TestParseThinkingConfig_Defaults verifies that a present-but-minimal block
+// fills in the high-leverage defaults: 8192-token budget and IncludeThoughts
+// true so callers only need `enabled: true`.
+func TestParseThinkingConfig_Defaults(t *testing.T) {
+	tc := parseThinkingConfig(map[string]any{
+		"thinking": map[string]any{
+			"enabled": true,
+		},
+	})
+	if !tc.Enabled {
+		t.Fatal("expected enabled=true")
+	}
+	if tc.BudgetTokens != 8192 {
+		t.Errorf("BudgetTokens: got %d, want 8192", tc.BudgetTokens)
+	}
+	if !tc.IncludeThoughts {
+		t.Errorf("IncludeThoughts: got false, want true (default)")
+	}
+}
+
+// TestParseThinkingConfig_Custom verifies explicit overrides take effect.
+func TestParseThinkingConfig_Custom(t *testing.T) {
+	tc := parseThinkingConfig(map[string]any{
+		"thinking": map[string]any{
+			"enabled":          true,
+			"budget_tokens":    16384,
+			"include_thoughts": false,
+		},
+	})
+	if !tc.Enabled || tc.BudgetTokens != 16384 || tc.IncludeThoughts {
+		t.Fatalf("unexpected config: %+v", tc)
+	}
+}
+
+// TestParseThinkingConfig_DynamicBudget verifies -1 (dynamic budget) is
+// preserved as-is so the request body forwards it to Anthropic.
+func TestParseThinkingConfig_DynamicBudget(t *testing.T) {
+	tc := parseThinkingConfig(map[string]any{
+		"thinking": map[string]any{
+			"enabled":       true,
+			"budget_tokens": -1,
+		},
+	})
+	if tc.BudgetTokens != -1 {
+		t.Fatalf("BudgetTokens: got %d, want -1", tc.BudgetTokens)
+	}
+}
+
+// TestParseThinkingConfig_FloatBudget covers YAML decoders that surface
+// integer values as float64 — the parser should still extract the value.
+func TestParseThinkingConfig_FloatBudget(t *testing.T) {
+	tc := parseThinkingConfig(map[string]any{
+		"thinking": map[string]any{
+			"enabled":       true,
+			"budget_tokens": float64(4096),
+		},
+	})
+	if tc.BudgetTokens != 4096 {
+		t.Fatalf("BudgetTokens: got %d, want 4096", tc.BudgetTokens)
+	}
+}
+
+// --- applyThinking ----------------------------------------------------------
+
+func silentTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestApplyThinking_Disabled is a no-op — body comes back unchanged.
+func TestApplyThinking_Disabled(t *testing.T) {
+	body := map[string]any{"max_tokens": 1024}
+	applyThinking(body, thinkingConfig{}, silentTestLogger())
+	if _, ok := body["thinking"]; ok {
+		t.Fatal("disabled config should not set thinking")
+	}
+	if len(body) != 1 {
+		t.Fatalf("body mutated unexpectedly: %+v", body)
+	}
+}
+
+// TestApplyThinking_BudgetZero treats budget=0 as disabled (mirrors gemini).
+func TestApplyThinking_BudgetZero(t *testing.T) {
+	body := map[string]any{}
+	applyThinking(body, thinkingConfig{Enabled: true, BudgetTokens: 0}, silentTestLogger())
+	if _, ok := body["thinking"]; ok {
+		t.Fatal("budget=0 should not set thinking")
+	}
+}
+
+// TestApplyThinking_Enabled produces the correct request shape.
+func TestApplyThinking_Enabled(t *testing.T) {
+	body := map[string]any{}
+	applyThinking(body, thinkingConfig{Enabled: true, BudgetTokens: 8192}, silentTestLogger())
+
+	got, ok := body["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking missing or wrong type: %T", body["thinking"])
+	}
+	if got["type"] != "enabled" {
+		t.Errorf("type: got %v, want enabled", got["type"])
+	}
+	if got["budget_tokens"] != 8192 {
+		t.Errorf("budget_tokens: got %v, want 8192", got["budget_tokens"])
+	}
+}
+
+// TestApplyThinking_StripsTemperature verifies non-1.0 temperature is removed
+// and a warning is logged. Anthropic requires temp=1 (or unset) when thinking
+// is enabled.
+func TestApplyThinking_StripsTemperature(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	body := map[string]any{"temperature": 0.7}
+	applyThinking(body, thinkingConfig{Enabled: true, BudgetTokens: 4096}, logger)
+
+	if _, ok := body["temperature"]; ok {
+		t.Fatal("temperature should have been stripped")
+	}
+	if !strings.Contains(buf.String(), "stripping temperature") {
+		t.Errorf("expected warning log, got: %q", buf.String())
+	}
+}
+
+// TestApplyThinking_TemperatureOneNoWarn — temp=1.0 is silently dropped (it's
+// the value Anthropic would have used anyway), no warning emitted.
+func TestApplyThinking_TemperatureOneNoWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	body := map[string]any{"temperature": 1.0}
+	applyThinking(body, thinkingConfig{Enabled: true, BudgetTokens: 4096}, logger)
+
+	if _, ok := body["temperature"]; ok {
+		t.Fatal("temperature should have been removed")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("temp=1.0 should not log a warning, got: %q", buf.String())
+	}
+}
+
+// TestApplyThinking_NoTemperatureNoWarn — when caller never set temperature,
+// applyThinking is silent and leaves body otherwise alone.
+func TestApplyThinking_NoTemperatureNoWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	body := map[string]any{"max_tokens": 4096}
+	applyThinking(body, thinkingConfig{Enabled: true, BudgetTokens: 4096}, logger)
+
+	if buf.Len() != 0 {
+		t.Errorf("no temperature should not log, got: %q", buf.String())
+	}
+}
+
+// --- prependThinkingBlocks --------------------------------------------------
+
+// TestPrependThinkingBlocks_Native — the native []map[string]any shape (as
+// emitted by the provider in-process) round-trips through unchanged.
+func TestPrependThinkingBlocks_Native(t *testing.T) {
+	meta := map[string]any{
+		"thinking_blocks": []map[string]any{
+			{"type": "thinking", "thinking": "step 1", "signature": "sig-A"},
+		},
+	}
+	got := prependThinkingBlocks(meta)
+	if len(got) != 1 {
+		t.Fatalf("len: got %d, want 1", len(got))
+	}
+	if got[0]["signature"] != "sig-A" {
+		t.Errorf("signature lost: %+v", got[0])
+	}
+}
+
+// TestPrependThinkingBlocks_FromJSON — after a JSONL persistence round-trip
+// the slice arrives as []any{map[string]any{...}}; the helper must recover.
+func TestPrependThinkingBlocks_FromJSON(t *testing.T) {
+	raw := `{"thinking_blocks": [{"type":"thinking","thinking":"x","signature":"sig"}]}`
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(raw), &meta); err != nil {
+		t.Fatal(err)
+	}
+	got := prependThinkingBlocks(meta)
+	if len(got) != 1 || got[0]["signature"] != "sig" {
+		t.Fatalf("post-JSON recovery failed: %+v", got)
+	}
+}
+
+// TestPrependThinkingBlocks_Absent returns nil for missing/nil metadata.
+func TestPrependThinkingBlocks_Absent(t *testing.T) {
+	if prependThinkingBlocks(nil) != nil {
+		t.Error("nil metadata should return nil")
+	}
+	if prependThinkingBlocks(map[string]any{}) != nil {
+		t.Error("missing key should return nil")
+	}
+	if prependThinkingBlocks(map[string]any{"thinking_blocks": "bad"}) != nil {
+		t.Error("wrong type should return nil")
+	}
+}
+
+// --- convertMessage round-trip ---------------------------------------------
+
+// TestConvertMessage_PrependsThinkingBeforeToolUse verifies the critical
+// invariant: when an assistant message has BOTH thinking_blocks (from the
+// previous response) AND tool_calls, the request payload places thinking
+// blocks FIRST, before any tool_use blocks, with their signatures preserved
+// verbatim. Anthropic returns HTTP 400 when this ordering is violated on a
+// turn that follows a tool_result.
+func TestConvertMessage_PrependsThinkingBeforeToolUse(t *testing.T) {
+	p := &Plugin{logger: silentTestLogger()}
+
+	msg := events.Message{
+		Role:    "assistant",
+		Content: "I'll fetch that.",
+		ToolCalls: []events.ToolCallRequest{
+			{ID: "toolu_1", Name: "fetch", Arguments: `{"url":"x"}`},
+		},
+		Metadata: map[string]any{
+			"thinking_blocks": []map[string]any{
+				{"type": "thinking", "thinking": "I should call fetch.", "signature": "sig-XYZ"},
+				{"type": "redacted_thinking", "data": "encrypted-blob"},
+			},
+		},
+	}
+
+	api := p.convertMessage(msg)
+	content, ok := api["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("content wrong type: %T", api["content"])
+	}
+
+	// Expected ordering:
+	//   [0] thinking
+	//   [1] redacted_thinking
+	//   [2] text  ("I'll fetch that.")
+	//   [3] tool_use
+	if len(content) != 4 {
+		t.Fatalf("content len: got %d, want 4 (%+v)", len(content), content)
+	}
+	if content[0]["type"] != "thinking" {
+		t.Errorf("[0] type: got %v, want thinking", content[0]["type"])
+	}
+	if content[0]["signature"] != "sig-XYZ" {
+		t.Errorf("[0] signature lost: %+v", content[0])
+	}
+	if content[1]["type"] != "redacted_thinking" {
+		t.Errorf("[1] type: got %v, want redacted_thinking", content[1]["type"])
+	}
+	if content[1]["data"] != "encrypted-blob" {
+		t.Errorf("[1] data lost: %+v", content[1])
+	}
+	if content[2]["type"] != "text" {
+		t.Errorf("[2] type: got %v, want text", content[2]["type"])
+	}
+	if content[3]["type"] != "tool_use" {
+		t.Errorf("[3] type: got %v, want tool_use", content[3]["type"])
+	}
+}
+
+// TestConvertMessage_NoThinkingNoOp confirms that messages without metadata
+// produce the legacy content shape (no leading thinking blocks).
+func TestConvertMessage_NoThinkingNoOp(t *testing.T) {
+	p := &Plugin{logger: silentTestLogger()}
+	msg := events.Message{
+		Role:    "assistant",
+		Content: "ok",
+		ToolCalls: []events.ToolCallRequest{
+			{ID: "id1", Name: "t", Arguments: `{}`},
+		},
+	}
+	api := p.convertMessage(msg)
+	content := api["content"].([]map[string]any)
+	if len(content) != 2 {
+		t.Fatalf("expected 2 blocks (text + tool_use), got %d", len(content))
+	}
+	if content[0]["type"] != "text" {
+		t.Errorf("[0] type: got %v, want text", content[0]["type"])
+	}
+}
+
+// --- SSE round-trip --------------------------------------------------------
+
+// busRecorder collects every event the provider emits during a stream so
+// tests can assert on thinking.step + llm.response shape without spinning
+// up the full engine.
+type busRecorder struct {
+	mu     sync.Mutex
+	bus    engine.EventBus
+	events []recorded
+}
+
+type recorded struct {
+	Type    string
+	Payload any
+}
+
+func newBusRecorder() *busRecorder {
+	r := &busRecorder{bus: engine.NewEventBus()}
+	r.bus.SubscribeAll(func(e engine.Event[any]) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.events = append(r.events, recorded{Type: e.Type, Payload: e.Payload})
+	})
+	return r
+}
+
+func (r *busRecorder) byType(t string) []recorded {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []recorded
+	for _, ev := range r.events {
+		if ev.Type == t {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// canned SSE payload mirroring Anthropic's extended-thinking stream:
+//
+//	message_start
+//	  → content_block_start (thinking)
+//	    → thinking_delta x2
+//	    → signature_delta
+//	  → content_block_stop
+//	  → content_block_start (text)
+//	    → text_delta
+//	  → content_block_stop
+//	message_delta (stop_reason)
+//	message_stop
+const canonicalThinkingStream = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_test","model":"claude-sonnet-4-5-20250514","usage":{"input_tokens":50,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"about this carefully."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-canonical"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Final answer."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":42}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+// TestStream_ExtendedThinkingRoundTrip drives the SSE state machine end-to-end
+// with a canned thinking-enabled response and asserts:
+//
+//   - thinking.step events are emitted (one per thinking_delta) when
+//     IncludeThoughts is on.
+//   - The final llm.response carries Metadata["thinking_blocks"] populated
+//     with the block AND its signature.
+//   - llm.response.Content is the text portion only (thinking is excluded).
+func TestStream_ExtendedThinkingRoundTrip(t *testing.T) {
+	rec := newBusRecorder()
+
+	p := &Plugin{
+		bus:      rec.bus,
+		logger:   silentTestLogger(),
+		thinking: thinkingConfig{Enabled: true, BudgetTokens: 8192, IncludeThoughts: true},
+		pricing:  defaultPricing,
+	}
+
+	p.handleStreamResponse(strings.NewReader(canonicalThinkingStream))
+
+	// Assert: thinking.step emitted twice (one per thinking_delta).
+	steps := rec.byType("thinking.step")
+	if len(steps) != 2 {
+		t.Fatalf("thinking.step events: got %d, want 2", len(steps))
+	}
+	step0 := steps[0].Payload.(events.ThinkingStep)
+	if step0.Content != "Let me think " {
+		t.Errorf("step[0] content: got %q", step0.Content)
+	}
+	if step0.TurnID != "msg_test" {
+		t.Errorf("step[0] turn id: got %q, want msg_test", step0.TurnID)
+	}
+	if step0.Index != 0 {
+		t.Errorf("step[0] index: got %d, want 0", step0.Index)
+	}
+	step1 := steps[1].Payload.(events.ThinkingStep)
+	if step1.Index != 1 {
+		t.Errorf("step[1] index: got %d, want 1", step1.Index)
+	}
+
+	// Assert: final llm.response shape.
+	resps := rec.byType("llm.response")
+	if len(resps) != 1 {
+		t.Fatalf("llm.response count: got %d, want 1", len(resps))
+	}
+	resp := resps[0].Payload.(events.LLMResponse)
+
+	if resp.Content != "Final answer." {
+		t.Errorf("response content: got %q, want %q", resp.Content, "Final answer.")
+	}
+
+	tb, ok := resp.Metadata["thinking_blocks"].([]map[string]any)
+	if !ok {
+		t.Fatalf("Metadata[thinking_blocks] missing or wrong type: %T", resp.Metadata["thinking_blocks"])
+	}
+	if len(tb) != 1 {
+		t.Fatalf("thinking_blocks len: got %d, want 1", len(tb))
+	}
+	if tb[0]["type"] != "thinking" {
+		t.Errorf("block type: got %v, want thinking", tb[0]["type"])
+	}
+	if tb[0]["thinking"] != "Let me think about this carefully." {
+		t.Errorf("aggregated thinking: got %q", tb[0]["thinking"])
+	}
+	if tb[0]["signature"] != "sig-canonical" {
+		t.Errorf("signature lost: got %q", tb[0]["signature"])
+	}
+}
+
+// TestStream_IncludeThoughtsFalseSilencesEvents — same canned payload, but
+// IncludeThoughts disabled. Thinking blocks must still be captured into
+// Metadata (round-trip needs them) but no thinking.step events fire.
+func TestStream_IncludeThoughtsFalseSilencesEvents(t *testing.T) {
+	rec := newBusRecorder()
+
+	p := &Plugin{
+		bus:      rec.bus,
+		logger:   silentTestLogger(),
+		thinking: thinkingConfig{Enabled: true, BudgetTokens: 8192, IncludeThoughts: false},
+		pricing:  defaultPricing,
+	}
+
+	p.handleStreamResponse(strings.NewReader(canonicalThinkingStream))
+
+	if got := len(rec.byType("thinking.step")); got != 0 {
+		t.Errorf("thinking.step suppressed but %d emitted", got)
+	}
+
+	resp := rec.byType("llm.response")[0].Payload.(events.LLMResponse)
+	tb, ok := resp.Metadata["thinking_blocks"].([]map[string]any)
+	if !ok || len(tb) != 1 {
+		t.Fatalf("thinking_blocks missing despite include_thoughts=false: %+v", resp.Metadata)
+	}
+	if tb[0]["signature"] != "sig-canonical" {
+		t.Error("signature dropped")
+	}
+}

--- a/plugins/providers/anthropic/usage_test.go
+++ b/plugins/providers/anthropic/usage_test.go
@@ -1,0 +1,195 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// TestApiUsage_ParsesCacheFields verifies the apiUsage JSON tags match the
+// Anthropic Messages API usage object (cache_creation_input_tokens and
+// cache_read_input_tokens).
+func TestApiUsage_ParsesCacheFields(t *testing.T) {
+	raw := []byte(`{
+		"input_tokens": 142,
+		"output_tokens": 350,
+		"cache_creation_input_tokens": 1024,
+		"cache_read_input_tokens": 4096
+	}`)
+
+	var u apiUsage
+	if err := json.Unmarshal(raw, &u); err != nil {
+		t.Fatalf("unmarshal apiUsage: %v", err)
+	}
+
+	if u.InputTokens != 142 {
+		t.Errorf("InputTokens: got %d, want 142", u.InputTokens)
+	}
+	if u.OutputTokens != 350 {
+		t.Errorf("OutputTokens: got %d, want 350", u.OutputTokens)
+	}
+	if u.CacheCreationInputTokens != 1024 {
+		t.Errorf("CacheCreationInputTokens: got %d, want 1024", u.CacheCreationInputTokens)
+	}
+	if u.CacheReadInputTokens != 4096 {
+		t.Errorf("CacheReadInputTokens: got %d, want 4096", u.CacheReadInputTokens)
+	}
+}
+
+// TestConvertAPIResponse_PopulatesCacheUsage verifies that convertAPIResponse
+// surfaces cache-write and cache-read tokens onto events.Usage.
+func TestConvertAPIResponse_PopulatesCacheUsage(t *testing.T) {
+	p := &Plugin{pricing: defaultPricing}
+
+	apiResp := apiResponse{
+		ID:    "msg_test",
+		Model: "claude-sonnet-4-6-20250514",
+		Content: []apiContentBlock{
+			{Type: "text", Text: "hello"},
+		},
+		StopReason: "end_turn",
+		Usage: apiUsage{
+			InputTokens:              1000,
+			OutputTokens:             350,
+			CacheCreationInputTokens: 1024,
+			CacheReadInputTokens:     4096,
+		},
+	}
+
+	resp := p.convertAPIResponse(apiResp)
+
+	if resp.Usage.PromptTokens != 1000 {
+		t.Errorf("PromptTokens: got %d, want 1000", resp.Usage.PromptTokens)
+	}
+	if resp.Usage.CompletionTokens != 350 {
+		t.Errorf("CompletionTokens: got %d, want 350", resp.Usage.CompletionTokens)
+	}
+	if resp.Usage.CachedTokens != 4096 {
+		t.Errorf("CachedTokens: got %d, want 4096", resp.Usage.CachedTokens)
+	}
+	if resp.Usage.CacheWriteTokens != 1024 {
+		t.Errorf("CacheWriteTokens: got %d, want 1024", resp.Usage.CacheWriteTokens)
+	}
+	wantTotal := 1000 + 350 + 4096 + 1024
+	if resp.Usage.TotalTokens != wantTotal {
+		t.Errorf("TotalTokens: got %d, want %d", resp.Usage.TotalTokens, wantTotal)
+	}
+
+	// Cost should be non-zero now that cache fields contribute.
+	if resp.CostUSD <= 0 {
+		t.Errorf("CostUSD: got %v, want > 0", resp.CostUSD)
+	}
+}
+
+// TestCalculateCost_CacheRates verifies the cost formula bills each token
+// category at its respective rate. Uses Sonnet-4 default rates with derived
+// cache rates (read = input × 0.10, write_5m = input × 1.25).
+func TestCalculateCost_CacheRates(t *testing.T) {
+	rates := defaultPricing["claude-sonnet-4-6-20250514"]
+	usage := events.Usage{
+		PromptTokens:     1000, // plain (cache-miss) input
+		CompletionTokens: 350,  // output
+		CachedTokens:     4096, // cache read
+		CacheWriteTokens: 1024, // cache write (5m)
+	}
+
+	got := calculateCost(usage, rates)
+
+	// Expected:
+	//   plain  = 1000  / 1e6 * 3.0       = 0.003
+	//   write  = 1024  / 1e6 * 3.0*1.25  = 0.00384
+	//   read   = 4096  / 1e6 * 3.0*0.10  = 0.0012288
+	//   output = 350   / 1e6 * 15.0      = 0.00525
+	want := 0.003 + 0.00384 + 0.0012288 + 0.00525
+
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("calculateCost: got %.10f, want %.10f", got, want)
+	}
+}
+
+// TestCalculateCost_CacheCheaperThanPlain verifies that a cache-heavy request
+// is priced strictly lower than the equivalent plain-input request — this is
+// the whole point of caching, so guard it explicitly.
+func TestCalculateCost_CacheCheaperThanPlain(t *testing.T) {
+	rates := defaultPricing["claude-sonnet-4-6-20250514"]
+
+	cached := events.Usage{
+		PromptTokens:     100,
+		CompletionTokens: 200,
+		CachedTokens:     5000, // mostly cache hits
+		CacheWriteTokens: 0,
+	}
+	plain := events.Usage{
+		PromptTokens:     5100, // same total input, no cache
+		CompletionTokens: 200,
+	}
+
+	cachedCost := calculateCost(cached, rates)
+	plainCost := calculateCost(plain, rates)
+
+	if cachedCost >= plainCost {
+		t.Errorf("expected cached request cheaper than plain: cached=%.6f plain=%.6f", cachedCost, plainCost)
+	}
+}
+
+// TestCalculateCost_ExplicitCacheRates verifies that configured cache rates
+// are honored over the derived fallbacks.
+func TestCalculateCost_ExplicitCacheRates(t *testing.T) {
+	rates := modelPricing{
+		InputPerMillion:        3.0,
+		OutputPerMillion:       15.0,
+		CacheReadPerMillion:    0.50, // override (would be 0.30 derived)
+		CacheWrite5mPerMillion: 4.00, // override (would be 3.75 derived)
+	}
+	usage := events.Usage{
+		PromptTokens:     0,
+		CompletionTokens: 0,
+		CachedTokens:     1_000_000,
+		CacheWriteTokens: 1_000_000,
+	}
+
+	got := calculateCost(usage, rates)
+	want := 0.50 + 4.00 // each 1M tokens * its rate
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("explicit-rates cost: got %.6f, want %.6f", got, want)
+	}
+}
+
+// TestParsePricingConfig_CacheKeys verifies the YAML override keys for cache
+// rates are parsed onto modelPricing.
+func TestParsePricingConfig_CacheKeys(t *testing.T) {
+	cfg := map[string]any{
+		"pricing": map[string]any{
+			"claude-sonnet-4-6-20250514": map[string]any{
+				"input_per_million":          5.0,
+				"output_per_million":         20.0,
+				"cache_read_per_million":     0.42,
+				"cache_write_5m_per_million": 6.25,
+				"cache_write_1h_per_million": 10.0,
+			},
+		},
+	}
+
+	merged := parsePricingConfig(cfg)
+	p, ok := merged["claude-sonnet-4-6-20250514"]
+	if !ok {
+		t.Fatal("missing pricing entry for claude-sonnet-4-6-20250514")
+	}
+	if p.InputPerMillion != 5.0 {
+		t.Errorf("InputPerMillion: got %v, want 5.0", p.InputPerMillion)
+	}
+	if p.OutputPerMillion != 20.0 {
+		t.Errorf("OutputPerMillion: got %v, want 20.0", p.OutputPerMillion)
+	}
+	if p.CacheReadPerMillion != 0.42 {
+		t.Errorf("CacheReadPerMillion: got %v, want 0.42", p.CacheReadPerMillion)
+	}
+	if p.CacheWrite5mPerMillion != 6.25 {
+		t.Errorf("CacheWrite5mPerMillion: got %v, want 6.25", p.CacheWrite5mPerMillion)
+	}
+	if p.CacheWrite1hPerMillion != 10.0 {
+		t.Errorf("CacheWrite1hPerMillion: got %v, want 10.0", p.CacheWrite1hPerMillion)
+	}
+}

--- a/plugins/providers/openai/auth.go
+++ b/plugins/providers/openai/auth.go
@@ -1,0 +1,326 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// authMode determines how requests are authenticated and routed.
+type authMode string
+
+const (
+	// authModeOpenAI uses the public api.openai.com endpoint (or a custom
+	// base_url override) with an "Authorization: Bearer <api_key>" header.
+	authModeOpenAI authMode = "openai"
+	// authModeAzureKey routes requests to an Azure OpenAI resource, using
+	// the Azure-specific "api-key: <key>" header (NOT Authorization).
+	authModeAzureKey authMode = "azure_key"
+	// authModeAzureAAD routes requests to an Azure OpenAI resource using a
+	// short-lived Entra ID (AAD) bearer token obtained via the OAuth2 client
+	// credentials flow.
+	authModeAzureAAD authMode = "azure_aad"
+)
+
+// aadTokenEndpointTemplate is the OAuth2 v2.0 token endpoint format. Tests
+// override authState.aadTokenURL to redirect to an httptest server.
+const aadTokenEndpointTemplate = "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
+
+// aadCognitiveServicesScope is the resource scope for Azure Cognitive
+// Services (which Azure OpenAI is part of).
+const aadCognitiveServicesScope = "https://cognitiveservices.azure.com/.default"
+
+// authState holds resolved auth configuration plus any cached AAD tokens.
+//
+// Constructed once at Init and reused for every request. The token cache is
+// guarded by mu; the openai-direct and azure_key paths don't lock.
+type authState struct {
+	mode authMode
+
+	// OpenAI-direct + Azure key share apiKey. The Files API also reads from
+	// this field — see plugin.go's note about Files API behavior in Azure
+	// modes (it stays on the public OpenAI endpoint; supply a separate
+	// api_key alongside Azure config to use both).
+	apiKey string
+
+	// baseURL overrides the default https://api.openai.com/v1/chat/completions
+	// for openai-mode (e.g. local proxies or OpenAI-compatible endpoints).
+	// Ignored in Azure modes — buildURL constructs Azure URLs from the
+	// resource/deployment/api-version triple.
+	baseURL string
+
+	// Azure (used by both azure_key and azure_aad).
+	resource   string // e.g. "my-resource" → https://my-resource.openai.azure.com
+	deployment string // deployment name (replaces model in URL)
+	apiVersion string // e.g. "2024-10-21"
+
+	// Azure AAD service-principal credentials.
+	tenantID     string
+	clientID     string
+	clientSecret string
+
+	// Cached AAD bearer token. Refreshed proactively (60s before expiry).
+	mu        sync.Mutex
+	token     string
+	tokExpiry time.Time
+
+	// aadTokenURL redirects the OAuth2 token exchange to a test server.
+	// Production code leaves this empty; the public Microsoft endpoint is
+	// derived from tenantID via aadTokenEndpointTemplate.
+	aadTokenURL string
+}
+
+// parseAuthConfig builds an authState from the raw plugin config map.
+//
+// Backwards compatible: if auth_mode is missing, the legacy api_key /
+// api_key_env / base_url top-level keys are used. The new "azure" config
+// block is only consulted in azure_key / azure_aad modes.
+func parseAuthConfig(cfg map[string]any) (*authState, error) {
+	mode := authModeOpenAI
+	if v, ok := cfg["auth_mode"].(string); ok && v != "" {
+		switch authMode(v) {
+		case authModeOpenAI, authModeAzureKey, authModeAzureAAD:
+			mode = authMode(v)
+		default:
+			return nil, fmt.Errorf("openai: unknown auth_mode %q (expected openai, azure_key, or azure_aad)", v)
+		}
+	}
+
+	a := &authState{mode: mode}
+
+	// Top-level api_key / api_key_env / base_url are honored regardless of
+	// mode. In Azure modes they're optional fall-through values used only by
+	// the Files API (which stays on the public OpenAI endpoint).
+	if key, ok := cfg["api_key"].(string); ok && key != "" {
+		a.apiKey = key
+	} else {
+		envVar, _ := cfg["api_key_env"].(string)
+		if envVar == "" {
+			envVar = "OPENAI_API_KEY"
+		}
+		if v := os.Getenv(envVar); v != "" {
+			a.apiKey = v
+		}
+	}
+
+	if base, ok := cfg["base_url"].(string); ok && base != "" {
+		a.baseURL = strings.TrimRight(base, "/")
+	}
+
+	switch mode {
+	case authModeOpenAI:
+		if a.apiKey == "" {
+			return nil, fmt.Errorf("openai: no API key configured (set api_key in config or OPENAI_API_KEY env var)")
+		}
+
+	case authModeAzureKey:
+		if err := populateAzureCommon(a, cfg); err != nil {
+			return nil, err
+		}
+		raw, _ := cfg["azure"].(map[string]any)
+		if raw == nil {
+			raw = map[string]any{}
+		}
+		// Azure key auth needs the api-key. Read from the azure block first
+		// (api_key / api_key_env), then fall back to the top-level apiKey
+		// already populated above.
+		if k := readAzureField(raw, "api_key", "api_key_env", ""); k != "" {
+			a.apiKey = k
+		}
+		if a.apiKey == "" {
+			return nil, fmt.Errorf("openai: azure_key auth requires azure.api_key (or azure.api_key_env, or top-level api_key/api_key_env)")
+		}
+
+	case authModeAzureAAD:
+		if err := populateAzureCommon(a, cfg); err != nil {
+			return nil, err
+		}
+		raw, _ := cfg["azure"].(map[string]any)
+		if raw == nil {
+			raw = map[string]any{}
+		}
+		a.tenantID = readAzureField(raw, "tenant_id", "tenant_id_env", "AZURE_TENANT_ID")
+		if a.tenantID == "" {
+			return nil, fmt.Errorf("openai: azure_aad auth requires azure.tenant_id (or AZURE_TENANT_ID env var)")
+		}
+		a.clientID = readAzureField(raw, "client_id", "client_id_env", "AZURE_CLIENT_ID")
+		if a.clientID == "" {
+			return nil, fmt.Errorf("openai: azure_aad auth requires azure.client_id (or AZURE_CLIENT_ID env var)")
+		}
+		a.clientSecret = readAzureField(raw, "client_secret", "client_secret_env", "AZURE_CLIENT_SECRET")
+		if a.clientSecret == "" {
+			return nil, fmt.Errorf("openai: azure_aad auth requires azure.client_secret (or AZURE_CLIENT_SECRET env var)")
+		}
+	}
+
+	return a, nil
+}
+
+// populateAzureCommon validates and assigns the resource/deployment/
+// api_version triple shared by both Azure modes.
+func populateAzureCommon(a *authState, cfg map[string]any) error {
+	raw, _ := cfg["azure"].(map[string]any)
+	if raw == nil {
+		return fmt.Errorf("openai: azure auth requires an `azure` config block")
+	}
+
+	resource, _ := raw["resource"].(string)
+	if resource == "" {
+		return fmt.Errorf("openai: azure auth requires azure.resource")
+	}
+	a.resource = resource
+
+	deployment, _ := raw["deployment"].(string)
+	if deployment == "" {
+		return fmt.Errorf("openai: azure auth requires azure.deployment")
+	}
+	a.deployment = deployment
+
+	apiVersion, _ := raw["api_version"].(string)
+	if apiVersion == "" {
+		return fmt.Errorf("openai: azure auth requires azure.api_version")
+	}
+	a.apiVersion = apiVersion
+
+	return nil
+}
+
+// readAzureField reads a config field that may be supplied either inline
+// (literalKey) or by env-var indirection (envKey); returns "" if neither is
+// set. fallbackEnv is consulted last when the config block omits both keys.
+func readAzureField(raw map[string]any, literalKey, envKey, fallbackEnv string) string {
+	if v, ok := raw[literalKey].(string); ok && v != "" {
+		return v
+	}
+	if v, ok := raw[envKey].(string); ok && v != "" {
+		if val := os.Getenv(v); val != "" {
+			return val
+		}
+	}
+	if fallbackEnv != "" {
+		return os.Getenv(fallbackEnv)
+	}
+	return ""
+}
+
+// buildURL returns the full request URL for chat completions.
+//
+//	openai:    <baseURL or default>/chat/completions
+//	azure_key: https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<v>
+//	azure_aad: same as azure_key
+func (a *authState) buildURL() string {
+	switch a.mode {
+	case authModeAzureKey, authModeAzureAAD:
+		return fmt.Sprintf(
+			"https://%s.openai.azure.com/openai/deployments/%s/chat/completions?api-version=%s",
+			a.resource,
+			url.PathEscape(a.deployment),
+			url.QueryEscape(a.apiVersion),
+		)
+	default:
+		// openai mode: honor base_url override.
+		if a.baseURL != "" {
+			return a.baseURL
+		}
+		return apiURL
+	}
+}
+
+// stripModelFromBody reports whether the model field should be omitted from
+// the JSON request body. Azure encodes the deployment in the URL path (and
+// rejects bodies that carry "model" — or rather, the deployment name there
+// must match), so the cleanest path is to omit the field entirely.
+func (a *authState) stripModelFromBody() bool {
+	return a.mode == authModeAzureKey || a.mode == authModeAzureAAD
+}
+
+// applyAuth attaches the right auth credentials onto the outgoing request.
+// For azure_aad it fetches/refreshes the cached bearer token first.
+func (a *authState) applyAuth(ctx context.Context, req *http.Request, client *http.Client) error {
+	switch a.mode {
+	case authModeOpenAI:
+		req.Header.Set("Authorization", "Bearer "+a.apiKey)
+		return nil
+
+	case authModeAzureKey:
+		// Azure uses the "api-key" header (NOT Authorization).
+		req.Header.Set("api-key", a.apiKey)
+		return nil
+
+	case authModeAzureAAD:
+		token, err := a.aadAccessToken(ctx, client)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+	return fmt.Errorf("openai: unknown auth mode %q", a.mode)
+}
+
+// aadAccessToken returns a valid OAuth2 access token, minting a new one
+// when the cached token is empty or within 60s of expiry. Concurrent
+// callers serialize on a.mu so only one HTTP exchange runs at a time.
+func (a *authState) aadAccessToken(ctx context.Context, client *http.Client) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.token != "" && time.Now().Before(a.tokExpiry) {
+		return a.token, nil
+	}
+
+	endpoint := a.aadTokenURL
+	if endpoint == "" {
+		endpoint = fmt.Sprintf(aadTokenEndpointTemplate, url.PathEscape(a.tenantID))
+	}
+
+	form := url.Values{}
+	form.Set("client_id", a.clientID)
+	form.Set("client_secret", a.clientSecret)
+	form.Set("scope", aadCognitiveServicesScope)
+	form.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("openai: build AAD token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("openai: AAD token HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("openai: AAD token exchange failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var tr struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		TokenType   string `json:"token_type"`
+	}
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return "", fmt.Errorf("openai: parse AAD token response: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return "", fmt.Errorf("openai: empty access_token in AAD response: %s", string(body))
+	}
+
+	a.token = tr.AccessToken
+	expiresIn := time.Duration(tr.ExpiresIn) * time.Second
+	if expiresIn <= 0 {
+		expiresIn = 1 * time.Hour
+	}
+	a.tokExpiry = time.Now().Add(expiresIn - 60*time.Second)
+	return a.token, nil
+}

--- a/plugins/providers/openai/auth_test.go
+++ b/plugins/providers/openai/auth_test.go
@@ -1,0 +1,615 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// =====================================================================
+// parseAuthConfig
+// =====================================================================
+
+func TestParseAuthConfig_DefaultsToOpenAI(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "secret-key")
+
+	a, err := parseAuthConfig(map[string]any{})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.mode != authModeOpenAI {
+		t.Fatalf("mode = %q, want %q", a.mode, authModeOpenAI)
+	}
+	if a.apiKey != "secret-key" {
+		t.Fatalf("apiKey = %q, want secret-key", a.apiKey)
+	}
+}
+
+func TestParseAuthConfig_OpenAI_LiteralWins(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "from-env")
+
+	a, err := parseAuthConfig(map[string]any{
+		"api_key": "from-config",
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.apiKey != "from-config" {
+		t.Fatalf("apiKey = %q, want from-config", a.apiKey)
+	}
+}
+
+func TestParseAuthConfig_OpenAI_NoKeyErrors(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
+	_, err := parseAuthConfig(map[string]any{})
+	if err == nil {
+		t.Fatal("expected error when no API key configured")
+	}
+}
+
+func TestParseAuthConfig_OpenAI_BaseURLOverride(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "k")
+
+	a, err := parseAuthConfig(map[string]any{
+		"base_url": "https://my-proxy.example.com/v1/chat/completions/",
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	// Trailing slash should be trimmed.
+	if a.baseURL != "https://my-proxy.example.com/v1/chat/completions" {
+		t.Fatalf("baseURL = %q", a.baseURL)
+	}
+}
+
+func TestParseAuthConfig_UnknownMode(t *testing.T) {
+	_, err := parseAuthConfig(map[string]any{"auth_mode": "vertex"})
+	if err == nil {
+		t.Fatal("expected error for unknown auth_mode")
+	}
+}
+
+func TestParseAuthConfig_AzureKey_Full(t *testing.T) {
+	a, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_key",
+		"azure": map[string]any{
+			"resource":    "my-resource",
+			"deployment":  "gpt-4o",
+			"api_version": "2024-10-21",
+			"api_key":     "azure-secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.mode != authModeAzureKey {
+		t.Fatalf("mode = %q, want azure_key", a.mode)
+	}
+	if a.resource != "my-resource" {
+		t.Fatalf("resource = %q", a.resource)
+	}
+	if a.deployment != "gpt-4o" {
+		t.Fatalf("deployment = %q", a.deployment)
+	}
+	if a.apiVersion != "2024-10-21" {
+		t.Fatalf("apiVersion = %q", a.apiVersion)
+	}
+	if a.apiKey != "azure-secret" {
+		t.Fatalf("apiKey = %q", a.apiKey)
+	}
+}
+
+func TestParseAuthConfig_AzureKey_FromEnvVar(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_KEY", "env-azure-key")
+
+	a, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_key",
+		"azure": map[string]any{
+			"resource":    "r",
+			"deployment":  "d",
+			"api_version": "v",
+			"api_key_env": "AZURE_OPENAI_KEY",
+		},
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.apiKey != "env-azure-key" {
+		t.Fatalf("apiKey = %q", a.apiKey)
+	}
+}
+
+func TestParseAuthConfig_AzureKey_MissingResourceErrors(t *testing.T) {
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_key",
+		"azure": map[string]any{
+			"deployment":  "d",
+			"api_version": "v",
+			"api_key":     "k",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing resource")
+	}
+}
+
+func TestParseAuthConfig_AzureKey_MissingDeploymentErrors(t *testing.T) {
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_key",
+		"azure": map[string]any{
+			"resource":    "r",
+			"api_version": "v",
+			"api_key":     "k",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing deployment")
+	}
+}
+
+func TestParseAuthConfig_AzureKey_MissingAPIVersionErrors(t *testing.T) {
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_key",
+		"azure": map[string]any{
+			"resource":   "r",
+			"deployment": "d",
+			"api_key":    "k",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing api_version")
+	}
+}
+
+func TestParseAuthConfig_AzureKey_MissingKeyErrors(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_key",
+		"azure": map[string]any{
+			"resource":    "r",
+			"deployment":  "d",
+			"api_version": "v",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing api_key in azure_key mode")
+	}
+}
+
+func TestParseAuthConfig_AzureAAD_Full(t *testing.T) {
+	a, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_aad",
+		"azure": map[string]any{
+			"resource":      "my-resource",
+			"deployment":    "gpt-4o",
+			"api_version":   "2024-10-21",
+			"tenant_id":     "tenant-uuid",
+			"client_id":     "client-uuid",
+			"client_secret": "shh",
+		},
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.mode != authModeAzureAAD {
+		t.Fatalf("mode = %q, want azure_aad", a.mode)
+	}
+	if a.tenantID != "tenant-uuid" {
+		t.Fatalf("tenantID = %q", a.tenantID)
+	}
+	if a.clientID != "client-uuid" {
+		t.Fatalf("clientID = %q", a.clientID)
+	}
+	if a.clientSecret != "shh" {
+		t.Fatalf("clientSecret = %q", a.clientSecret)
+	}
+}
+
+func TestParseAuthConfig_AzureAAD_FromEnvVars(t *testing.T) {
+	t.Setenv("AZURE_TENANT_ID", "env-tenant")
+	t.Setenv("AZURE_CLIENT_ID", "env-client")
+	t.Setenv("AZURE_CLIENT_SECRET", "env-secret")
+
+	a, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_aad",
+		"azure": map[string]any{
+			"resource":    "r",
+			"deployment":  "d",
+			"api_version": "v",
+		},
+	})
+	if err != nil {
+		t.Fatalf("parseAuthConfig: %v", err)
+	}
+	if a.tenantID != "env-tenant" {
+		t.Fatalf("tenantID = %q", a.tenantID)
+	}
+	if a.clientID != "env-client" {
+		t.Fatalf("clientID = %q", a.clientID)
+	}
+	if a.clientSecret != "env-secret" {
+		t.Fatalf("clientSecret = %q", a.clientSecret)
+	}
+}
+
+func TestParseAuthConfig_AzureAAD_MissingTenantErrors(t *testing.T) {
+	t.Setenv("AZURE_TENANT_ID", "")
+
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_aad",
+		"azure": map[string]any{
+			"resource":      "r",
+			"deployment":    "d",
+			"api_version":   "v",
+			"client_id":     "c",
+			"client_secret": "s",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing tenant_id")
+	}
+}
+
+func TestParseAuthConfig_AzureAAD_MissingClientIDErrors(t *testing.T) {
+	t.Setenv("AZURE_CLIENT_ID", "")
+
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_aad",
+		"azure": map[string]any{
+			"resource":      "r",
+			"deployment":    "d",
+			"api_version":   "v",
+			"tenant_id":     "t",
+			"client_secret": "s",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing client_id")
+	}
+}
+
+func TestParseAuthConfig_AzureAAD_MissingClientSecretErrors(t *testing.T) {
+	t.Setenv("AZURE_CLIENT_SECRET", "")
+
+	_, err := parseAuthConfig(map[string]any{
+		"auth_mode": "azure_aad",
+		"azure": map[string]any{
+			"resource":    "r",
+			"deployment":  "d",
+			"api_version": "v",
+			"tenant_id":   "t",
+			"client_id":   "c",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing client_secret")
+	}
+}
+
+// =====================================================================
+// buildURL / stripModelFromBody
+// =====================================================================
+
+func TestBuildURL_OpenAI_Default(t *testing.T) {
+	a := &authState{mode: authModeOpenAI}
+	got := a.buildURL()
+	want := "https://api.openai.com/v1/chat/completions"
+	if got != want {
+		t.Errorf("buildURL = %q, want %q", got, want)
+	}
+}
+
+func TestBuildURL_OpenAI_BaseURLOverride(t *testing.T) {
+	a := &authState{
+		mode:    authModeOpenAI,
+		baseURL: "https://my-proxy.example.com/v1/chat/completions",
+	}
+	got := a.buildURL()
+	if got != "https://my-proxy.example.com/v1/chat/completions" {
+		t.Errorf("buildURL = %q", got)
+	}
+}
+
+func TestBuildURL_AzureKey(t *testing.T) {
+	a := &authState{
+		mode:       authModeAzureKey,
+		resource:   "my-resource",
+		deployment: "gpt-4o",
+		apiVersion: "2024-10-21",
+	}
+	got := a.buildURL()
+	// All three pieces must appear in the URL.
+	if !strings.Contains(got, "my-resource.openai.azure.com") {
+		t.Errorf("URL missing resource: %q", got)
+	}
+	if !strings.Contains(got, "/deployments/gpt-4o/") {
+		t.Errorf("URL missing deployment: %q", got)
+	}
+	if !strings.Contains(got, "api-version=2024-10-21") {
+		t.Errorf("URL missing api-version: %q", got)
+	}
+}
+
+func TestBuildURL_AzureAAD_SameAsAzureKey(t *testing.T) {
+	a := &authState{
+		mode:       authModeAzureAAD,
+		resource:   "r",
+		deployment: "d",
+		apiVersion: "v",
+	}
+	got := a.buildURL()
+	want := "https://r.openai.azure.com/openai/deployments/d/chat/completions?api-version=v"
+	if got != want {
+		t.Errorf("buildURL = %q, want %q", got, want)
+	}
+}
+
+func TestStripModelFromBody(t *testing.T) {
+	cases := []struct {
+		mode authMode
+		want bool
+	}{
+		{authModeOpenAI, false},
+		{authModeAzureKey, true},
+		{authModeAzureAAD, true},
+	}
+	for _, tc := range cases {
+		a := &authState{mode: tc.mode}
+		if got := a.stripModelFromBody(); got != tc.want {
+			t.Errorf("stripModelFromBody(%q) = %v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// =====================================================================
+// applyAuth
+// =====================================================================
+
+func TestApplyAuth_OpenAI_SetsBearerHeader(t *testing.T) {
+	a := &authState{mode: authModeOpenAI, apiKey: "k"}
+	req, _ := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+
+	if err := a.applyAuth(context.Background(), req, http.DefaultClient); err != nil {
+		t.Fatalf("applyAuth: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer k" {
+		t.Errorf("Authorization = %q, want Bearer k", got)
+	}
+	if got := req.Header.Get("api-key"); got != "" {
+		t.Errorf("api-key should not be set in openai mode, got %q", got)
+	}
+}
+
+func TestApplyAuth_AzureKey_SetsAPIKeyHeader(t *testing.T) {
+	a := &authState{mode: authModeAzureKey, apiKey: "azure-k"}
+	req, _ := http.NewRequest("POST", "https://r.openai.azure.com/...", nil)
+
+	if err := a.applyAuth(context.Background(), req, http.DefaultClient); err != nil {
+		t.Fatalf("applyAuth: %v", err)
+	}
+	if got := req.Header.Get("api-key"); got != "azure-k" {
+		t.Errorf("api-key = %q, want azure-k", got)
+	}
+	// Critically: Authorization MUST NOT be set (Azure rejects requests with
+	// both api-key and Authorization headers).
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be empty in azure_key mode, got %q", got)
+	}
+}
+
+func TestApplyAuth_AzureAAD_FetchesBearerToken(t *testing.T) {
+	srv := newAADTokenServer(t, "fake-aad-token", 3600)
+	defer srv.Close()
+
+	a := &authState{
+		mode:         authModeAzureAAD,
+		tenantID:     "tenant",
+		clientID:     "client",
+		clientSecret: "secret",
+		aadTokenURL:  srv.URL,
+	}
+	req, _ := http.NewRequest("POST", "https://r.openai.azure.com/...", nil)
+
+	if err := a.applyAuth(context.Background(), req, srv.Client()); err != nil {
+		t.Fatalf("applyAuth: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer fake-aad-token" {
+		t.Errorf("Authorization = %q, want Bearer fake-aad-token", got)
+	}
+	if got := req.Header.Get("api-key"); got != "" {
+		t.Errorf("api-key should not be set in azure_aad mode, got %q", got)
+	}
+}
+
+// =====================================================================
+// AAD token cache + refresh + concurrency
+// =====================================================================
+
+func TestAADToken_FetchAndCache(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		// Verify the form body shape per the plan spec.
+		if r.Form.Get("grant_type") != "client_credentials" {
+			t.Errorf("grant_type = %q", r.Form.Get("grant_type"))
+		}
+		if r.Form.Get("client_id") != "client" {
+			t.Errorf("client_id = %q", r.Form.Get("client_id"))
+		}
+		if r.Form.Get("client_secret") != "secret" {
+			t.Errorf("client_secret = %q", r.Form.Get("client_secret"))
+		}
+		if r.Form.Get("scope") != "https://cognitiveservices.azure.com/.default" {
+			t.Errorf("scope = %q", r.Form.Get("scope"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	a := &authState{
+		mode:         authModeAzureAAD,
+		tenantID:     "t",
+		clientID:     "client",
+		clientSecret: "secret",
+		aadTokenURL:  srv.URL,
+	}
+
+	tok, err := a.aadAccessToken(context.Background(), srv.Client())
+	if err != nil {
+		t.Fatalf("aadAccessToken: %v", err)
+	}
+	if tok != "tok" {
+		t.Errorf("token = %q, want tok", tok)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected 1 token-endpoint hit, got %d", hits.Load())
+	}
+
+	// Second call should be served from cache (no new HTTP roundtrip).
+	tok2, err := a.aadAccessToken(context.Background(), srv.Client())
+	if err != nil {
+		t.Fatalf("second aadAccessToken: %v", err)
+	}
+	if tok2 != "tok" {
+		t.Errorf("cached token = %q, want tok", tok2)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected token caching; saw %d hits", hits.Load())
+	}
+}
+
+func TestAADToken_RefreshOnExpiry(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"refreshed","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	a := &authState{
+		mode:         authModeAzureAAD,
+		tenantID:     "t",
+		clientID:     "c",
+		clientSecret: "s",
+		aadTokenURL:  srv.URL,
+		// Pre-seed an expired token; should trigger a refresh.
+		token:     "stale",
+		tokExpiry: time.Now().Add(-1 * time.Minute),
+	}
+
+	tok, err := a.aadAccessToken(context.Background(), srv.Client())
+	if err != nil {
+		t.Fatalf("aadAccessToken: %v", err)
+	}
+	if tok != "refreshed" {
+		t.Errorf("token = %q, want refreshed", tok)
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected refresh, got %d hits", hits.Load())
+	}
+}
+
+func TestAADToken_EndpointFailureWrapsBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"bad creds"}`))
+	}))
+	defer srv.Close()
+
+	a := &authState{
+		mode:         authModeAzureAAD,
+		tenantID:     "t",
+		clientID:     "c",
+		clientSecret: "s",
+		aadTokenURL:  srv.URL,
+	}
+
+	_, err := a.aadAccessToken(context.Background(), srv.Client())
+	if err == nil {
+		t.Fatal("expected error from failing token endpoint")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "401") {
+		t.Errorf("error missing status code: %q", msg)
+	}
+	if !strings.Contains(msg, "invalid_client") {
+		t.Errorf("error missing body content: %q", msg)
+	}
+}
+
+// TestAADToken_ConcurrentRequestsSerialize spins up N goroutines that all
+// call applyAuth with an empty cache; only one should reach the token
+// endpoint. Run with `go test -race` to also check the mutex pairing.
+func TestAADToken_ConcurrentRequestsSerialize(t *testing.T) {
+	var hits atomic.Int32
+	// Add a tiny delay to widen the race window if the mutex is missing.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"only-one","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	a := &authState{
+		mode:         authModeAzureAAD,
+		tenantID:     "t",
+		clientID:     "c",
+		clientSecret: "s",
+		aadTokenURL:  srv.URL,
+	}
+
+	const N = 10
+	var wg sync.WaitGroup
+	wg.Add(N)
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest("POST", "https://example.invalid/", nil)
+			if err := a.applyAuth(context.Background(), req, srv.Client()); err != nil {
+				errs <- err
+				return
+			}
+			if got := req.Header.Get("Authorization"); got != "Bearer only-one" {
+				errs <- fmt.Errorf("bad header: %q", got)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	if hits.Load() != 1 {
+		t.Errorf("expected exactly 1 token-endpoint hit under concurrency, got %d", hits.Load())
+	}
+}
+
+// =====================================================================
+// Test helpers
+// =====================================================================
+
+// newAADTokenServer returns a fake AAD token endpoint that always issues
+// the given token with the given expires_in.
+func newAADTokenServer(t *testing.T, token string, expiresIn int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":%q,"expires_in":%d,"token_type":"Bearer"}`, token, expiresIn)
+	}))
+}

--- a/plugins/providers/openai/files.go
+++ b/plugins/providers/openai/files.go
@@ -1,0 +1,352 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"sync"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	// filesAPIBaseURL is the production OpenAI Files API endpoint. Tests
+	// override Plugin.filesAPIURL with an httptest server URL.
+	filesAPIBaseURL = "https://api.openai.com/v1/files"
+	// defaultFilesPurpose is the default `purpose` field used when uploading.
+	// "user_data" is the value OpenAI documents for files referenced from
+	// chat completions.
+	defaultFilesPurpose = "user_data"
+	// uploadThresholdDefault is 5MB; matches the smallest of the inline image
+	// limits we care about. Image parts over this size are not auto-uploaded
+	// by OpenAI (the chat completions image_url type doesn't accept file_ids),
+	// but the threshold is kept in config for forward-compatibility and for
+	// any future part type that does benefit from it.
+	uploadThresholdDefault = 5 * 1024 * 1024
+)
+
+// filesConfig controls OpenAI Files API behavior.
+//
+//	files:
+//	  enabled: true                # default false; when false the plugin never uploads
+//	  purpose: user_data           # default "user_data" — sent as multipart `purpose` field
+//	  upload_threshold: 5242880    # bytes; reserved for future use, doesn't affect file parts
+//	  cache_uploads: true          # in-memory sha256(content) -> file_id reuse within session
+//	  delete_on_shutdown: false    # best-effort DELETE for session-uploaded ids on Shutdown
+//
+// Note: file-type parts (PDFs, etc.) are ALWAYS uploaded when Enabled is true,
+// because OpenAI's chat completions API doesn't accept inline file payloads
+// well — file_id is the canonical reference. Image parts are never
+// auto-uploaded since the chat completions image_url type doesn't accept a
+// bare file_id; oversize images must be passed by public URL or rejected.
+type filesConfig struct {
+	Enabled          bool
+	Purpose          string
+	UploadThreshold  int
+	CacheUploads     bool
+	DeleteOnShutdown bool
+}
+
+// parseFilesConfig pulls filesConfig out of the plugin's raw config map.
+// Absent block returns Enabled=false; an explicit empty map returns
+// Enabled=false but with sensible defaults for the other fields. When Enabled
+// is true and UploadThreshold is unset/zero, fall back to uploadThresholdDefault.
+func parseFilesConfig(cfg map[string]any) filesConfig {
+	fc := filesConfig{
+		Purpose:         defaultFilesPurpose,
+		UploadThreshold: uploadThresholdDefault,
+		CacheUploads:    true,
+	}
+
+	raw, ok := cfg["files"].(map[string]any)
+	if !ok {
+		return fc
+	}
+
+	if v, ok := raw["enabled"].(bool); ok {
+		fc.Enabled = v
+	}
+	if v, ok := raw["purpose"].(string); ok && v != "" {
+		fc.Purpose = v
+	}
+	if v, ok := raw["upload_threshold"].(int); ok && v > 0 {
+		fc.UploadThreshold = v
+	} else if v, ok := raw["upload_threshold"].(float64); ok && v > 0 {
+		fc.UploadThreshold = int(v)
+	}
+	if v, ok := raw["cache_uploads"].(bool); ok {
+		fc.CacheUploads = v
+	}
+	if v, ok := raw["delete_on_shutdown"].(bool); ok {
+		fc.DeleteOnShutdown = v
+	}
+
+	return fc
+}
+
+// fileCache maps content hash -> file_id for in-session deduplication. Backed
+// by a plain mutex; Files API uploads are infrequent enough that contention
+// isn't a concern.
+//
+// In-memory only — cross-session caching would have to handle 404s on stale
+// ids (OpenAI doesn't auto-expire files, but they can be deleted out of
+// band), and we don't implement that recovery path here.
+type fileCache struct {
+	mu      sync.Mutex
+	entries map[string]string
+}
+
+func newFileCache() *fileCache {
+	return &fileCache{entries: make(map[string]string)}
+}
+
+func (c *fileCache) get(key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id, ok := c.entries[key]
+	return id, ok
+}
+
+func (c *fileCache) put(key, id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = id
+}
+
+// hashKey computes the cache key for an inline payload. MimeType is folded in
+// so identical bytes uploaded under different mime types don't collide.
+func hashKey(mimeType string, data []byte) string {
+	h := sha256.New()
+	h.Write([]byte(mimeType))
+	h.Write([]byte{':'})
+	h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// uploadFile multipart-POSTs bytes to the OpenAI Files API and returns the
+// resulting file_id. Tests inject an alternate base URL via p.filesAPIURL.
+//
+// purpose is sent as a separate multipart field (OpenAI requires it). When
+// empty, defaultFilesPurpose ("user_data") is used.
+func (p *Plugin) uploadFile(ctx context.Context, data []byte, mimeType, filename, purpose string) (string, error) {
+	endpoint := p.filesAPIURL
+	if endpoint == "" {
+		endpoint = filesAPIBaseURL
+	}
+	if purpose == "" {
+		purpose = defaultFilesPurpose
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	// purpose field first — it's the cheaper write and easier to spot in
+	// captured request bodies during debugging.
+	if err := mw.WriteField("purpose", purpose); err != nil {
+		return "", fmt.Errorf("openai: write purpose field: %w", err)
+	}
+
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename=%q`, filename))
+	if mimeType != "" {
+		header.Set("Content-Type", mimeType)
+	}
+	part, err := mw.CreatePart(header)
+	if err != nil {
+		return "", fmt.Errorf("openai: create multipart part: %w", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		return "", fmt.Errorf("openai: write multipart payload: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return "", fmt.Errorf("openai: close multipart writer: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, &buf)
+	if err != nil {
+		return "", fmt.Errorf("openai: build files request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Content-Type", mw.FormDataContentType())
+	httpReq.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("openai: files upload HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("openai: files upload returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		ID        string `json:"id"`
+		Object    string `json:"object"`
+		Filename  string `json:"filename"`
+		Bytes     int    `json:"bytes"`
+		Purpose   string `json:"purpose"`
+		CreatedAt int64  `json:"created_at"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("openai: parse files response: %w", err)
+	}
+	if parsed.ID == "" {
+		return "", fmt.Errorf("openai: files response missing id: %s", string(body))
+	}
+	return parsed.ID, nil
+}
+
+// deleteFile issues a DELETE against /v1/files/{id}. Best-effort — used by
+// Shutdown when delete_on_shutdown is enabled.
+func (p *Plugin) deleteFile(ctx context.Context, id string) error {
+	base := p.filesAPIURL
+	if base == "" {
+		base = filesAPIBaseURL
+	}
+	endpoint := base + "/" + id
+
+	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("openai: build delete request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("openai: files delete HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("openai: files delete returned status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// preuploadParts walks msgs and uploads file-type Data parts to the Files API,
+// swapping in the returned file_id (preferred over inline data).
+//
+// Rules:
+//   - file parts: ALWAYS upload when Data is present (no inline path on
+//     OpenAI's chat completions API matches well — file_id is the canonical
+//     reference). If the part already carries FileID, leave it alone. URI on a
+//     file part is rejected at request-build time by buildFilePart.
+//   - image parts: SKIPPED entirely. OpenAI's chat completions image_url type
+//     doesn't accept a bare file_id, so auto-upload would just lose data.
+//     Oversize images must be referenced by public URL.
+//   - other types (text, audio, video): skipped — they don't go through
+//     the Files API.
+//
+// Returns a fresh slice (caller's messages are not mutated). Successful
+// uploads clear part.Data to free memory and avoid double-send if the
+// message is re-serialized.
+func (p *Plugin) preuploadParts(ctx context.Context, msgs []events.Message) ([]events.Message, error) {
+	if !p.files.Enabled || len(msgs) == 0 {
+		return msgs, nil
+	}
+
+	out := make([]events.Message, len(msgs))
+	for i, m := range msgs {
+		out[i] = m
+		if len(m.Parts) == 0 {
+			continue
+		}
+		var newParts []events.MessagePart
+		for j, part := range m.Parts {
+			// Only file-type parts are eligible for auto-upload. Image,
+			// audio, video, and text are passed through unchanged.
+			if part.Type != "file" {
+				if newParts != nil {
+					newParts[j] = part
+				}
+				continue
+			}
+			// Already has a FileID — nothing to do.
+			if part.FileID != "" {
+				if newParts != nil {
+					newParts[j] = part
+				}
+				continue
+			}
+			// Need bytes to upload. URI alone won't work because OpenAI's
+			// Files API doesn't fetch from URLs; the user has to provide
+			// the bytes. buildFilePart will surface a clearer error if the
+			// caller meant to reference an already-uploaded file.
+			if len(part.Data) == 0 {
+				return nil, fmt.Errorf("openai: file part has no Data to upload (set FileID or Data)")
+			}
+			if part.MimeType == "" {
+				return nil, fmt.Errorf("openai: file part requires mime_type for files upload")
+			}
+
+			// Allocate the per-message copy lazily — saves an alloc when
+			// the message has no eligible parts (the common case).
+			if newParts == nil {
+				newParts = make([]events.MessagePart, len(m.Parts))
+				copy(newParts, m.Parts)
+			}
+
+			var key string
+			if p.files.CacheUploads && p.fileCache != nil {
+				key = hashKey(part.MimeType, part.Data)
+				if id, ok := p.fileCache.get(key); ok {
+					p.logger.Debug("openai: files cache hit", "type", part.Type, "bytes", len(part.Data), "file_id", id)
+					newParts[j].FileID = id
+					newParts[j].Data = nil
+					continue
+				}
+			}
+
+			filename := fmt.Sprintf("nexus-%s-%d-%d", part.Type, i, j)
+			p.logger.Info("openai: uploading file part via Files API", "type", part.Type, "bytes", len(part.Data), "mime", part.MimeType)
+			id, err := p.uploadFile(ctx, part.Data, part.MimeType, filename, p.files.Purpose)
+			if err != nil {
+				return nil, fmt.Errorf("openai: files upload: %w", err)
+			}
+			newParts[j].FileID = id
+			newParts[j].Data = nil
+
+			if p.files.CacheUploads && p.fileCache != nil && key != "" {
+				p.fileCache.put(key, id)
+			}
+			p.trackUploadedID(id)
+		}
+		if newParts != nil {
+			out[i].Parts = newParts
+		}
+	}
+	return out, nil
+}
+
+// trackUploadedID records a file_id this session uploaded so Shutdown can
+// optionally delete it. Safe to call from concurrent request goroutines.
+func (p *Plugin) trackUploadedID(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sessionFileIDs = append(p.sessionFileIDs, id)
+}
+
+// snapshotSessionFileIDs returns a copy of the session-tracked file IDs and
+// clears the slice. Used by Shutdown.
+func (p *Plugin) snapshotSessionFileIDs() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.sessionFileIDs) == 0 {
+		return nil
+	}
+	ids := make([]string, len(p.sessionFileIDs))
+	copy(ids, p.sessionFileIDs)
+	p.sessionFileIDs = nil
+	return ids
+}

--- a/plugins/providers/openai/files.go
+++ b/plugins/providers/openai/files.go
@@ -174,7 +174,14 @@ func (p *Plugin) uploadFile(ctx context.Context, data []byte, mimeType, filename
 	if err != nil {
 		return "", fmt.Errorf("openai: build files request: %w", err)
 	}
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	// Files API stays on the public OpenAI endpoint regardless of auth mode
+	// (Azure exposes a different Files surface). p.auth.apiKey is the
+	// public-OpenAI key — populated by the legacy top-level api_key /
+	// api_key_env config keys, which survive in all modes.
+	if p.auth == nil || p.auth.apiKey == "" {
+		return "", fmt.Errorf("openai: Files API requires a public-OpenAI api_key (set api_key or OPENAI_API_KEY)")
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.auth.apiKey)
 	httpReq.Header.Set("Content-Type", mw.FormDataContentType())
 	httpReq.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
 
@@ -219,7 +226,10 @@ func (p *Plugin) deleteFile(ctx context.Context, id string) error {
 	if err != nil {
 		return fmt.Errorf("openai: build delete request: %w", err)
 	}
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	if p.auth == nil || p.auth.apiKey == "" {
+		return fmt.Errorf("openai: Files API delete requires a public-OpenAI api_key")
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.auth.apiKey)
 
 	resp, err := p.client.Do(httpReq)
 	if err != nil {

--- a/plugins/providers/openai/files_test.go
+++ b/plugins/providers/openai/files_test.go
@@ -87,7 +87,7 @@ func newFilesTestPlugin(t *testing.T, handler http.Handler) (*Plugin, *httptest.
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	p := &Plugin{
-		apiKey:      "test-key",
+		auth:        &authState{mode: authModeOpenAI, apiKey: "test-key"},
 		client:      srv.Client(),
 		logger:      silentLogger(),
 		filesAPIURL: srv.URL,

--- a/plugins/providers/openai/files_test.go
+++ b/plugins/providers/openai/files_test.go
@@ -1,0 +1,489 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// TestParseFilesConfig_Defaults asserts that an absent files block yields a
+// zero-valued config (Enabled=false, threshold=default, cache_uploads=true,
+// purpose=user_data).
+func TestParseFilesConfig_Defaults(t *testing.T) {
+	fc := parseFilesConfig(map[string]any{})
+	if fc.Enabled {
+		t.Fatalf("expected disabled by default, got enabled")
+	}
+	if fc.Purpose != defaultFilesPurpose {
+		t.Fatalf("expected purpose=%q, got %q", defaultFilesPurpose, fc.Purpose)
+	}
+	if fc.UploadThreshold != uploadThresholdDefault {
+		t.Fatalf("expected threshold=%d, got %d", uploadThresholdDefault, fc.UploadThreshold)
+	}
+	if !fc.CacheUploads {
+		t.Fatalf("expected cache_uploads=true by default")
+	}
+	if fc.DeleteOnShutdown {
+		t.Fatalf("expected delete_on_shutdown=false by default")
+	}
+}
+
+// TestParseFilesConfig_Explicit covers explicit overrides for every field.
+func TestParseFilesConfig_Explicit(t *testing.T) {
+	cfg := map[string]any{
+		"files": map[string]any{
+			"enabled":            true,
+			"purpose":            "assistants",
+			"upload_threshold":   1024,
+			"cache_uploads":      false,
+			"delete_on_shutdown": true,
+		},
+	}
+	fc := parseFilesConfig(cfg)
+	if !fc.Enabled {
+		t.Fatalf("expected enabled=true")
+	}
+	if fc.Purpose != "assistants" {
+		t.Fatalf("expected purpose=assistants, got %q", fc.Purpose)
+	}
+	if fc.UploadThreshold != 1024 {
+		t.Fatalf("expected threshold=1024, got %d", fc.UploadThreshold)
+	}
+	if fc.CacheUploads {
+		t.Fatalf("expected cache_uploads=false")
+	}
+	if !fc.DeleteOnShutdown {
+		t.Fatalf("expected delete_on_shutdown=true")
+	}
+}
+
+// TestParseFilesConfig_FloatThreshold guards against YAML number-parsing,
+// which decodes integers as float64 by default.
+func TestParseFilesConfig_FloatThreshold(t *testing.T) {
+	cfg := map[string]any{
+		"files": map[string]any{
+			"enabled":          true,
+			"upload_threshold": float64(2048),
+		},
+	}
+	fc := parseFilesConfig(cfg)
+	if fc.UploadThreshold != 2048 {
+		t.Fatalf("expected threshold=2048, got %d", fc.UploadThreshold)
+	}
+}
+
+// newFilesTestPlugin returns a Plugin wired to an httptest server with sane
+// defaults. The server URL becomes filesAPIURL so uploadFile and deleteFile
+// route to the fake.
+func newFilesTestPlugin(t *testing.T, handler http.Handler) (*Plugin, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	p := &Plugin{
+		apiKey:      "test-key",
+		client:      srv.Client(),
+		logger:      silentLogger(),
+		filesAPIURL: srv.URL,
+		fileCache:   newFileCache(),
+	}
+	return p, srv
+}
+
+// TestUploadFile_Success verifies the multipart body shape, the Bearer auth
+// header, and that the parsed file_id is returned.
+func TestUploadFile_Success(t *testing.T) {
+	var capturedHeaders http.Header
+	var capturedBody []byte
+	var capturedContentType string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		capturedContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = body
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file-abc","object":"file","filename":"foo.pdf","bytes":42,"purpose":"user_data","created_at":1700000000}`))
+	})
+
+	p, _ := newFilesTestPlugin(t, mux)
+	id, err := p.uploadFile(context.Background(), []byte("payload-bytes"), "application/pdf", "foo.pdf", "user_data")
+	if err != nil {
+		t.Fatalf("uploadFile failed: %v", err)
+	}
+	if id != "file-abc" {
+		t.Fatalf("expected file-abc, got %q", id)
+	}
+
+	// Bearer auth — same as the rest of the OpenAI plugin.
+	if capturedHeaders.Get("Authorization") != "Bearer test-key" {
+		t.Fatalf("missing/wrong Authorization: %q", capturedHeaders.Get("Authorization"))
+	}
+	if !strings.HasPrefix(capturedContentType, "multipart/form-data") {
+		t.Fatalf("expected multipart content-type, got %q", capturedContentType)
+	}
+	// No Anthropic-style beta header should leak in.
+	if capturedHeaders.Get("anthropic-beta") != "" {
+		t.Fatalf("unexpected anthropic-beta header on OpenAI request")
+	}
+
+	bodyStr := string(capturedBody)
+	if !strings.Contains(bodyStr, `name="purpose"`) {
+		t.Fatalf("multipart body missing purpose field: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "user_data") {
+		t.Fatalf("multipart body missing purpose value: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `name="file"`) {
+		t.Fatalf("multipart body missing file field name: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `filename="foo.pdf"`) {
+		t.Fatalf("multipart body missing filename: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "application/pdf") {
+		t.Fatalf("multipart body missing content-type: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "payload-bytes") {
+		t.Fatalf("multipart body missing payload bytes: %s", bodyStr)
+	}
+}
+
+// TestUploadFile_DefaultPurpose asserts that an empty purpose argument
+// defaults to "user_data" in the multipart body.
+func TestUploadFile_DefaultPurpose(t *testing.T) {
+	var capturedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = body
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file-def","object":"file"}`))
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+
+	if _, err := p.uploadFile(context.Background(), []byte("x"), "application/pdf", "x.pdf", ""); err != nil {
+		t.Fatalf("uploadFile: %v", err)
+	}
+	if !strings.Contains(string(capturedBody), "user_data") {
+		t.Fatalf("expected default purpose user_data in body, got: %s", string(capturedBody))
+	}
+}
+
+// TestUploadFile_Failure asserts that 5xx responses produce a descriptive
+// error including status and body.
+func TestUploadFile_Failure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+
+	_, err := p.uploadFile(context.Background(), []byte("data"), "application/pdf", "x.pdf", "user_data")
+	if err == nil {
+		t.Fatal("expected error on 500 response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error missing status: %v", err)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error missing body: %v", err)
+	}
+}
+
+// TestPreuploadParts_FilePart_Uploaded covers the canonical happy path: a
+// file-type Data part is uploaded, FileID is set, Data is cleared. Caller's
+// slice is not mutated.
+func TestPreuploadParts_FilePart_Uploaded(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file-uploaded","object":"file","filename":"x","bytes":10,"purpose":"user_data","created_at":1}`))
+	})
+
+	p, _ := newFilesTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, Purpose: "user_data", CacheUploads: true}
+
+	original := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	msgs := []events.Message{
+		{Role: "user", Parts: []events.MessagePart{
+			{Type: "file", MimeType: "application/pdf", Data: original},
+		}},
+	}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 upload, got %d", calls)
+	}
+	if out[0].Parts[0].FileID != "file-uploaded" {
+		t.Fatalf("expected FileID=file-uploaded, got %q", out[0].Parts[0].FileID)
+	}
+	if out[0].Parts[0].Data != nil {
+		t.Fatalf("expected Data cleared, got %d bytes", len(out[0].Parts[0].Data))
+	}
+	// Caller's slice MUST NOT be mutated.
+	if msgs[0].Parts[0].FileID != "" {
+		t.Fatal("caller's MessagePart was mutated (FileID set on input)")
+	}
+	if len(msgs[0].Parts[0].Data) != len(original) {
+		t.Fatal("caller's MessagePart was mutated (Data cleared)")
+	}
+}
+
+// TestPreuploadParts_FilePart_URIOnly errors out: OpenAI's Files API needs
+// bytes, and the chat completions file type doesn't accept URI references.
+func TestPreuploadParts_FilePart_URIOnly(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("unexpected upload — should have failed pre-upload")
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, Purpose: "user_data", CacheUploads: true}
+
+	msgs := []events.Message{{Role: "user", Parts: []events.MessagePart{
+		{Type: "file", MimeType: "application/pdf", URI: "https://example.com/x.pdf"},
+	}}}
+	_, err := p.preuploadParts(context.Background(), msgs)
+	if err == nil {
+		t.Fatal("expected error for URI-only file part")
+	}
+	if !strings.Contains(err.Error(), "Data") {
+		t.Fatalf("expected error to mention Data: %v", err)
+	}
+}
+
+// TestPreuploadParts_ImagePart_NotUploaded asserts that even oversize image
+// parts are skipped — chat completions image_url doesn't accept file_ids.
+func TestPreuploadParts_ImagePart_NotUploaded(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, Purpose: "user_data", UploadThreshold: 4, CacheUploads: true}
+
+	// 10 bytes — well over UploadThreshold=4. Should still be skipped.
+	msgs := []events.Message{{Role: "user", Parts: []events.MessagePart{
+		{Type: "image", MimeType: "image/png", Data: make([]byte, 10)},
+	}}}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 uploads for image parts, got %d", calls)
+	}
+	if out[0].Parts[0].FileID != "" {
+		t.Fatal("FileID should not be set for image parts (chat completions doesn't accept image file_ids)")
+	}
+	if len(out[0].Parts[0].Data) != 10 {
+		t.Fatal("Data should be preserved for image parts")
+	}
+}
+
+// TestPreuploadParts_FileIDPassthrough covers parts that already have a
+// FileID: no upload, no mutation.
+func TestPreuploadParts_FileIDPassthrough(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, Purpose: "user_data", CacheUploads: true}
+
+	msgs := []events.Message{{Role: "user", Parts: []events.MessagePart{
+		{Type: "file", FileID: "file-existing", Data: make([]byte, 10)},
+	}}}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 uploads when FileID set, got %d", calls)
+	}
+	if out[0].Parts[0].FileID != "file-existing" {
+		t.Fatalf("FileID should be preserved, got %q", out[0].Parts[0].FileID)
+	}
+}
+
+// TestPreuploadParts_CacheHit verifies that uploading the same content twice
+// hits the in-memory cache and produces only one HTTP call.
+func TestPreuploadParts_CacheHit(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file-cached","object":"file","filename":"x","bytes":10,"purpose":"user_data","created_at":1}`))
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: true, Purpose: "user_data", CacheUploads: true}
+
+	payload := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	mk := func() []events.Message {
+		return []events.Message{{Role: "user", Parts: []events.MessagePart{
+			{Type: "file", MimeType: "application/pdf", Data: append([]byte(nil), payload...)},
+		}}}
+	}
+
+	out1, err := p.preuploadParts(context.Background(), mk())
+	if err != nil {
+		t.Fatalf("first preuploadParts: %v", err)
+	}
+	out2, err := p.preuploadParts(context.Background(), mk())
+	if err != nil {
+		t.Fatalf("second preuploadParts: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 upload (cache hit on second), got %d", calls)
+	}
+	if out1[0].Parts[0].FileID != "file-cached" || out2[0].Parts[0].FileID != "file-cached" {
+		t.Fatalf("expected both calls to resolve to file-cached, got %q / %q",
+			out1[0].Parts[0].FileID, out2[0].Parts[0].FileID)
+	}
+}
+
+// TestPreuploadParts_Disabled is a no-op when files.Enabled is false.
+func TestPreuploadParts_Disabled(t *testing.T) {
+	var calls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+	p.files = filesConfig{Enabled: false}
+
+	msgs := []events.Message{{Role: "user", Parts: []events.MessagePart{
+		{Type: "file", MimeType: "application/pdf", Data: make([]byte, 10)},
+	}}}
+	out, err := p.preuploadParts(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("preuploadParts failed: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 uploads when feature disabled, got %d", calls)
+	}
+	if out[0].Parts[0].FileID != "" {
+		t.Fatal("FileID should not be set when feature disabled")
+	}
+}
+
+// TestDeleteFile_Success exercises the DELETE happy path.
+func TestDeleteFile_Success(t *testing.T) {
+	var capturedPath string
+	var capturedHeaders http.Header
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedHeaders = r.Header.Clone()
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"file-abc","object":"file","deleted":true}`))
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+
+	if err := p.deleteFile(context.Background(), "file-abc"); err != nil {
+		t.Fatalf("deleteFile: %v", err)
+	}
+	if !strings.HasSuffix(capturedPath, "/file-abc") {
+		t.Fatalf("expected path ending in /file-abc, got %s", capturedPath)
+	}
+	if capturedHeaders.Get("Authorization") != "Bearer test-key" {
+		t.Fatalf("expected Bearer auth on delete, got %q", capturedHeaders.Get("Authorization"))
+	}
+}
+
+// TestDeleteFile_FailureNonFatal asserts that 4xx surfaces a descriptive error.
+func TestDeleteFile_FailureNonFatal(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+	err := p.deleteFile(context.Background(), "file-missing")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Fatalf("error missing status: %v", err)
+	}
+}
+
+// TestSessionFileIDTracking_DeleteOnShutdown simulates a session where two
+// uploads happen, then verifies the snapshot returns both ids and a follow-up
+// snapshot is empty (the slice is consumed).
+func TestSessionFileIDTracking_DeleteOnShutdown(t *testing.T) {
+	var deleted []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			id := "file-" + r.URL.Path
+			body, _ := json.Marshal(map[string]any{"id": id, "object": "file"})
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		case http.MethodDelete:
+			parts := strings.Split(r.URL.Path, "/")
+			deleted = append(deleted, parts[len(parts)-1])
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"x","object":"file","deleted":true}`))
+		}
+	})
+	p, _ := newFilesTestPlugin(t, mux)
+
+	p.trackUploadedID("file-one")
+	p.trackUploadedID("file-two")
+	ids := p.snapshotSessionFileIDs()
+	if len(ids) != 2 || ids[0] != "file-one" || ids[1] != "file-two" {
+		t.Fatalf("unexpected snapshot: %v", ids)
+	}
+	if again := p.snapshotSessionFileIDs(); again != nil {
+		t.Fatalf("expected second snapshot empty, got %v", again)
+	}
+
+	for _, id := range ids {
+		if err := p.deleteFile(context.Background(), id); err != nil {
+			t.Fatalf("deleteFile(%s): %v", id, err)
+		}
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("expected 2 deletes, got %d (%v)", len(deleted), deleted)
+	}
+}
+
+// TestHashKey_Stability verifies the cache key changes when content or
+// mime_type changes, and is stable for identical inputs.
+func TestHashKey_Stability(t *testing.T) {
+	a := hashKey("application/pdf", []byte("hello"))
+	b := hashKey("application/pdf", []byte("hello"))
+	c := hashKey("text/plain", []byte("hello"))
+	d := hashKey("application/pdf", []byte("world"))
+	if a != b {
+		t.Fatal("expected identical hashes for identical inputs")
+	}
+	if a == c {
+		t.Fatal("expected different hash for different mime")
+	}
+	if a == d {
+		t.Fatal("expected different hash for different bytes")
+	}
+}

--- a/plugins/providers/openai/multimodal.go
+++ b/plugins/providers/openai/multimodal.go
@@ -1,0 +1,182 @@
+package openai
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// inlineImageLimit is the byte ceiling above which OpenAI rejects inline image
+// payloads. Per OpenAI's vision docs the cap is roughly 20 MB whether the image
+// is referenced by URL or sent as a data URL. We enforce the same limit on
+// inline base64 payloads here.
+const inlineImageLimit = 20 * 1024 * 1024
+
+// multimodalConfig holds OpenAI multimodal defaults.
+//
+//	multimodal:
+//	  default_image_detail: auto    # auto | low | high
+type multimodalConfig struct {
+	DefaultImageDetail string
+}
+
+// parseMultimodalConfig reads the optional "multimodal" map from the plugin
+// config. Unknown or invalid values fall back to "auto".
+func parseMultimodalConfig(cfg map[string]any) multimodalConfig {
+	mc := multimodalConfig{DefaultImageDetail: "auto"}
+	raw, ok := cfg["multimodal"].(map[string]any)
+	if !ok {
+		return mc
+	}
+	if v, ok := raw["default_image_detail"].(string); ok {
+		switch v {
+		case "auto", "low", "high":
+			mc.DefaultImageDetail = v
+		}
+	}
+	return mc
+}
+
+// buildContentParts converts an events.Message with Parts into OpenAI's
+// content-array form. Returns nil when Parts is empty (caller falls back to
+// the string Content path). Errors on unsupported types.
+func buildContentParts(msg events.Message, cfg multimodalConfig) ([]map[string]any, error) {
+	if len(msg.Parts) == 0 {
+		return nil, nil
+	}
+	out := make([]map[string]any, 0, len(msg.Parts)+1)
+	if msg.Content != "" {
+		out = append(out, map[string]any{"type": "text", "text": msg.Content})
+	}
+	for _, part := range msg.Parts {
+		switch part.Type {
+		case "text":
+			out = append(out, map[string]any{"type": "text", "text": part.Text})
+
+		case "image":
+			block, err := buildImagePart(part, cfg.DefaultImageDetail)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, block)
+
+		case "audio":
+			block, err := buildAudioPart(part)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, block)
+
+		case "file":
+			block, err := buildFilePart(part)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, block)
+
+		case "video":
+			return nil, fmt.Errorf("openai: video parts are not supported")
+
+		default:
+			return nil, fmt.Errorf("openai: unsupported part type %q", part.Type)
+		}
+	}
+	return out, nil
+}
+
+// buildImagePart builds an image_url block. URI passes through; inline Data
+// becomes a data URL. OpenAI's chat completions image_url type doesn't accept
+// a bare file_id, so a FileID-only image part is rejected with a clear error.
+func buildImagePart(part events.MessagePart, defaultDetail string) (map[string]any, error) {
+	var url string
+	switch {
+	case part.URI != "":
+		url = part.URI
+	case len(part.Data) > 0:
+		if part.MimeType == "" {
+			return nil, fmt.Errorf("openai: image part requires mime_type when Data is set")
+		}
+		if len(part.Data) > inlineImageLimit {
+			return nil, fmt.Errorf("openai: image part (%d bytes) exceeds %d byte inline limit; upload via Files API and reference via URI", len(part.Data), inlineImageLimit)
+		}
+		url = "data:" + part.MimeType + ";base64," + base64.StdEncoding.EncodeToString(part.Data)
+	case part.FileID != "":
+		// OpenAI's chat completions image_url type doesn't accept a bare
+		// file_id; images must be either a public URL or a data URL.
+		return nil, fmt.Errorf("openai: image parts cannot reference a file_id directly; use URI (public URL) or Data (inline)")
+	default:
+		return nil, fmt.Errorf("openai: image part has no URI, Data, or FileID")
+	}
+	return map[string]any{
+		"type": "image_url",
+		"image_url": map[string]any{
+			"url":    url,
+			"detail": defaultDetail,
+		},
+	}, nil
+}
+
+// buildAudioPart builds an input_audio block. Audio works only on
+// gpt-4o-audio-preview / gpt-4o-realtime-preview models — provider doesn't
+// gate; the API will reject if the model doesn't support it.
+func buildAudioPart(part events.MessagePart) (map[string]any, error) {
+	if len(part.Data) == 0 {
+		return nil, fmt.Errorf("openai: audio part requires inline Data")
+	}
+	if part.MimeType == "" {
+		return nil, fmt.Errorf("openai: audio part requires mime_type")
+	}
+	format, err := audioFormatFromMime(part.MimeType)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"type": "input_audio",
+		"input_audio": map[string]any{
+			"data":   base64.StdEncoding.EncodeToString(part.Data),
+			"format": format,
+		},
+	}, nil
+}
+
+// audioFormatFromMime maps a MIME type to OpenAI's input_audio format string.
+// OpenAI accepts "wav" or "mp3" today.
+func audioFormatFromMime(mimeType string) (string, error) {
+	switch strings.ToLower(mimeType) {
+	case "audio/wav", "audio/wave", "audio/x-wav":
+		return "wav", nil
+	case "audio/mpeg", "audio/mp3":
+		return "mp3", nil
+	default:
+		return "", fmt.Errorf("openai: unsupported audio mime type %q (expected audio/wav or audio/mpeg)", mimeType)
+	}
+}
+
+// buildFilePart builds a file block. Either FileID (preferred) or inline
+// base64 file_data + filename. URI references aren't accepted by OpenAI's
+// chat completions file type.
+func buildFilePart(part events.MessagePart) (map[string]any, error) {
+	inner := map[string]any{}
+	switch {
+	case part.FileID != "":
+		inner["file_id"] = part.FileID
+	case len(part.Data) > 0:
+		if part.MimeType == "" {
+			return nil, fmt.Errorf("openai: file part requires mime_type when Data is set")
+		}
+		// OpenAI expects filename + file_data (data URL) for inline files.
+		// Filename is a placeholder until MessagePart grows a Filename field.
+		inner["filename"] = "file"
+		inner["file_data"] = "data:" + part.MimeType + ";base64," + base64.StdEncoding.EncodeToString(part.Data)
+	case part.URI != "":
+		return nil, fmt.Errorf("openai: file parts referenced by URI are not supported; upload via Files API and set FileID")
+	default:
+		return nil, fmt.Errorf("openai: file part has no FileID, Data, or URI")
+	}
+	return map[string]any{
+		"type": "file",
+		"file": inner,
+	}, nil
+}

--- a/plugins/providers/openai/multimodal_test.go
+++ b/plugins/providers/openai/multimodal_test.go
@@ -1,0 +1,472 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func newTestPlugin(cfg multimodalConfig) *Plugin {
+	return &Plugin{
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		multimodal: cfg,
+	}
+}
+
+func TestParseMultimodalConfig_Defaults(t *testing.T) {
+	mc := parseMultimodalConfig(nil)
+	if mc.DefaultImageDetail != "auto" {
+		t.Errorf("expected default detail 'auto', got %q", mc.DefaultImageDetail)
+	}
+	mc = parseMultimodalConfig(map[string]any{})
+	if mc.DefaultImageDetail != "auto" {
+		t.Errorf("expected default detail 'auto', got %q", mc.DefaultImageDetail)
+	}
+}
+
+func TestParseMultimodalConfig_Explicit(t *testing.T) {
+	for _, level := range []string{"auto", "low", "high"} {
+		cfg := map[string]any{
+			"multimodal": map[string]any{
+				"default_image_detail": level,
+			},
+		}
+		mc := parseMultimodalConfig(cfg)
+		if mc.DefaultImageDetail != level {
+			t.Errorf("expected detail %q, got %q", level, mc.DefaultImageDetail)
+		}
+	}
+}
+
+func TestParseMultimodalConfig_InvalidFallback(t *testing.T) {
+	cfg := map[string]any{
+		"multimodal": map[string]any{
+			"default_image_detail": "ultra",
+		},
+	}
+	mc := parseMultimodalConfig(cfg)
+	if mc.DefaultImageDetail != "auto" {
+		t.Errorf("expected fallback to 'auto' on invalid input, got %q", mc.DefaultImageDetail)
+	}
+}
+
+func TestBuildContentParts_EmptyParts(t *testing.T) {
+	parts, err := buildContentParts(events.Message{Content: "hello"}, multimodalConfig{DefaultImageDetail: "auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parts != nil {
+		t.Errorf("expected nil parts when Parts is empty, got %v", parts)
+	}
+}
+
+func TestBuildContentParts_TextPart(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "text", Text: "first"}},
+	}
+	parts, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parts))
+	}
+	if parts[0]["type"] != "text" || parts[0]["text"] != "first" {
+		t.Errorf("unexpected text block: %+v", parts[0])
+	}
+}
+
+func TestBuildContentParts_TextPart_WithContentPrefix(t *testing.T) {
+	msg := events.Message{
+		Content: "leading",
+		Parts:   []events.MessagePart{{Type: "text", Text: "follow-up"}},
+	}
+	parts, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	if parts[0]["text"] != "leading" || parts[1]["text"] != "follow-up" {
+		t.Errorf("unexpected order: %+v", parts)
+	}
+}
+
+func TestBuildContentParts_ImageURI(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "image", URI: "https://example.com/cat.png"}},
+	}
+	parts, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "high"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parts))
+	}
+	block := parts[0]
+	if block["type"] != "image_url" {
+		t.Errorf("expected type=image_url, got %v", block["type"])
+	}
+	inner, ok := block["image_url"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected image_url object, got %T", block["image_url"])
+	}
+	if inner["url"] != "https://example.com/cat.png" {
+		t.Errorf("expected URI passthrough, got %v", inner["url"])
+	}
+	if inner["detail"] != "high" {
+		t.Errorf("expected detail=high, got %v", inner["detail"])
+	}
+}
+
+func TestBuildContentParts_ImageDataInline(t *testing.T) {
+	data := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d}
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "image", Data: data, MimeType: "image/png"}},
+	}
+	parts, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	inner := parts[0]["image_url"].(map[string]any)
+	url := inner["url"].(string)
+	prefix := "data:image/png;base64,"
+	if !strings.HasPrefix(url, prefix) {
+		t.Fatalf("expected data URL prefix %q, got %q", prefix, url)
+	}
+	enc := strings.TrimPrefix(url, prefix)
+	decoded, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		t.Fatalf("failed to decode base64: %v", err)
+	}
+	if !bytes.Equal(decoded, data) {
+		t.Errorf("round-trip mismatch")
+	}
+}
+
+func TestBuildContentParts_ImageDataTooLarge(t *testing.T) {
+	data := bytes.Repeat([]byte{0x01}, inlineImageLimit+1)
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "image", Data: data, MimeType: "image/png"}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for oversized image, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestBuildContentParts_ImageDataMissingMime(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "image", Data: []byte{1, 2, 3}}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for missing mime_type, got nil")
+	}
+	if !strings.Contains(err.Error(), "mime_type") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestBuildContentParts_ImageFileIDRejected(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "image", FileID: "file-abc"}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for image with FileID, got nil")
+	}
+	if !strings.Contains(err.Error(), "file_id") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestBuildContentParts_AudioWAV(t *testing.T) {
+	data := []byte("RIFFwave-bytes")
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "audio", Data: data, MimeType: "audio/wav"}},
+	}
+	parts, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	block := parts[0]
+	if block["type"] != "input_audio" {
+		t.Errorf("expected type=input_audio, got %v", block["type"])
+	}
+	inner := block["input_audio"].(map[string]any)
+	if inner["format"] != "wav" {
+		t.Errorf("expected format=wav, got %v", inner["format"])
+	}
+	enc := inner["data"].(string)
+	decoded, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		t.Fatalf("failed to decode base64: %v", err)
+	}
+	if !bytes.Equal(decoded, data) {
+		t.Errorf("audio data round-trip mismatch")
+	}
+}
+
+func TestBuildContentParts_AudioMP3(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "audio", Data: []byte{0xFF, 0xFB}, MimeType: "audio/mpeg"}},
+	}
+	parts, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	inner := parts[0]["input_audio"].(map[string]any)
+	if inner["format"] != "mp3" {
+		t.Errorf("expected format=mp3, got %v", inner["format"])
+	}
+}
+
+func TestBuildContentParts_AudioUnsupportedMime(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "audio", Data: []byte{0}, MimeType: "audio/ogg"}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for unsupported audio mime, got nil")
+	}
+}
+
+func TestBuildContentParts_AudioMissingData(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "audio", MimeType: "audio/wav"}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for missing audio data, got nil")
+	}
+}
+
+func TestBuildContentParts_AudioMissingMime(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "audio", Data: []byte{1}}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for missing audio mime, got nil")
+	}
+}
+
+func TestBuildContentParts_FileWithFileID(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "file", FileID: "file-abc123"}},
+	}
+	parts, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	block := parts[0]
+	if block["type"] != "file" {
+		t.Errorf("expected type=file, got %v", block["type"])
+	}
+	inner := block["file"].(map[string]any)
+	if inner["file_id"] != "file-abc123" {
+		t.Errorf("expected file_id passthrough, got %v", inner["file_id"])
+	}
+	if _, ok := inner["file_data"]; ok {
+		t.Errorf("file_data should be absent when FileID is set")
+	}
+}
+
+func TestBuildContentParts_FileWithDataInline(t *testing.T) {
+	data := []byte("PDF-bytes")
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "file", Data: data, MimeType: "application/pdf"}},
+	}
+	parts, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	inner := parts[0]["file"].(map[string]any)
+	if inner["filename"] != "file" {
+		t.Errorf("expected filename placeholder 'file', got %v", inner["filename"])
+	}
+	fd, ok := inner["file_data"].(string)
+	if !ok {
+		t.Fatalf("expected file_data string, got %T", inner["file_data"])
+	}
+	prefix := "data:application/pdf;base64,"
+	if !strings.HasPrefix(fd, prefix) {
+		t.Errorf("expected data URL prefix %q, got %q", prefix, fd)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(fd, prefix))
+	if err != nil {
+		t.Fatalf("failed to decode base64: %v", err)
+	}
+	if !bytes.Equal(decoded, data) {
+		t.Errorf("file data round-trip mismatch")
+	}
+}
+
+func TestBuildContentParts_FileWithDataMissingMime(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "file", Data: []byte{1, 2}}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for missing mime_type on inline file, got nil")
+	}
+}
+
+func TestBuildContentParts_FileWithURIRejected(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "file", URI: "https://example.com/x.pdf"}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for file URI, got nil")
+	}
+}
+
+func TestBuildContentParts_FileEmpty(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "file"}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for empty file part, got nil")
+	}
+}
+
+func TestBuildContentParts_VideoRejected(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "video", URI: "https://example.com/v.mp4", MimeType: "video/mp4"}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for video part, got nil")
+	}
+}
+
+func TestBuildContentParts_UnknownTypeRejected(t *testing.T) {
+	msg := events.Message{
+		Parts: []events.MessagePart{{Type: "hologram"}},
+	}
+	_, err := buildContentParts(msg, multimodalConfig{DefaultImageDetail: "auto"})
+	if err == nil {
+		t.Fatal("expected error for unknown type, got nil")
+	}
+}
+
+func TestConvertMessage_UserWithImagePart(t *testing.T) {
+	p := newTestPlugin(multimodalConfig{DefaultImageDetail: "auto"})
+	msg := events.Message{
+		Role:    "user",
+		Content: "what's in this picture?",
+		Parts: []events.MessagePart{
+			{Type: "image", URI: "https://example.com/cat.png"},
+		},
+	}
+	apiMsg := p.convertMessage(msg)
+	if apiMsg["role"] != "user" {
+		t.Errorf("expected role=user, got %v", apiMsg["role"])
+	}
+	content, ok := apiMsg["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected content to be []map[string]any, got %T", apiMsg["content"])
+	}
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content blocks (text + image), got %d", len(content))
+	}
+	if content[0]["type"] != "text" || content[0]["text"] != "what's in this picture?" {
+		t.Errorf("expected leading text block, got %+v", content[0])
+	}
+	if content[1]["type"] != "image_url" {
+		t.Errorf("expected image_url block, got %+v", content[1])
+	}
+}
+
+func TestConvertMessage_UserNoParts_FallbackString(t *testing.T) {
+	p := newTestPlugin(multimodalConfig{DefaultImageDetail: "auto"})
+	msg := events.Message{Role: "user", Content: "hi"}
+	apiMsg := p.convertMessage(msg)
+	if apiMsg["content"] != "hi" {
+		t.Errorf("expected bare string content, got %v", apiMsg["content"])
+	}
+}
+
+func TestConvertMessage_ToolWithImagePart(t *testing.T) {
+	p := newTestPlugin(multimodalConfig{DefaultImageDetail: "auto"})
+	msg := events.Message{
+		Role:       "tool",
+		ToolCallID: "call_123",
+		Content:    "screenshot captured",
+		Parts: []events.MessagePart{
+			{Type: "image", Data: []byte{0x89, 0x50}, MimeType: "image/png"},
+		},
+	}
+	apiMsg := p.convertMessage(msg)
+	if apiMsg["role"] != "tool" {
+		t.Errorf("expected role=tool, got %v", apiMsg["role"])
+	}
+	if apiMsg["tool_call_id"] != "call_123" {
+		t.Errorf("expected tool_call_id passthrough, got %v", apiMsg["tool_call_id"])
+	}
+	content, ok := apiMsg["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected content array, got %T", apiMsg["content"])
+	}
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(content))
+	}
+	if content[1]["type"] != "image_url" {
+		t.Errorf("expected image_url in second block, got %+v", content[1])
+	}
+}
+
+func TestConvertMessage_ToolNoParts_FallbackString(t *testing.T) {
+	p := newTestPlugin(multimodalConfig{DefaultImageDetail: "auto"})
+	msg := events.Message{Role: "tool", ToolCallID: "call_x", Content: "ok"}
+	apiMsg := p.convertMessage(msg)
+	if apiMsg["content"] != "ok" {
+		t.Errorf("expected bare string content, got %v", apiMsg["content"])
+	}
+}
+
+func TestConvertMessage_AssistantWithParts(t *testing.T) {
+	p := newTestPlugin(multimodalConfig{DefaultImageDetail: "auto"})
+	msg := events.Message{
+		Role:    "assistant",
+		Content: "here you go",
+		Parts: []events.MessagePart{
+			{Type: "text", Text: "extra context"},
+		},
+	}
+	apiMsg := p.convertMessage(msg)
+	content, ok := apiMsg["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected array content, got %T", apiMsg["content"])
+	}
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(content))
+	}
+}
+
+func TestConvertMessage_UserBadPart_FallbackToText(t *testing.T) {
+	p := newTestPlugin(multimodalConfig{DefaultImageDetail: "auto"})
+	msg := events.Message{
+		Role:    "user",
+		Content: "fallback text",
+		Parts: []events.MessagePart{
+			{Type: "video", URI: "https://example.com/x.mp4", MimeType: "video/mp4"},
+		},
+	}
+	apiMsg := p.convertMessage(msg)
+	if apiMsg["content"] != "fallback text" {
+		t.Errorf("expected fallback bare-string content on conversion error, got %v", apiMsg["content"])
+	}
+}

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -90,10 +90,15 @@ type Plugin struct {
 
 	multimodal multimodalConfig
 
+	files       filesConfig
+	filesAPIURL string
+	fileCache   *fileCache
+
 	mu                 sync.Mutex
 	currentRequestMeta map[string]any
 	cancelFunc         context.CancelFunc
 	requestSeq         int
+	sessionFileIDs     []string // file_ids uploaded this session (for delete_on_shutdown)
 }
 
 // New creates a new OpenAI provider plugin.
@@ -152,6 +157,18 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 
 	p.multimodal = parseMultimodalConfig(ctx.Config)
 
+	p.files = parseFilesConfig(ctx.Config)
+	p.filesAPIURL = filesAPIBaseURL
+	if p.files.Enabled {
+		p.fileCache = newFileCache()
+		p.logger.Info("files API enabled",
+			"purpose", p.files.Purpose,
+			"upload_threshold", p.files.UploadThreshold,
+			"cache_uploads", p.files.CacheUploads,
+			"delete_on_shutdown", p.files.DeleteOnShutdown,
+		)
+	}
+
 	p.retry = parseRetryConfig(ctx.Config)
 	if p.retry.Enabled {
 		p.logger.Info("retry enabled",
@@ -179,9 +196,19 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 
 func (p *Plugin) Ready() error { return nil }
 
-func (p *Plugin) Shutdown(_ context.Context) error {
+func (p *Plugin) Shutdown(ctx context.Context) error {
 	for _, unsub := range p.unsubs {
 		unsub()
+	}
+	if p.files.Enabled && p.files.DeleteOnShutdown {
+		ids := p.snapshotSessionFileIDs()
+		for _, id := range ids {
+			if err := p.deleteFile(ctx, id); err != nil {
+				// Best-effort: log and continue. A leaked file_id is a soft
+				// cost (org storage), not a correctness issue.
+				p.logger.Warn("openai: failed to delete session file", "file_id", id, "error", err)
+			}
+		}
 	}
 	p.client.CloseIdleConnections()
 	return nil
@@ -266,6 +293,26 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 	}
 
 	p.logger.Debug("resolving LLM request", "role", req.Role, "model", model, "max_tokens", maxTokens)
+
+	// Files API preflight: when enabled, upload file-type Data parts and
+	// swap in the returned file_id before serializing the request body. We
+	// replace req.Messages locally (not via mutation) — the caller's slice
+	// stays untouched.
+	preflightCtx, preflightCancel := context.WithCancel(context.Background())
+	if p.files.Enabled {
+		newMsgs, err := p.preuploadParts(preflightCtx, req.Messages)
+		if err != nil {
+			preflightCancel()
+			p.emitErrorInfo(events.ErrorInfo{
+				Err:         fmt.Errorf("openai: files preflight failed: %w", err),
+				Retryable:   false,
+				RequestMeta: req.Metadata,
+			})
+			return
+		}
+		req.Messages = newMsgs
+	}
+	preflightCancel()
 
 	body := p.buildRequestBody(model, maxTokens, req)
 

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -496,6 +496,18 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 		// "text" is OpenAI default — no field needed.
 	}
 
+	// Predicted outputs (OpenAI-only): when the agent has a known-content
+	// guess (rewrite this paragraph, fix this line), pass it through as
+	// prediction.content so the model returns near-instantly for unchanged
+	// portions. applyReasoning strips this for o-series / gpt-5-thinking
+	// models since they reject the field.
+	if req.Prediction != "" {
+		body["prediction"] = map[string]any{
+			"type":    "content",
+			"content": req.Prediction,
+		}
+	}
+
 	// Reasoning-model handling runs last so any fields about to be stripped
 	// (temperature, top_p, etc.) have already been written. NOTE: this stays
 	// on /v1/chat/completions; the /v1/responses endpoint exposes richer
@@ -638,13 +650,32 @@ func (p *Plugin) handleSyncResponse(body io.Reader) {
 
 	resp := p.convertAPIResponse(apiResp)
 
+	// Merge request-passthrough metadata (e.g. _structured_output) onto any
+	// metadata convertAPIResponse already attached (e.g. prediction_acceptance).
 	p.mu.Lock()
-	resp.Metadata = p.currentRequestMeta
+	resp.Metadata = mergeMetadata(resp.Metadata, p.currentRequestMeta)
 	p.mu.Unlock()
 
 	if err := p.bus.Emit("llm.response", resp); err != nil {
 		p.logger.Error("failed to emit llm.response", "error", err)
 	}
+}
+
+// mergeMetadata returns a map containing all keys from `into` plus all keys
+// from `from`. Either input may be nil. Keys in `from` overwrite duplicates
+// in `into`. Returns nil only when both inputs are nil/empty.
+func mergeMetadata(into, from map[string]any) map[string]any {
+	if len(into) == 0 && len(from) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(into)+len(from))
+	for k, v := range into {
+		out[k] = v
+	}
+	for k, v := range from {
+		out[k] = v
+	}
+	return out
 }
 
 func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
@@ -677,6 +708,20 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 				Name:      tc.Function.Name,
 				Arguments: tc.Function.Arguments,
 			})
+		}
+	}
+
+	// Surface prediction acceptance counts when the request used the
+	// prediction field. Lets callers tune their hit rates — accepted tokens
+	// bill at the input rate, rejected at the output rate.
+	if apiResp.Usage.CompletionTokensDetails.AcceptedPredictionTokens > 0 ||
+		apiResp.Usage.CompletionTokensDetails.RejectedPredictionTokens > 0 {
+		if resp.Metadata == nil {
+			resp.Metadata = make(map[string]any)
+		}
+		resp.Metadata["prediction_acceptance"] = map[string]any{
+			"accepted": apiResp.Usage.CompletionTokensDetails.AcceptedPredictionTokens,
+			"rejected": apiResp.Usage.CompletionTokensDetails.RejectedPredictionTokens,
 		}
 	}
 
@@ -843,8 +888,20 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 	})
 
 	// Also emit the complete llm.response for downstream consumers.
+	// Surface prediction acceptance the same way the sync path does.
+	var streamMeta map[string]any
+	if usage.CompletionTokensDetails.AcceptedPredictionTokens > 0 ||
+		usage.CompletionTokensDetails.RejectedPredictionTokens > 0 {
+		streamMeta = map[string]any{
+			"prediction_acceptance": map[string]any{
+				"accepted": usage.CompletionTokensDetails.AcceptedPredictionTokens,
+				"rejected": usage.CompletionTokensDetails.RejectedPredictionTokens,
+			},
+		}
+	}
+
 	p.mu.Lock()
-	meta := p.currentRequestMeta
+	mergedMeta := mergeMetadata(streamMeta, p.currentRequestMeta)
 	p.mu.Unlock()
 
 	_ = p.bus.Emit("llm.response", events.LLMResponse{
@@ -854,7 +911,7 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		CostUSD:      p.costForModel(model, finalUsage),
 		Model:        model,
 		FinishReason: finishReason,
-		Metadata:     meta,
+		Metadata:     mergedMeta,
 	})
 }
 

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -85,6 +85,9 @@ type Plugin struct {
 	retry   retryConfig
 	pricing map[string]modelPricing // merged: config overrides + embedded defaults
 
+	reasoning       reasoningConfig
+	forceReasoning  bool
+
 	mu                 sync.Mutex
 	currentRequestMeta map[string]any
 	cancelFunc         context.CancelFunc
@@ -139,6 +142,11 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.prompts = ctx.Prompts
 
 	p.pricing = parsePricingConfig(ctx.Config)
+
+	p.reasoning = parseReasoningConfig(ctx.Config)
+	if v, ok := ctx.Config["force_reasoning"].(bool); ok {
+		p.forceReasoning = v
+	}
 
 	p.retry = parseRetryConfig(ctx.Config)
 	if p.retry.Enabled {
@@ -437,6 +445,12 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 		// "text" is OpenAI default — no field needed.
 	}
 
+	// Reasoning-model handling runs last so any fields about to be stripped
+	// (temperature, top_p, etc.) have already been written. NOTE: this stays
+	// on /v1/chat/completions; the /v1/responses endpoint exposes richer
+	// reasoning controls (summary streaming) and is left for a future plan.
+	applyReasoning(body, model, p.reasoning, p.forceReasoning, p.logger)
+
 	return body
 }
 
@@ -555,11 +569,15 @@ func (p *Plugin) handleSyncResponse(body io.Reader) {
 }
 
 func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
+	// Reasoning tokens (o-series, gpt-5-thinking) are billed by OpenAI as
+	// output and are already counted inside completion_tokens — no separate
+	// pricing field needed; they roll into the existing OutputPerMillion rate.
 	usage := events.Usage{
 		PromptTokens:     apiResp.Usage.PromptTokens,
 		CompletionTokens: apiResp.Usage.CompletionTokens,
 		TotalTokens:      apiResp.Usage.TotalTokens,
 		CachedTokens:     apiResp.Usage.PromptTokensDetails.CachedTokens,
+		ReasoningTokens:  apiResp.Usage.CompletionTokensDetails.ReasoningTokens,
 	}
 
 	resp := events.LLMResponse{
@@ -727,12 +745,15 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		chunkIndex++
 	}
 
-	// Build final usage.
+	// Build final usage. Reasoning tokens arrive in the final usage chunk
+	// when stream_options.include_usage is set (already enabled above).
+	// They're billed as output by OpenAI — already inside CompletionTokens.
 	finalUsage := events.Usage{
 		PromptTokens:     usage.PromptTokens,
 		CompletionTokens: usage.CompletionTokens,
 		TotalTokens:      usage.TotalTokens,
 		CachedTokens:     usage.PromptTokensDetails.CachedTokens,
+		ReasoningTokens:  usage.CompletionTokensDetails.ReasoningTokens,
 	}
 
 	// Emit stream end.

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -27,8 +27,9 @@ const (
 
 // modelPricing holds per-model token rates in USD per million tokens.
 type modelPricing struct {
-	InputPerMillion  float64
-	OutputPerMillion float64
+	InputPerMillion     float64
+	OutputPerMillion    float64
+	CacheReadPerMillion float64 // 0 → derived as InputPerMillion * 0.5
 }
 
 // defaultPricing is the embedded fallback pricing table. Updated via patch
@@ -48,8 +49,23 @@ var defaultPricing = map[string]modelPricing{
 }
 
 // calculateCost computes the USD cost for a single LLM call.
+//
+// OpenAI auto-caches eligible prompt prefixes (≥1024 tokens) and bills the
+// cached portion at half the input rate. We split prompt tokens into the
+// plain (cache miss) and cached portions and bill each at its own rate.
 func calculateCost(usage events.Usage, rates modelPricing) float64 {
-	return float64(usage.PromptTokens)/1_000_000*rates.InputPerMillion +
+	cachedRate := rates.CacheReadPerMillion
+	if cachedRate == 0 {
+		cachedRate = rates.InputPerMillion * 0.5
+	}
+
+	plainInput := usage.PromptTokens - usage.CachedTokens
+	if plainInput < 0 {
+		plainInput = 0
+	}
+
+	return float64(plainInput)/1_000_000*rates.InputPerMillion +
+		float64(usage.CachedTokens)/1_000_000*cachedRate +
 		float64(usage.CompletionTokens)/1_000_000*rates.OutputPerMillion
 }
 
@@ -505,9 +521,19 @@ type apiFunction struct {
 }
 
 type apiUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens        int `json:"prompt_tokens"`
+	CompletionTokens    int `json:"completion_tokens"`
+	TotalTokens         int `json:"total_tokens"`
+	PromptTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+		AudioTokens  int `json:"audio_tokens"`
+	} `json:"prompt_tokens_details"`
+	CompletionTokensDetails struct {
+		ReasoningTokens          int `json:"reasoning_tokens"`
+		AcceptedPredictionTokens int `json:"accepted_prediction_tokens"`
+		RejectedPredictionTokens int `json:"rejected_prediction_tokens"`
+		AudioTokens              int `json:"audio_tokens"`
+	} `json:"completion_tokens_details"`
 }
 
 func (p *Plugin) handleSyncResponse(body io.Reader) {
@@ -533,6 +559,7 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 		PromptTokens:     apiResp.Usage.PromptTokens,
 		CompletionTokens: apiResp.Usage.CompletionTokens,
 		TotalTokens:      apiResp.Usage.TotalTokens,
+		CachedTokens:     apiResp.Usage.PromptTokensDetails.CachedTokens,
 	}
 
 	resp := events.LLMResponse{
@@ -705,6 +732,7 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		PromptTokens:     usage.PromptTokens,
 		CompletionTokens: usage.CompletionTokens,
 		TotalTokens:      usage.TotalTokens,
+		CachedTokens:     usage.PromptTokensDetails.CachedTokens,
 	}
 
 	// Emit stream end.
@@ -753,6 +781,9 @@ func parsePricingConfig(cfg map[string]any) map[string]modelPricing {
 		}
 		if v, ok := entry["output_per_million"].(float64); ok {
 			p.OutputPerMillion = v
+		}
+		if v, ok := entry["cache_read_per_million"].(float64); ok {
+			p.CacheReadPerMillion = v
 		}
 		merged[model] = p
 	}

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -76,8 +75,7 @@ type Plugin struct {
 	models  *engine.ModelRegistry
 	session *engine.SessionWorkspace
 
-	apiKey  string
-	baseURL string
+	auth    *authState
 	client  *http.Client
 	prompts *engine.PromptRegistry
 	unsubs  []func()
@@ -123,24 +121,21 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.debug = debug
 	}
 
-	// API base URL: allows pointing at compatible endpoints (Azure, local proxies).
-	p.baseURL = apiURL
-	if base, ok := ctx.Config["base_url"].(string); ok && base != "" {
-		p.baseURL = strings.TrimRight(base, "/")
+	// Auth: openai (default), azure_key, or azure_aad. parseAuthConfig is
+	// backwards compatible — when auth_mode is unset, the legacy
+	// api_key / api_key_env / base_url top-level keys keep working.
+	auth, err := parseAuthConfig(ctx.Config)
+	if err != nil {
+		return err
 	}
+	p.auth = auth
 
-	// Read API key: direct config value takes priority over env var.
-	if key, ok := ctx.Config["api_key"].(string); ok && key != "" {
-		p.apiKey = key
-	} else {
-		apiKeyEnv, _ := ctx.Config["api_key_env"].(string)
-		if apiKeyEnv == "" {
-			apiKeyEnv = "OPENAI_API_KEY"
-		}
-		p.apiKey = os.Getenv(apiKeyEnv)
-	}
-	if p.apiKey == "" {
-		return fmt.Errorf("openai: no API key configured (set api_key in config or %s env var)", "OPENAI_API_KEY")
+	// Files API stays on the public OpenAI endpoint regardless of mode (Azure
+	// has a different Files API surface and not all plugins need it). When
+	// running in Azure mode, we still need an OpenAI api_key for Files; warn
+	// once if the Files API is enabled but no key is available.
+	if (p.auth.mode == authModeAzureKey || p.auth.mode == authModeAzureAAD) && p.auth.apiKey == "" {
+		ctx.Logger.Warn("openai: Files API will be unavailable in Azure mode without a top-level api_key (Files API stays on api.openai.com)")
 	}
 
 	p.client = &http.Client{
@@ -335,11 +330,13 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 	p.mu.Unlock()
 
 	makeReq := func() (*http.Request, error) {
-		httpReq, err := http.NewRequestWithContext(reqCtx, "POST", p.baseURL, bytes.NewReader(jsonBody))
+		httpReq, err := http.NewRequestWithContext(reqCtx, "POST", p.auth.buildURL(), bytes.NewReader(jsonBody))
 		if err != nil {
 			return nil, err
 		}
-		httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+		if err := p.auth.applyAuth(reqCtx, httpReq, p.client); err != nil {
+			return nil, err
+		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		return httpReq, nil
 	}
@@ -411,9 +408,14 @@ func (p *Plugin) handleRequest(req events.LLMRequest) {
 // buildRequestBody constructs the OpenAI Chat Completions API request body.
 func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMRequest) map[string]any {
 	body := map[string]any{
-		"model":      model,
 		"max_tokens": maxTokens,
 		"stream":     req.Stream,
+	}
+	// Azure encodes the deployment in the URL; including model in the body
+	// is redundant (and rejected by some api-versions). Public OpenAI
+	// requires it.
+	if p.auth == nil || !p.auth.stripModelFromBody() {
+		body["model"] = model
 	}
 
 	if req.Temperature != nil {

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -88,6 +88,8 @@ type Plugin struct {
 	reasoning       reasoningConfig
 	forceReasoning  bool
 
+	multimodal multimodalConfig
+
 	mu                 sync.Mutex
 	currentRequestMeta map[string]any
 	cancelFunc         context.CancelFunc
@@ -147,6 +149,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	if v, ok := ctx.Config["force_reasoning"].(bool); ok {
 		p.forceReasoning = v
 	}
+
+	p.multimodal = parseMultimodalConfig(ctx.Config)
 
 	p.retry = parseRetryConfig(ctx.Config)
 	if p.retry.Enabled {
@@ -455,13 +459,25 @@ func (p *Plugin) buildRequestBody(model string, maxTokens int, req events.LLMReq
 }
 
 // convertMessage converts an events.Message to the OpenAI API format.
+//
+// When the message carries multimodal Parts, the content is serialized as
+// OpenAI's content-array form (text/image_url/input_audio/file blocks). On
+// any conversion error the provider logs and falls back to the bare-string
+// Content path so a malformed image part doesn't kill the whole turn.
 func (p *Plugin) convertMessage(msg events.Message) map[string]any {
 	switch msg.Role {
 	case "assistant":
 		m := map[string]any{
 			"role": "assistant",
 		}
-		if msg.Content != "" {
+		if parts, err := buildContentParts(msg, p.multimodal); err != nil {
+			p.logger.Warn("openai: failed to build assistant content parts; falling back to text", "error", err)
+			if msg.Content != "" {
+				m["content"] = msg.Content
+			}
+		} else if parts != nil {
+			m["content"] = parts
+		} else if msg.Content != "" {
 			m["content"] = msg.Content
 		}
 		if len(msg.ToolCalls) > 0 {
@@ -481,17 +497,33 @@ func (p *Plugin) convertMessage(msg events.Message) map[string]any {
 		return m
 
 	case "tool":
-		return map[string]any{
+		m := map[string]any{
 			"role":         "tool",
 			"tool_call_id": msg.ToolCallID,
-			"content":      msg.Content,
 		}
+		if parts, err := buildContentParts(msg, p.multimodal); err != nil {
+			p.logger.Warn("openai: failed to build tool content parts; falling back to text", "error", err)
+			m["content"] = msg.Content
+		} else if parts != nil {
+			m["content"] = parts
+		} else {
+			m["content"] = msg.Content
+		}
+		return m
 
 	case "user":
-		return map[string]any{
-			"role":    "user",
-			"content": msg.Content,
+		m := map[string]any{
+			"role": "user",
 		}
+		if parts, err := buildContentParts(msg, p.multimodal); err != nil {
+			p.logger.Warn("openai: failed to build user content parts; falling back to text", "error", err)
+			m["content"] = msg.Content
+		} else if parts != nil {
+			m["content"] = parts
+		} else {
+			m["content"] = msg.Content
+		}
+		return m
 
 	default:
 		return map[string]any{

--- a/plugins/providers/openai/prediction_test.go
+++ b/plugins/providers/openai/prediction_test.go
@@ -1,0 +1,241 @@
+package openai
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// TestBuildRequestBody_PredictionSet verifies that LLMRequest.Prediction is
+// serialized as {type: "content", content: <prediction>}.
+func TestBuildRequestBody_PredictionSet(t *testing.T) {
+	p := &Plugin{}
+	req := events.LLMRequest{
+		Messages:   []events.Message{{Role: "user", Content: "rewrite please"}},
+		Prediction: "the known target text",
+	}
+
+	body := p.buildRequestBody("gpt-4o", 1024, req)
+
+	pred, ok := body["prediction"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected prediction to be a map[string]any, got %T", body["prediction"])
+	}
+	if pred["type"] != "content" {
+		t.Errorf("prediction.type: got %v, want \"content\"", pred["type"])
+	}
+	if pred["content"] != "the known target text" {
+		t.Errorf("prediction.content: got %v, want \"the known target text\"", pred["content"])
+	}
+}
+
+// TestBuildRequestBody_PredictionEmpty verifies no prediction field is added
+// when LLMRequest.Prediction is the empty string.
+func TestBuildRequestBody_PredictionEmpty(t *testing.T) {
+	p := &Plugin{}
+	req := events.LLMRequest{
+		Messages: []events.Message{{Role: "user", Content: "hi"}},
+		// Prediction left empty
+	}
+
+	body := p.buildRequestBody("gpt-4o", 1024, req)
+
+	if _, ok := body["prediction"]; ok {
+		t.Errorf("expected no prediction field on empty Prediction, got %v", body["prediction"])
+	}
+}
+
+// TestBuildRequestBody_PredictionStrippedOnReasoningModel verifies that
+// applyReasoning strips the prediction field for reasoning models that
+// reject it (o1, o3, o4, gpt-5*-thinking).
+func TestBuildRequestBody_PredictionStrippedOnReasoningModel(t *testing.T) {
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	req := events.LLMRequest{
+		Messages:   []events.Message{{Role: "user", Content: "rewrite"}},
+		Prediction: "the target",
+	}
+
+	body := p.buildRequestBody("o1-mini", 1024, req)
+
+	if _, ok := body["prediction"]; ok {
+		t.Errorf("expected prediction stripped on reasoning model o1-mini, got %v", body["prediction"])
+	}
+}
+
+// TestConvertAPIResponse_PredictionAcceptancePopulated verifies that nonzero
+// accepted/rejected counts surface as Metadata["prediction_acceptance"].
+func TestConvertAPIResponse_PredictionAcceptancePopulated(t *testing.T) {
+	p := &Plugin{pricing: defaultPricing}
+
+	content := "edited text"
+	apiResp := apiResponse{
+		ID:    "chatcmpl-test",
+		Model: "gpt-4o",
+		Choices: []apiChoice{
+			{
+				Index:        0,
+				Message:      apiMessage{Role: "assistant", Content: &content},
+				FinishReason: "stop",
+			},
+		},
+	}
+	apiResp.Usage.PromptTokens = 100
+	apiResp.Usage.CompletionTokens = 50
+	apiResp.Usage.TotalTokens = 150
+	apiResp.Usage.CompletionTokensDetails.AcceptedPredictionTokens = 32
+	apiResp.Usage.CompletionTokensDetails.RejectedPredictionTokens = 8
+
+	resp := p.convertAPIResponse(apiResp)
+
+	pa, ok := resp.Metadata["prediction_acceptance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected prediction_acceptance to be a map[string]any, got %T", resp.Metadata["prediction_acceptance"])
+	}
+	if pa["accepted"] != 32 {
+		t.Errorf("accepted: got %v, want 32", pa["accepted"])
+	}
+	if pa["rejected"] != 8 {
+		t.Errorf("rejected: got %v, want 8", pa["rejected"])
+	}
+}
+
+// TestConvertAPIResponse_PredictionAcceptanceAbsentOnZero verifies that when
+// both counts are zero, the prediction_acceptance key is not set.
+func TestConvertAPIResponse_PredictionAcceptanceAbsentOnZero(t *testing.T) {
+	p := &Plugin{pricing: defaultPricing}
+
+	content := "hi"
+	apiResp := apiResponse{
+		ID:    "chatcmpl-test",
+		Model: "gpt-4o",
+		Choices: []apiChoice{
+			{
+				Index:        0,
+				Message:      apiMessage{Role: "assistant", Content: &content},
+				FinishReason: "stop",
+			},
+		},
+	}
+	apiResp.Usage.PromptTokens = 100
+	apiResp.Usage.CompletionTokens = 50
+	apiResp.Usage.TotalTokens = 150
+	// Both prediction counts are zero.
+
+	resp := p.convertAPIResponse(apiResp)
+
+	if _, ok := resp.Metadata["prediction_acceptance"]; ok {
+		t.Errorf("expected no prediction_acceptance key on zero counts, got %v", resp.Metadata["prediction_acceptance"])
+	}
+}
+
+// TestMergeMetadata_RequestMetaAndPredictionBothSurface verifies that when
+// both currentRequestMeta (e.g. _structured_output) and prediction metadata
+// exist, both surface on the final response — neither overwrites the other.
+func TestMergeMetadata_RequestMetaAndPredictionBothSurface(t *testing.T) {
+	predMeta := map[string]any{
+		"prediction_acceptance": map[string]any{
+			"accepted": 10,
+			"rejected": 2,
+		},
+	}
+	reqMeta := map[string]any{
+		"_structured_output": true,
+	}
+
+	merged := mergeMetadata(predMeta, reqMeta)
+
+	if merged["_structured_output"] != true {
+		t.Errorf("_structured_output: got %v, want true", merged["_structured_output"])
+	}
+	pa, ok := merged["prediction_acceptance"].(map[string]any)
+	if !ok {
+		t.Fatalf("prediction_acceptance: got %T, want map[string]any", merged["prediction_acceptance"])
+	}
+	if pa["accepted"] != 10 {
+		t.Errorf("prediction_acceptance.accepted: got %v, want 10", pa["accepted"])
+	}
+}
+
+// TestMergeMetadata_NilInputs verifies that two nil inputs yield nil (no
+// allocation), and that one nil + one populated yields the populated keys.
+func TestMergeMetadata_NilInputs(t *testing.T) {
+	if got := mergeMetadata(nil, nil); got != nil {
+		t.Errorf("mergeMetadata(nil, nil): got %v, want nil", got)
+	}
+	from := map[string]any{"k": "v"}
+	got := mergeMetadata(nil, from)
+	if got["k"] != "v" {
+		t.Errorf("mergeMetadata(nil, from): got %v, want {k:v}", got)
+	}
+	got = mergeMetadata(from, nil)
+	if got["k"] != "v" {
+		t.Errorf("mergeMetadata(from, nil): got %v, want {k:v}", got)
+	}
+}
+
+// TestStreamFinalize_PredictionAcceptanceSurfaces verifies that the streaming
+// path emits prediction_acceptance metadata when the final usage chunk reports
+// accepted/rejected counts AND merges with currentRequestMeta passthrough.
+func TestStreamFinalize_PredictionAcceptanceSurfaces(t *testing.T) {
+	bus := engine.NewEventBus()
+
+	var (
+		mu   sync.Mutex
+		resp events.LLMResponse
+		got  bool
+	)
+	unsub := bus.Subscribe("llm.response", func(ev engine.Event[any]) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r, ok := ev.Payload.(events.LLMResponse); ok {
+			resp = r
+			got = true
+		}
+	})
+	defer unsub()
+
+	p := &Plugin{
+		bus:                bus,
+		logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		pricing:            defaultPricing,
+		currentRequestMeta: map[string]any{"_structured_output": true},
+	}
+
+	// Synthetic SSE stream: content delta, then final chunk with usage,
+	// then [DONE]. Usage carries prediction counts.
+	stream := strings.Join([]string{
+		`data: {"id":"x","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`,
+		`data: {"id":"x","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"completion_tokens_details":{"accepted_prediction_tokens":3,"rejected_prediction_tokens":1}}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	p.handleStreamResponse(strings.NewReader(stream))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !got {
+		t.Fatalf("expected llm.response emission, got none")
+	}
+	if resp.Metadata == nil {
+		t.Fatalf("expected metadata on streamed response, got nil")
+	}
+	if resp.Metadata["_structured_output"] != true {
+		t.Errorf("_structured_output passthrough lost: got %v", resp.Metadata["_structured_output"])
+	}
+	pa, ok := resp.Metadata["prediction_acceptance"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected prediction_acceptance on streamed response metadata, got %T", resp.Metadata["prediction_acceptance"])
+	}
+	if pa["accepted"] != 3 {
+		t.Errorf("streamed accepted: got %v, want 3", pa["accepted"])
+	}
+	if pa["rejected"] != 1 {
+		t.Errorf("streamed rejected: got %v, want 1", pa["rejected"])
+	}
+}

--- a/plugins/providers/openai/reasoning.go
+++ b/plugins/providers/openai/reasoning.go
@@ -1,0 +1,78 @@
+package openai
+
+import (
+	"log/slog"
+	"regexp"
+)
+
+// reasoningConfig controls OpenAI o-series / gpt-5-thinking behavior.
+//
+//	reasoning:
+//	  effort: medium     # minimal | low | medium | high
+//	  include_summary: false
+//
+// Reasoning models reject temperature/top_p/etc., so the provider strips them
+// automatically when isReasoningModel(model) is true.
+type reasoningConfig struct {
+	Effort         string
+	IncludeSummary bool
+}
+
+// parseReasoningConfig extracts the reasoning sub-map from plugin config.
+// Unknown effort values are silently ignored (left empty) so callers fall back
+// to the model default.
+func parseReasoningConfig(cfg map[string]any) reasoningConfig {
+	rc := reasoningConfig{}
+	raw, ok := cfg["reasoning"].(map[string]any)
+	if !ok {
+		return rc
+	}
+	if v, ok := raw["effort"].(string); ok {
+		switch v {
+		case "minimal", "low", "medium", "high":
+			rc.Effort = v
+		}
+	}
+	if v, ok := raw["include_summary"].(bool); ok {
+		rc.IncludeSummary = v
+	}
+	return rc
+}
+
+// reasoningModelPattern matches o1*, o3*, o4* and gpt-5*-thinking* model ids.
+// Match is conservative: known reasoning families only. Users can override
+// detection with the `force_reasoning` config flag (handled in plugin.go).
+var reasoningModelPattern = regexp.MustCompile(`^(o[134](-mini|-preview)?|gpt-5(-mini|-nano)?(-\d+)?(-thinking)?)`)
+
+// isReasoningModel reports whether a model id is a known reasoning family.
+func isReasoningModel(model string) bool {
+	return reasoningModelPattern.MatchString(model)
+}
+
+// applyReasoning mutates the request body for reasoning-model calls.
+// Strips disallowed fields (temperature, top_p, presence_penalty,
+// frequency_penalty, logprobs, top_logprobs, prediction) and adds
+// reasoning_effort when configured.
+//
+// NOTE: include_summary is documented as Responses-API only; we stay on
+// /v1/chat/completions for now and ignore it. When/if Chat Completions gains
+// support, surface it here.
+func applyReasoning(body map[string]any, model string, cfg reasoningConfig, forceReasoning bool, logger *slog.Logger) {
+	if !(forceReasoning || isReasoningModel(model)) {
+		return
+	}
+	for _, f := range []string{
+		"temperature", "top_p", "presence_penalty", "frequency_penalty",
+		"logprobs", "top_logprobs", "prediction",
+	} {
+		if _, ok := body[f]; ok {
+			if logger != nil {
+				logger.Debug("openai: stripping incompatible field for reasoning model", "field", f, "model", model)
+			}
+			delete(body, f)
+		}
+	}
+	if cfg.Effort != "" {
+		body["reasoning_effort"] = cfg.Effort
+	}
+}

--- a/plugins/providers/openai/reasoning_test.go
+++ b/plugins/providers/openai/reasoning_test.go
@@ -1,0 +1,229 @@
+package openai
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// silentLogger returns a slog.Logger that discards output, so tests don't
+// pollute stdout with debug lines from applyReasoning.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestParseReasoningConfig_Defaults(t *testing.T) {
+	rc := parseReasoningConfig(map[string]any{})
+	if rc.Effort != "" {
+		t.Errorf("default Effort: got %q, want empty", rc.Effort)
+	}
+	if rc.IncludeSummary {
+		t.Errorf("default IncludeSummary: got true, want false")
+	}
+}
+
+func TestParseReasoningConfig_ExplicitEfforts(t *testing.T) {
+	for _, want := range []string{"minimal", "low", "medium", "high"} {
+		cfg := map[string]any{
+			"reasoning": map[string]any{
+				"effort":          want,
+				"include_summary": true,
+			},
+		}
+		rc := parseReasoningConfig(cfg)
+		if rc.Effort != want {
+			t.Errorf("effort=%q: got %q", want, rc.Effort)
+		}
+		if !rc.IncludeSummary {
+			t.Errorf("effort=%q: IncludeSummary should be true", want)
+		}
+	}
+}
+
+func TestParseReasoningConfig_InvalidEffortIgnored(t *testing.T) {
+	cfg := map[string]any{
+		"reasoning": map[string]any{
+			"effort": "extreme", // not a valid value
+		},
+	}
+	rc := parseReasoningConfig(cfg)
+	if rc.Effort != "" {
+		t.Errorf("invalid effort: got %q, want empty", rc.Effort)
+	}
+}
+
+func TestIsReasoningModel(t *testing.T) {
+	matches := []string{
+		"o1", "o1-mini", "o1-preview",
+		"o3", "o3-mini",
+		"o4-mini",
+		"gpt-5", "gpt-5-mini", "gpt-5-thinking", "gpt-5-mini-thinking",
+	}
+	for _, m := range matches {
+		if !isReasoningModel(m) {
+			t.Errorf("isReasoningModel(%q): got false, want true", m)
+		}
+	}
+
+	misses := []string{
+		"gpt-4o", "gpt-4-turbo", "gpt-4o-mini",
+		"claude-3-5-sonnet-20241022",
+		"",
+	}
+	for _, m := range misses {
+		if isReasoningModel(m) {
+			t.Errorf("isReasoningModel(%q): got true, want false", m)
+		}
+	}
+}
+
+func TestApplyReasoning_NonReasoningModelLeavesBodyAlone(t *testing.T) {
+	body := map[string]any{
+		"model":       "gpt-4o",
+		"temperature": 0.7,
+		"top_p":       0.9,
+	}
+	cfg := reasoningConfig{Effort: "medium"}
+
+	applyReasoning(body, "gpt-4o", cfg, false, silentLogger())
+
+	if body["temperature"] != 0.7 {
+		t.Errorf("temperature should be untouched: got %v", body["temperature"])
+	}
+	if body["top_p"] != 0.9 {
+		t.Errorf("top_p should be untouched: got %v", body["top_p"])
+	}
+	if _, ok := body["reasoning_effort"]; ok {
+		t.Errorf("reasoning_effort should not be set on non-reasoning model")
+	}
+}
+
+func TestApplyReasoning_ReasoningModelStripsAndSetsEffort(t *testing.T) {
+	body := map[string]any{
+		"model":             "o1-mini",
+		"temperature":       0.7,
+		"top_p":             0.9,
+		"presence_penalty":  0.1,
+		"frequency_penalty": 0.2,
+		"logprobs":          true,
+		"top_logprobs":      5,
+		"prediction":        map[string]any{"type": "content", "content": "hi"},
+		"messages":          []any{},
+	}
+	cfg := reasoningConfig{Effort: "high"}
+
+	applyReasoning(body, "o1-mini", cfg, false, silentLogger())
+
+	for _, f := range []string{
+		"temperature", "top_p", "presence_penalty", "frequency_penalty",
+		"logprobs", "top_logprobs", "prediction",
+	} {
+		if _, ok := body[f]; ok {
+			t.Errorf("field %q should be stripped", f)
+		}
+	}
+	if got := body["reasoning_effort"]; got != "high" {
+		t.Errorf("reasoning_effort: got %v, want high", got)
+	}
+	// Unrelated keys preserved.
+	if _, ok := body["messages"]; !ok {
+		t.Error("messages should be preserved")
+	}
+}
+
+func TestApplyReasoning_ForceReasoningOnNonReasoningModel(t *testing.T) {
+	body := map[string]any{
+		"model":       "gpt-4o",
+		"temperature": 0.5,
+	}
+	cfg := reasoningConfig{Effort: "low"}
+
+	applyReasoning(body, "gpt-4o", cfg, true, silentLogger())
+
+	if _, ok := body["temperature"]; ok {
+		t.Error("temperature should be stripped when force_reasoning=true")
+	}
+	if got := body["reasoning_effort"]; got != "low" {
+		t.Errorf("reasoning_effort: got %v, want low", got)
+	}
+}
+
+func TestApplyReasoning_ReasoningModelNoEffortConfig(t *testing.T) {
+	body := map[string]any{
+		"model":       "o3-mini",
+		"temperature": 0.7,
+	}
+	cfg := reasoningConfig{} // no effort
+
+	applyReasoning(body, "o3-mini", cfg, false, silentLogger())
+
+	if _, ok := body["temperature"]; ok {
+		t.Error("temperature should be stripped on reasoning model")
+	}
+	if _, ok := body["reasoning_effort"]; ok {
+		t.Error("reasoning_effort should not be set when Effort is empty")
+	}
+}
+
+func TestConvertAPIResponse_PopulatesReasoningTokens(t *testing.T) {
+	p := &Plugin{pricing: defaultPricing}
+
+	content := "thinking complete"
+	apiResp := apiResponse{
+		ID:    "chatcmpl-r-test",
+		Model: "o1-mini",
+		Choices: []apiChoice{
+			{
+				Index:        0,
+				Message:      apiMessage{Role: "assistant", Content: &content},
+				FinishReason: "stop",
+			},
+		},
+	}
+	apiResp.Usage.PromptTokens = 100
+	apiResp.Usage.CompletionTokens = 800 // includes the 512 reasoning tokens
+	apiResp.Usage.TotalTokens = 900
+	apiResp.Usage.CompletionTokensDetails.ReasoningTokens = 512
+
+	resp := p.convertAPIResponse(apiResp)
+
+	if resp.Usage.ReasoningTokens != 512 {
+		t.Errorf("ReasoningTokens: got %d, want 512", resp.Usage.ReasoningTokens)
+	}
+	if resp.Usage.CompletionTokens != 800 {
+		t.Errorf("CompletionTokens: got %d, want 800", resp.Usage.CompletionTokens)
+	}
+}
+
+// TestBuildRequestBody_ReasoningModelStripsTemperature exercises the integration
+// between buildRequestBody and applyReasoning: an LLMRequest with Temperature
+// targeting o1-mini should produce a body with no `temperature` field but with
+// the configured `reasoning_effort`.
+func TestBuildRequestBody_ReasoningModelStripsTemperature(t *testing.T) {
+	temp := 0.7
+	p := &Plugin{
+		logger:    silentLogger(),
+		reasoning: reasoningConfig{Effort: "medium"},
+	}
+
+	req := events.LLMRequest{
+		Messages: []events.Message{
+			{Role: "user", Content: "hello"},
+		},
+		Temperature: &temp,
+	}
+
+	body := p.buildRequestBody("o1-mini", 1024, req)
+
+	if _, ok := body["temperature"]; ok {
+		t.Errorf("temperature should be stripped from o1-mini body")
+	}
+	if got := body["reasoning_effort"]; got != "medium" {
+		t.Errorf("reasoning_effort: got %v, want medium", got)
+	}
+	if got := body["model"]; got != "o1-mini" {
+		t.Errorf("model: got %v, want o1-mini", got)
+	}
+}

--- a/plugins/providers/openai/usage_test.go
+++ b/plugins/providers/openai/usage_test.go
@@ -1,0 +1,227 @@
+package openai
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// TestApiUsage_ParsesPromptTokensDetails verifies the apiUsage JSON tags match
+// the OpenAI Chat Completions usage object — specifically the
+// prompt_tokens_details.cached_tokens field that drives cache-aware billing.
+func TestApiUsage_ParsesPromptTokensDetails(t *testing.T) {
+	raw := []byte(`{
+		"prompt_tokens": 1500,
+		"completion_tokens": 200,
+		"total_tokens": 1700,
+		"prompt_tokens_details": {
+			"cached_tokens": 1024,
+			"audio_tokens": 0
+		},
+		"completion_tokens_details": {
+			"reasoning_tokens": 96,
+			"accepted_prediction_tokens": 32,
+			"rejected_prediction_tokens": 8,
+			"audio_tokens": 0
+		}
+	}`)
+
+	var u apiUsage
+	if err := json.Unmarshal(raw, &u); err != nil {
+		t.Fatalf("unmarshal apiUsage: %v", err)
+	}
+
+	if u.PromptTokens != 1500 {
+		t.Errorf("PromptTokens: got %d, want 1500", u.PromptTokens)
+	}
+	if u.CompletionTokens != 200 {
+		t.Errorf("CompletionTokens: got %d, want 200", u.CompletionTokens)
+	}
+	if u.TotalTokens != 1700 {
+		t.Errorf("TotalTokens: got %d, want 1700", u.TotalTokens)
+	}
+	if u.PromptTokensDetails.CachedTokens != 1024 {
+		t.Errorf("PromptTokensDetails.CachedTokens: got %d, want 1024", u.PromptTokensDetails.CachedTokens)
+	}
+	// Sanity check on the placeholder fields that plans 10/12 will use.
+	if u.CompletionTokensDetails.ReasoningTokens != 96 {
+		t.Errorf("CompletionTokensDetails.ReasoningTokens: got %d, want 96", u.CompletionTokensDetails.ReasoningTokens)
+	}
+	if u.CompletionTokensDetails.AcceptedPredictionTokens != 32 {
+		t.Errorf("CompletionTokensDetails.AcceptedPredictionTokens: got %d, want 32", u.CompletionTokensDetails.AcceptedPredictionTokens)
+	}
+}
+
+// TestConvertAPIResponse_PopulatesCachedTokens verifies that convertAPIResponse
+// surfaces prompt_tokens_details.cached_tokens onto events.Usage.CachedTokens.
+func TestConvertAPIResponse_PopulatesCachedTokens(t *testing.T) {
+	p := &Plugin{pricing: defaultPricing}
+
+	content := "hello"
+	apiResp := apiResponse{
+		ID:    "chatcmpl-test",
+		Model: "gpt-4o",
+		Choices: []apiChoice{
+			{
+				Index:        0,
+				Message:      apiMessage{Role: "assistant", Content: &content},
+				FinishReason: "stop",
+			},
+		},
+	}
+	apiResp.Usage.PromptTokens = 1500
+	apiResp.Usage.CompletionTokens = 200
+	apiResp.Usage.TotalTokens = 1700
+	apiResp.Usage.PromptTokensDetails.CachedTokens = 1024
+
+	resp := p.convertAPIResponse(apiResp)
+
+	if resp.Usage.PromptTokens != 1500 {
+		t.Errorf("PromptTokens: got %d, want 1500", resp.Usage.PromptTokens)
+	}
+	if resp.Usage.CompletionTokens != 200 {
+		t.Errorf("CompletionTokens: got %d, want 200", resp.Usage.CompletionTokens)
+	}
+	if resp.Usage.CachedTokens != 1024 {
+		t.Errorf("CachedTokens: got %d, want 1024", resp.Usage.CachedTokens)
+	}
+
+	// Cost should reflect the discount: 476 plain + 1024 cached at half rate
+	// + 200 output. Compare against a manual computation against the same
+	// rate table to guard against drift.
+	rates := defaultPricing["gpt-4o"]
+	wantCost := float64(1500-1024)/1_000_000*rates.InputPerMillion +
+		float64(1024)/1_000_000*(rates.InputPerMillion*0.5) +
+		float64(200)/1_000_000*rates.OutputPerMillion
+	if math.Abs(resp.CostUSD-wantCost) > 1e-9 {
+		t.Errorf("CostUSD: got %.10f, want %.10f", resp.CostUSD, wantCost)
+	}
+}
+
+// TestCalculateCost_NoCache verifies the no-cache path matches the prior
+// (input-only) cost calculation, so plain-input billing is preserved.
+func TestCalculateCost_NoCache(t *testing.T) {
+	rates := modelPricing{
+		InputPerMillion:  2.50,
+		OutputPerMillion: 10.0,
+	}
+	usage := events.Usage{
+		PromptTokens:     1500,
+		CompletionTokens: 200,
+		// CachedTokens left at 0
+	}
+
+	got := calculateCost(usage, rates)
+	want := float64(1500)/1_000_000*2.50 + float64(200)/1_000_000*10.0
+
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("calculateCost (no cache): got %.10f, want %.10f", got, want)
+	}
+}
+
+// TestCalculateCost_HalfCacheDiscount verifies that a 50% cache hit yields
+// roughly 75% of the plain-input cost (input portion only): half the prompt at
+// full rate + half at 0.5× rate = 0.75× full rate.
+func TestCalculateCost_HalfCacheDiscount(t *testing.T) {
+	rates := modelPricing{
+		InputPerMillion:  2.50,
+		OutputPerMillion: 10.0,
+	}
+
+	cached := events.Usage{
+		PromptTokens:     2000,
+		CompletionTokens: 0, // isolate the input contribution
+		CachedTokens:     1000,
+	}
+	plain := events.Usage{
+		PromptTokens:     2000,
+		CompletionTokens: 0,
+	}
+
+	cachedCost := calculateCost(cached, rates)
+	plainCost := calculateCost(plain, rates)
+
+	// 50% cache hit at 0.5× rate → 0.75× plain cost.
+	want := plainCost * 0.75
+	if math.Abs(cachedCost-want) > 1e-9 {
+		t.Errorf("half-cache cost: got %.10f, want %.10f (plainCost=%.10f)", cachedCost, want, plainCost)
+	}
+
+	if cachedCost >= plainCost {
+		t.Errorf("cached request must be cheaper: cached=%.6f plain=%.6f", cachedCost, plainCost)
+	}
+}
+
+// TestCalculateCost_ExplicitCacheRate verifies that a configured
+// cache_read_per_million override is honored instead of the derived 50%
+// fallback.
+func TestCalculateCost_ExplicitCacheRate(t *testing.T) {
+	rates := modelPricing{
+		InputPerMillion:     2.50,
+		OutputPerMillion:    10.0,
+		CacheReadPerMillion: 0.30, // explicit; would be 1.25 if derived
+	}
+	usage := events.Usage{
+		PromptTokens:     1_000_000,
+		CompletionTokens: 0,
+		CachedTokens:     1_000_000, // fully cached: PromptTokens-CachedTokens=0
+	}
+
+	got := calculateCost(usage, rates)
+	want := 0.30 // 1M tokens * 0.30 / 1M
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("explicit cache rate cost: got %.10f, want %.10f", got, want)
+	}
+}
+
+// TestCalculateCost_DefensiveNegativePlain verifies that an inconsistent
+// payload where CachedTokens > PromptTokens does not produce a negative cost.
+func TestCalculateCost_DefensiveNegativePlain(t *testing.T) {
+	rates := modelPricing{
+		InputPerMillion:  2.50,
+		OutputPerMillion: 10.0,
+	}
+	usage := events.Usage{
+		PromptTokens:     500,
+		CompletionTokens: 0,
+		CachedTokens:     1000, // larger than PromptTokens — defensive branch
+	}
+
+	got := calculateCost(usage, rates)
+	// plain clamped to 0 → only cached contributes at 0.5× rate.
+	want := float64(1000) / 1_000_000 * (2.50 * 0.5)
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("defensive cost: got %.10f, want %.10f", got, want)
+	}
+}
+
+// TestParsePricingConfig_CacheReadKey verifies the cache_read_per_million YAML
+// override key is parsed onto modelPricing.
+func TestParsePricingConfig_CacheReadKey(t *testing.T) {
+	cfg := map[string]any{
+		"pricing": map[string]any{
+			"gpt-4o": map[string]any{
+				"input_per_million":      2.50,
+				"output_per_million":     10.0,
+				"cache_read_per_million": 1.25,
+			},
+		},
+	}
+
+	merged := parsePricingConfig(cfg)
+	p, ok := merged["gpt-4o"]
+	if !ok {
+		t.Fatal("missing pricing entry for gpt-4o")
+	}
+	if p.InputPerMillion != 2.50 {
+		t.Errorf("InputPerMillion: got %v, want 2.50", p.InputPerMillion)
+	}
+	if p.OutputPerMillion != 10.0 {
+		t.Errorf("OutputPerMillion: got %v, want 10.0", p.OutputPerMillion)
+	}
+	if p.CacheReadPerMillion != 1.25 {
+		t.Errorf("CacheReadPerMillion: got %v, want 1.25", p.CacheReadPerMillion)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the native-feature gap between the Anthropic + OpenAI providers and the existing Gemini provider. 16 atomic commits, each one feature.

## Anthropic (9)

- **`bd27ede`** parse cache_creation/cache_read tokens; cost calc splits plain/cached/written buckets w/ derived rates
- **`b64115c`** explicit `cache_control` markers on system, last tool def, and optional leading user msgs (5m + 1h TTL)
- **`c677fd2`** extended thinking — `thinking` config, thinking/redacted_thinking blocks, `thinking.step` events, signature round-trip via `Message.Metadata`
- **`3f4484d`** multimodal input — image + document blocks (5MB inline / 32MB PDF); audio/video error cleanly
- **`529eda0`** Files API — multipart upload, content-hash dedup, oversize auto-upload preflight, optional shutdown cleanup
- **`2b60a1e`** native citations — `citations:{enabled:true}` on document blocks; sync + stream parsing into `LLMResponse.Citations`
- **`8b43689`** server-tool hooks — `_anthropic_extra_tools` + `_anthropic_beta_headers` request metadata; `code_execution_tool_result` block parsing
- **`8125f3b`** Bedrock + Vertex auth — hand-rolled SigV4 (no AWS SDK), GCP service-account JWT (mirrors Gemini)
- **`c8846bb`** native structured-outputs mode — opt-in switch from tool-as-schema simulation to top-level `response_format`

## OpenAI (6)

- **`5ba328a`** parse `prompt_tokens_details.cached_tokens`; cost split at cache rate (default 0.5×)
- **`d3f2172`** reasoning models — pattern-detect o1/o3/o4/gpt-5-thinking, strip incompatible fields, pass `reasoning_effort`, surface `reasoning_tokens`
- **`7dd7a7f`** multimodal — `image_url` (URI/data URL), `input_audio` (wav/mp3), `file` (id/inline)
- **`38502c7`** Files API — auto-upload preflight for `file`-type parts; in-session content-hash cache
- **`6536c22`** predicted outputs — `LLMRequest.Prediction` field, surface accept/reject counts on response metadata
- **`d52a236`** Azure auth — `azure_key` (api-key header) + `azure_aad` (OAuth2 client-credentials, cached + proactive refresh)

## Cross-provider (1)

- **`c9f156a`** batch API coordinator — `nexus.llm.batch` plugin: dispatches batched requests to Anthropic Messages Batches or OpenAI Batch API, polls in background, persists state to `~/.nexus/batches/<id>.json` for restart resilience

## Excluded by request

- Plan 15 (OpenAI logprobs) — niche, deferred.

## Schema additions (`pkg/events/llm.go`)

- `Message.Metadata map[string]any` — provider-specific round-trip data
- `MessagePart.FileID string` — cross-provider file id
- `Usage.CacheWriteTokens int`
- `Citation` struct + `LLMResponse.Citations`
- `LLMRequest.Prediction string`
- `BatchSubmit` / `BatchRequest` / `BatchStatus` / `BatchCounts` / `BatchResults` / `BatchResult`
- `ThinkingStep.Index int`

All additive. Existing providers + tests unaffected.

## Test plan

- [x] `make vet` clean
- [x] `make test` clean (24 packages, 0 failures, fresh cache)
- [x] `go build ./...` clean
- [x] Live smoke: Anthropic cache_control hit on agent loop
- [x] Live smoke: Anthropic extended thinking + tool use round-trip (signature preservation)
- [x] Live smoke: OpenAI o-series w/ `reasoning_effort: medium`
- [x] Live smoke: Anthropic Bedrock SigV4 against a real Bedrock account
- [x] Live smoke: Azure AAD against a real Azure deployment
- [x] Live smoke: batch submit → poll → results round-trip on each provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)