### PR TITLE
feat(sandbox): Wasm v1 — Yaegi-inside-Wasm backend + bridge SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ build-yaegi-wasm:
 	@echo "Building cmd/yaegi-runner for GOOS=wasip1 GOARCH=wasm..."
 	GOOS=wasip1 GOARCH=wasm $(GO) build -ldflags="-s -w" -trimpath -o $(YAEGI_WASM:.gz=) ./cmd/yaegi-runner
 	@echo "Compressing with gzip -9..."
-	gzip -9 -f $(YAEGI_WASM:.gz=)
+	gzip -9 -n -f $(YAEGI_WASM:.gz=)
 	@echo "Result: $(YAEGI_WASM)"
 	@ls -la $(YAEGI_WASM)
 
@@ -59,7 +59,7 @@ verify-yaegi-wasm:
 	@echo "Verifying $(YAEGI_WASM) is up to date..."
 	@tmp_dir=$$(mktemp -d); \
 	GOOS=wasip1 GOARCH=wasm $(GO) build -ldflags="-s -w" -trimpath -o $$tmp_dir/yaegi.wasm ./cmd/yaegi-runner && \
-	gzip -9 -f $$tmp_dir/yaegi.wasm && \
+	gzip -9 -n -f $$tmp_dir/yaegi.wasm && \
 	if cmp -s $(YAEGI_WASM) $$tmp_dir/yaegi.wasm.gz; then \
 	  echo "OK — embedded artefact matches a fresh build."; \
 	  rm -rf $$tmp_dir; \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: build run clean test fmt vet docs docs-serve docs-clean
+.PHONY: build run clean test fmt vet docs docs-serve docs-clean build-yaegi-wasm verify-yaegi-wasm
 
 BINARY_NAME=nexus
 BUILD_DIR=bin
 GO=go
+YAEGI_WASM=pkg/engine/sandbox/wasm/yaegi.wasm.gz
 
 ifneq (,$(wildcard ./.env))
     include .env
@@ -38,5 +39,34 @@ docs-serve:
 
 docs-clean:
 	rm -rf docs/book
+
+# Build the embedded Yaegi-on-Wasm runner. Output: pkg/engine/sandbox/wasm/yaegi.wasm.gz
+# Pinned to the host's Go toolchain. CI verifies reproducibility — see
+# verify-yaegi-wasm — so a drift between checked-in artefact and a fresh
+# build fails the build.
+build-yaegi-wasm:
+	@echo "Building cmd/yaegi-runner for GOOS=wasip1 GOARCH=wasm..."
+	GOOS=wasip1 GOARCH=wasm $(GO) build -ldflags="-s -w" -trimpath -o $(YAEGI_WASM:.gz=) ./cmd/yaegi-runner
+	@echo "Compressing with gzip -9..."
+	gzip -9 -f $(YAEGI_WASM:.gz=)
+	@echo "Result: $(YAEGI_WASM)"
+	@ls -la $(YAEGI_WASM)
+
+# Rebuild yaegi.wasm.gz into a tmp file and diff bytes against the
+# checked-in artefact. Bumping the Go toolchain or the runner source must be
+# an explicit commit that updates both .go-version and the embedded bytes.
+verify-yaegi-wasm:
+	@echo "Verifying $(YAEGI_WASM) is up to date..."
+	@tmp_dir=$$(mktemp -d); \
+	GOOS=wasip1 GOARCH=wasm $(GO) build -ldflags="-s -w" -trimpath -o $$tmp_dir/yaegi.wasm ./cmd/yaegi-runner && \
+	gzip -9 -f $$tmp_dir/yaegi.wasm && \
+	if cmp -s $(YAEGI_WASM) $$tmp_dir/yaegi.wasm.gz; then \
+	  echo "OK — embedded artefact matches a fresh build."; \
+	  rm -rf $$tmp_dir; \
+	else \
+	  echo "DRIFT — $(YAEGI_WASM) differs from a fresh build. Run 'make build-yaegi-wasm' and commit the result."; \
+	  rm -rf $$tmp_dir; \
+	  exit 1; \
+	fi
 
 .DEFAULT_GOAL := build

--- a/cmd/yaegi-runner/main.go
+++ b/cmd/yaegi-runner/main.go
@@ -52,7 +52,17 @@ func main() {
 	}
 }
 
-func run() error {
+func run() (err error) {
+	// Yaegi panics on certain malformed snippets (e.g., a script that
+	// references a type the bindings haven't fully registered). Convert to
+	// a structured error so the host sees an envelope instead of a missing-
+	// envelope diagnostic from a wasm process that died mid-eval.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("yaegi panic: %v", r)
+		}
+	}()
+
 	raw, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return fmt.Errorf("read stdin: %w", err)
@@ -129,12 +139,21 @@ func emit(r response) {
 // filteredStdlib mirrors plugins/tools/codeexec/stdlib.go. Kept inline to
 // keep the runner package self-contained — it must compile cleanly under
 // GOOS=wasip1 without dragging the engine module's plugins/* tree.
+//
+// Entries that name nexus_sdk/* paths are filtered out: those packages are
+// installed by sdkBindings(), not by stdlib.Symbols. Including them here
+// would be a no-op since stdlib.Symbols won't have a key for them, but
+// silently dropping them keeps a config that lists nexus_sdk imports under
+// allowed_packages from looking like a misconfiguration.
 func filteredStdlib(allowed []string) interp.Exports {
 	if len(allowed) == 0 {
 		return interp.Exports{}
 	}
 	allowedSet := make(map[string]bool, len(allowed))
 	for _, p := range allowed {
+		if strings.HasPrefix(p, "nexus_sdk/") {
+			continue
+		}
 		allowedSet[p] = true
 	}
 	out := interp.Exports{}

--- a/cmd/yaegi-runner/main.go
+++ b/cmd/yaegi-runner/main.go
@@ -1,3 +1,5 @@
+//go:build wasip1
+
 // Command yaegi-runner is the embedded Yaegi-inside-Wasm interpreter that
 // backs the wasm sandbox. It is compiled with GOOS=wasip1 GOARCH=wasm and
 // embedded into the engine binary via //go:embed in
@@ -75,6 +77,9 @@ func run() error {
 
 	if err := i.Use(filteredStdlib(req.AllowedPackages)); err != nil {
 		return fmt.Errorf("install stdlib: %w", err)
+	}
+	if err := i.Use(sdkBindings()); err != nil {
+		return fmt.Errorf("install nexus_sdk: %w", err)
 	}
 
 	if _, err := i.Eval(req.Source); err != nil {

--- a/cmd/yaegi-runner/main.go
+++ b/cmd/yaegi-runner/main.go
@@ -1,0 +1,152 @@
+// Command yaegi-runner is the embedded Yaegi-inside-Wasm interpreter that
+// backs the wasm sandbox. It is compiled with GOOS=wasip1 GOARCH=wasm and
+// embedded into the engine binary via //go:embed in
+// pkg/engine/sandbox/wasm. wazero instantiates one fresh module per snippet
+// invocation; the host writes a JSON request to stdin and reads the result
+// envelope from stdout, separated from any user-emitted stdout by a unique
+// sentinel.
+//
+// Wire protocol (v1):
+//
+//	stdin  → JSON request: {"source", "allowed_packages", "timeout_seconds"}
+//	stdout → user output emitted by the snippet, followed by:
+//	         "\n---NEXUS-RUNNER-RESULT-V1---\n" + JSON response
+//	         {"result", "error"}
+//	stderr → user stderr output emitted by the snippet
+//	exit   → 0 on success, 1 on any host-level failure (parse, timeout, etc.)
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/traefik/yaegi/interp"
+	"github.com/traefik/yaegi/stdlib"
+)
+
+const sentinel = "\n---NEXUS-RUNNER-RESULT-V1---\n"
+
+type request struct {
+	Source          string   `json:"source"`
+	AllowedPackages []string `json:"allowed_packages"`
+	TimeoutSeconds  int      `json:"timeout_seconds"`
+}
+
+type response struct {
+	Result string `json:"result,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		emit(response{Error: err.Error()})
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	raw, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("read stdin: %w", err)
+	}
+	var req request
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return fmt.Errorf("parse request: %w", err)
+	}
+	if req.Source == "" {
+		return fmt.Errorf("source is empty")
+	}
+
+	timeout := time.Duration(req.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	i := interp.New(interp.Options{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	})
+
+	if err := i.Use(filteredStdlib(req.AllowedPackages)); err != nil {
+		return fmt.Errorf("install stdlib: %w", err)
+	}
+
+	if _, err := i.Eval(req.Source); err != nil {
+		return fmt.Errorf("compile: %w", err)
+	}
+
+	runVal, err := i.Eval("main.Run")
+	if err != nil {
+		return fmt.Errorf("resolve main.Run: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	rv := reflect.ValueOf(runVal.Interface())
+	if rv.Kind() != reflect.Func {
+		return fmt.Errorf("main.Run is not a function")
+	}
+	out := rv.Call([]reflect.Value{reflect.ValueOf(ctx)})
+	if len(out) != 2 {
+		return fmt.Errorf("main.Run returned %d values, want 2", len(out))
+	}
+	if errVal := out[1].Interface(); errVal != nil {
+		if e, ok := errVal.(error); ok {
+			return fmt.Errorf("runtime: %w", e)
+		}
+		return fmt.Errorf("runtime: %v", errVal)
+	}
+
+	emit(response{Result: fmt.Sprintf("%v", out[0].Interface())})
+	return nil
+}
+
+func emit(r response) {
+	enc, err := json.Marshal(r)
+	if err != nil {
+		// Fallback: write a parseable envelope by hand. Should never happen
+		// since response only contains string fields.
+		fmt.Fprint(os.Stdout, sentinel)
+		fmt.Fprintf(os.Stdout, `{"error":"emit marshal: %s"}`, err)
+		return
+	}
+	fmt.Fprint(os.Stdout, sentinel)
+	os.Stdout.Write(enc)
+}
+
+// filteredStdlib mirrors plugins/tools/codeexec/stdlib.go. Kept inline to
+// keep the runner package self-contained — it must compile cleanly under
+// GOOS=wasip1 without dragging the engine module's plugins/* tree.
+func filteredStdlib(allowed []string) interp.Exports {
+	if len(allowed) == 0 {
+		return interp.Exports{}
+	}
+	allowedSet := make(map[string]bool, len(allowed))
+	for _, p := range allowed {
+		allowedSet[p] = true
+	}
+	out := interp.Exports{}
+	for key, syms := range stdlib.Symbols {
+		// yaegi keys are "importpath/pkgname"; trim the trailing /pkgname.
+		importPath := key
+		if idx := strings.LastIndex(key, "/"); idx >= 0 {
+			importPath = key[:idx]
+		}
+		if !allowedSet[importPath] {
+			continue
+		}
+		dup := make(map[string]reflect.Value, len(syms))
+		for k, v := range syms {
+			dup[k] = v
+		}
+		out[key] = dup
+	}
+	return out
+}

--- a/cmd/yaegi-runner/sdk.go
+++ b/cmd/yaegi-runner/sdk.go
@@ -1,0 +1,96 @@
+//go:build wasip1
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"unsafe"
+)
+
+// hostModuleName must match host.HostModuleName exactly. Bumped together
+// when the bridge ABI changes.
+const hostModuleName = "nexus_bridge_v1"
+
+// scratchBuf is the per-call response buffer. Single-threaded snippet
+// execution lets us reuse a fixed buffer; large responses can grow it via
+// retryWithBigger.
+var scratchBuf = make([]byte, 64*1024)
+
+// status codes match host.Bridge constants.
+const (
+	statusOK             uint16 = 0
+	statusInvalidOp      uint16 = 1
+	statusBadRequest     uint16 = 2
+	statusCapDenied      uint16 = 3
+	statusInternal       uint16 = 4
+	statusBufferTooSmall uint16 = 5
+)
+
+// invoke is the single wasmimport into the host bridge. Returns a packed
+// (status<<48 | length) result. When status == statusBufferTooSmall, length
+// is the size the response would have taken — the caller grows scratch and
+// retries.
+//
+//go:wasmimport nexus_bridge_v1 invoke
+//go:noescape
+func invoke(opPtr, opLen, reqPtr, reqLen, scratchPtr, scratchLen uint32) uint64
+
+// bridgeCall sends opcode + JSON request to the host, returns response bytes
+// (JSON when the call succeeded, plain UTF-8 error message on the negative
+// path). errCapDenied is surfaced as a typed error so SDK callers can
+// distinguish "you didn't have permission" from "the operation itself
+// failed" or "the bridge is misconfigured".
+func bridgeCall(op string, req any) ([]byte, error) {
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("nexus_sdk: marshal request: %w", err)
+	}
+	opBytes := []byte(op)
+
+	for {
+		ret := invoke(
+			ptr(opBytes), uint32(len(opBytes)),
+			ptr(reqBytes), uint32(len(reqBytes)),
+			ptr(scratchBuf), uint32(len(scratchBuf)),
+		)
+		status := uint16(ret >> 48)
+		length := uint32(ret)
+
+		switch status {
+		case statusOK:
+			out := make([]byte, length)
+			copy(out, scratchBuf[:length])
+			return out, nil
+		case statusBufferTooSmall:
+			scratchBuf = make([]byte, int(length)+1024)
+			continue
+		case statusCapDenied:
+			return nil, fmt.Errorf("%w: %s", errCapDenied, string(scratchBuf[:length]))
+		case statusInvalidOp:
+			return nil, fmt.Errorf("nexus_sdk: invalid op %q: %s", op, string(scratchBuf[:length]))
+		case statusBadRequest:
+			return nil, fmt.Errorf("nexus_sdk: bad request: %s", string(scratchBuf[:length]))
+		case statusInternal:
+			return nil, fmt.Errorf("nexus_sdk: bridge: %s", string(scratchBuf[:length]))
+		default:
+			return nil, fmt.Errorf("nexus_sdk: unknown status %d", status)
+		}
+	}
+}
+
+// errCapDenied is the sentinel returned to snippets when a capability gate
+// rejects the call. Use errors.Is(err, ErrCapDenied) in snippet code.
+var errCapDenied = errors.New("capability denied")
+
+// ptr returns the start address of b as a uint32 suitable for a wasmimport
+// argument. b must remain alive for the duration of the call (Go's GC may
+// not move heap objects but the pointer-as-int cast loses the tracker — use
+// this only for arguments that are clearly live across the call).
+func ptr(b []byte) uint32 {
+	if len(b) == 0 {
+		return 0
+	}
+	return uint32(uintptr(unsafe.Pointer(&b[0])))
+}

--- a/cmd/yaegi-runner/sdk_bindings.go
+++ b/cmd/yaegi-runner/sdk_bindings.go
@@ -1,0 +1,36 @@
+//go:build wasip1
+
+package main
+
+import (
+	"reflect"
+
+	"github.com/traefik/yaegi/interp"
+)
+
+// sdkBindings returns the Yaegi symbol map for the nexus_sdk/* packages.
+// Snippet code does `import "nexus_sdk/http"` and the imports resolve
+// against this map, dispatching through the wasmimport bridge to the host.
+//
+// Path key format is yaegi's "<importpath>/<pkgname>" convention.
+func sdkBindings() interp.Exports {
+	return interp.Exports{
+		"nexus_sdk/http/http": {
+			"Get":          reflect.ValueOf(HTTPGet),
+			"HTTPResponse": reflect.ValueOf((*HTTPResponse)(nil)).Elem(),
+			"ErrCapDenied": reflect.ValueOf(&ErrCapDenied).Elem(),
+			"IsCapDenied":  reflect.ValueOf(IsCapDenied),
+		},
+		"nexus_sdk/fs/fs": {
+			"ReadFile":  reflect.ValueOf(FSReadFile),
+			"WriteFile": reflect.ValueOf(FSWriteFile),
+		},
+		"nexus_sdk/exec/exec": {
+			"Run":        reflect.ValueOf(ExecRun),
+			"ExecResult": reflect.ValueOf((*ExecResult)(nil)).Elem(),
+		},
+		"nexus_sdk/env/env": {
+			"Get": reflect.ValueOf(EnvGet),
+		},
+	}
+}

--- a/cmd/yaegi-runner/sdk_env.go
+++ b/cmd/yaegi-runner/sdk_env.go
@@ -1,0 +1,21 @@
+//go:build wasip1
+
+package main
+
+import "encoding/json"
+
+// EnvGet returns a sandbox-scoped env value. Never reads the host's real
+// environment; values come from the configured env block.
+func EnvGet(key string) string {
+	resp, err := bridgeCall("env.get", map[string]any{"key": key})
+	if err != nil {
+		return ""
+	}
+	var out struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return ""
+	}
+	return out.Value
+}

--- a/cmd/yaegi-runner/sdk_exec.go
+++ b/cmd/yaegi-runner/sdk_exec.go
@@ -1,0 +1,34 @@
+//go:build wasip1
+
+package main
+
+import (
+	"encoding/json"
+)
+
+// ExecResult mirrors os/exec output: separate stdout/stderr buffers plus
+// exit code. Errors here represent host-level failures (missing binary,
+// timeout, capability denied); a non-zero Exit is not an error.
+type ExecResult struct {
+	Stdout []byte `json:"stdout"`
+	Stderr []byte `json:"stderr"`
+	Exit   int    `json:"exit"`
+}
+
+// ExecRun invokes a sandbox-allowlisted command with args and waits for
+// completion. Returns ErrCapDenied if name is not on the configured allow
+// list.
+func ExecRun(name string, args []string) (*ExecResult, error) {
+	resp, err := bridgeCall("exec.run", map[string]any{
+		"name": name,
+		"args": args,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var out ExecResult
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/cmd/yaegi-runner/sdk_fs.go
+++ b/cmd/yaegi-runner/sdk_fs.go
@@ -1,0 +1,33 @@
+//go:build wasip1
+
+package main
+
+import (
+	"encoding/json"
+)
+
+// FSReadFile reads a file from a guest path that maps to a configured
+// mount. Returns ErrCapDenied when the path falls outside any mount.
+func FSReadFile(path string) ([]byte, error) {
+	resp, err := bridgeCall("fs.read", map[string]any{"path": path})
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		Data []byte `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, err
+	}
+	return out.Data, nil
+}
+
+// FSWriteFile writes data to a guest path. The mount must be configured
+// with mode rw or the call returns ErrCapDenied.
+func FSWriteFile(path string, data []byte) error {
+	_, err := bridgeCall("fs.write", map[string]any{
+		"path": path,
+		"data": data,
+	})
+	return err
+}

--- a/cmd/yaegi-runner/sdk_http.go
+++ b/cmd/yaegi-runner/sdk_http.go
@@ -1,0 +1,42 @@
+//go:build wasip1
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// HTTPResponse mirrors a subset of net/http.Response shape that survives the
+// JSON envelope. Body is bytes, not an io.Reader, so the SDK ABI stays flat.
+type HTTPResponse struct {
+	Status  int                 `json:"status"`
+	Body    []byte              `json:"body"`
+	Headers map[string][]string `json:"headers"`
+}
+
+// HTTPGet performs a gated HTTP GET. Capability denied errors are reported
+// via ErrCapDenied; other errors are surfaced as plain errors.
+func HTTPGet(url string) (*HTTPResponse, error) {
+	resp, err := bridgeCall("http.get", map[string]any{"url": url})
+	if err != nil {
+		return nil, err
+	}
+	var out HTTPResponse
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ErrCapDenied is the sentinel for "the sandbox refused to perform the
+// operation because the configured capability gate denied it". Snippet code
+// uses errors.Is(err, ErrCapDenied) to distinguish denial from runtime
+// failure.
+var ErrCapDenied = errCapDenied
+
+// IsCapDenied is a helper for snippet code that wants the same answer
+// without importing errors directly.
+func IsCapDenied(err error) bool {
+	return errors.Is(err, ErrCapDenied)
+}

--- a/configs/README.md
+++ b/configs/README.md
@@ -118,6 +118,7 @@ go test -tags integration ./tests/integration/ -v
 | `test-minimal.yaml` | `minimal_test.go` | live (Anthropic) | Bare-engine boot, no tools/gates/observers |
 | `test-all-gates.yaml` | `all_gates_test.go` | live + mock variants | All 8 gates active, veto chain, gate interactions |
 | `test-code-exec.yaml` | `code_exec_test.go` | mock | `run_code` tool dispatching shell via in-process Yaegi |
+| `test-sandbox-wasm.yaml` | `sandboxwasm_test.go` | mock | `code_exec` under `compiler: yaegi-wasm`; pure-compute snippet round-trip + bridge net-deny path |
 | `test-fallback.yaml` | `fallback_test.go` | live | Provider fallback chain (primary fails → fallback responds) |
 | `test-fanout.yaml` | `fanout_test.go` | mock | Parallel multi-provider dispatch + collection |
 | `test-memory-simple.yaml` | `memory_test.go` | mock | Unbounded `memory.simple` provider |
@@ -164,3 +165,4 @@ Manual / interactive only. Run with `bin/nexus -config configs/<name>.yaml`. Not
 |--------|---------------|
 | `demo-gates-strict.yaml` | Tight gate limits, manual veto exploration |
 | `demo-rag.yaml` | RAG primitives walkthrough (embeddings + vector store + ingest + knowledge_search) |
+| `demo-sandbox-wasm.yaml` | `code_exec` under wasm sandbox; agent uses `nexus_sdk/{http,fs,exec,env}` to do gated I/O. Live Anthropic; `cache_dir` set so cold-start amortises across runs. |

--- a/configs/demo-sandbox-wasm.yaml
+++ b/configs/demo-sandbox-wasm.yaml
@@ -1,0 +1,121 @@
+# Hand-drive demo: code_exec under the wasm sandbox compiler with the
+# nexus_sdk/* bridge SDK. Lets you ask the agent to write Go that fetches
+# a URL, reads/writes a session-scoped file, runs a sandbox-allowlisted
+# command, or reads sandbox-scoped env values.
+#
+# Run:
+#   make build
+#   bin/nexus -config configs/demo-sandbox-wasm.yaml
+#
+# Then prompt the agent with things like:
+#   "Use run_code with nexus_sdk/http to fetch https://httpbin.org/json
+#    and tell me what status code you got."
+#   "Write a Go snippet that reads /workspace/notes.txt via nexus_sdk/fs."
+#   "Use nexus_sdk/exec to run `git status` and summarise the output."
+#
+# First run pays a ~5–9 s wazero AOT cost compiling the embedded runner
+# (39 MiB). The cache_dir below persists the compiled module across
+# processes; second-and-later runs cold-start in ~50–200 ms.
+
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: balanced
+    balanced:
+      provider: nexus.llm.anthropic
+      model: claude-sonnet-4-20250514
+      max_tokens: 8192
+  sessions:
+    root: ~/.nexus/sessions
+    retention: 30d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.tui
+    - nexus.llm.anthropic
+    - nexus.agent.react
+    - nexus.tool.code_exec
+    - nexus.gate.endless_loop
+    - nexus.memory.capped
+
+  nexus.llm.anthropic:
+    api_key_env: ANTHROPIC_API_KEY
+
+  nexus.agent.react:
+    system_prompt: |
+      You are a developer assistant. When the user asks you to fetch URLs,
+      read or write files, or run commands, use the `run_code` tool with
+      a Go script that uses the nexus_sdk/* packages. The familiar Go
+      stdlib (`net/http`, `os`) is NOT available inside this sandbox —
+      use `nexus_sdk/http`, `nexus_sdk/fs`, `nexus_sdk/exec`, and
+      `nexus_sdk/env` instead. They mirror the shape of the stdlib
+      equivalents.
+
+      Example HTTP fetch:
+
+          import nhttp "nexus_sdk/http"
+          resp, err := nhttp.Get("https://httpbin.org/json")
+          if err != nil { return nil, err }
+          fmt.Printf("status=%d body=%s\n", resp.Status, string(resp.Body))
+
+      Example file read:
+
+          import nfs "nexus_sdk/fs"
+          data, err := nfs.ReadFile("/workspace/notes.txt")
+          if err != nil { return nil, err }
+
+      Capability gates fire on the host side. If the user's URL is not in
+      the configured allow_hosts list, you will receive an
+      `nexus_sdk/http.ErrCapDenied`-wrapped error. Surface that gracefully.
+
+  nexus.gate.endless_loop:
+    max_iterations: 8
+
+  nexus.memory.capped:
+    max_messages: 100
+    persist: true
+
+  nexus.tool.code_exec:
+    compiler: yaegi-wasm
+    timeout_seconds: 60
+    max_output_bytes: 65536
+    allowed_packages:
+      - "fmt"
+      - "context"
+      - "strings"
+      - "strconv"
+      - "encoding/json"
+      - "errors"
+      - "time"
+    sandbox:
+      backend: wasm
+      timeout: 60s
+      cache_dir: ~/.nexus/sandbox/wasm/cache
+      net:
+        # Allow a small set of well-known testing endpoints. Tweak to fit
+        # your demo. Empty list = deny all.
+        allow_hosts:
+          - "httpbin.org"
+          - "api.github.com"
+          - "example.com"
+      fs_mounts:
+        # Map the session's files dir to /workspace inside the sandbox.
+        # ${session_id} is substituted by the engine at session start.
+        - host: "~/.nexus/sessions/${session_id}/files"
+          guest: "/workspace"
+          mode: rw
+      exec_allowed:
+        # Commands the snippet may invoke via nexus_sdk/exec.Run. Snippet
+        # invocations honour the same allowlist as the direct shell tool
+        # would — keep tight.
+        - "git"
+        - "ls"
+        - "echo"
+      env:
+        # Sandbox-scoped env values returned by nexus_sdk/env.Get. Never
+        # the host's real environment.
+        WORKSPACE: "/workspace"
+        DEMO_NAME: "sandbox-wasm"

--- a/configs/demo-sandbox-wasm.yaml
+++ b/configs/demo-sandbox-wasm.yaml
@@ -28,7 +28,7 @@ core:
       model: claude-sonnet-4-20250514
       max_tokens: 8192
   sessions:
-    root: ~/.nexus/sessions
+    root: ~/.nexus/sandbox-sessions
     retention: 30d
     id_format: datetime_short
 
@@ -48,28 +48,69 @@ plugins:
     system_prompt: |
       You are a developer assistant. When the user asks you to fetch URLs,
       read or write files, or run commands, use the `run_code` tool with
-      a Go script that uses the nexus_sdk/* packages. The familiar Go
-      stdlib (`net/http`, `os`) is NOT available inside this sandbox —
-      use `nexus_sdk/http`, `nexus_sdk/fs`, `nexus_sdk/exec`, and
-      `nexus_sdk/env` instead. They mirror the shape of the stdlib
-      equivalents.
+      a Go script.
 
-      Example HTTP fetch:
+      Hard rules — every script MUST follow these or it is rejected before
+      execution:
 
-          import nhttp "nexus_sdk/http"
-          resp, err := nhttp.Get("https://httpbin.org/json")
-          if err != nil { return nil, err }
-          fmt.Printf("status=%d body=%s\n", resp.Status, string(resp.Body))
+      1. Declare `package main` and a single function:
 
-      Example file read:
+             func Run(ctx context.Context) (any, error) { ... }
 
-          import nfs "nexus_sdk/fs"
-          data, err := nfs.ReadFile("/workspace/notes.txt")
-          if err != nil { return nil, err }
+         The parameter type is the qualified `context.Context`, never just
+         `Context`. The first return type is `any` (or `interface{}`); the
+         second is `error`.
 
-      Capability gates fire on the host side. If the user's URL is not in
-      the configured allow_hosts list, you will receive an
-      `nexus_sdk/http.ErrCapDenied`-wrapped error. Surface that gracefully.
+      2. Import `context` whenever Run is declared (you almost always need
+         it). Import `fmt` if you call Print*/Sprintf/Errorf.
+
+      3. The familiar Go stdlib for I/O (`net/http`, `os`, `os/exec`,
+         `database/sql`) is NOT available inside this sandbox. Use the
+         nexus_sdk/* packages instead — they mirror the stdlib API shape
+         but route through the sandbox's capability gates:
+
+           - `nexus_sdk/http` — HTTPGet(url) → (*HTTPResponse, error).
+             HTTPResponse fields: Status int, Body []byte, Headers map.
+           - `nexus_sdk/fs`   — ReadFile(path) → ([]byte, error);
+             WriteFile(path, data) → error. Paths are guest paths, e.g.
+             "/workspace/<name>".
+           - `nexus_sdk/exec` — Run(name, args) → (*ExecResult, error).
+             ExecResult fields: Stdout []byte, Stderr []byte, Exit int.
+           - `nexus_sdk/env`  — Get(key) → string (sandbox-scoped, not the
+             host's real environment).
+
+      4. Only reference symbols documented above for the nexus_sdk/* packages.
+         Do NOT invent fields like `nhttp.Client{}` or types like
+         `nhttp.Request` — they are not bound in this runtime and will
+         crash the interpreter.
+
+      5. If a capability gate denies a call, the err you receive wraps
+         `nexus_sdk/http.ErrCapDenied`. Use `errors.Is(err, nhttp.ErrCapDenied)`
+         to detect and report gracefully rather than failing hard.
+
+      Worked example — fetch and report:
+
+          package main
+
+          import (
+              "context"
+              "errors"
+              "fmt"
+              nhttp "nexus_sdk/http"
+          )
+
+          func Run(ctx context.Context) (any, error) {
+              resp, err := nhttp.Get("https://httpbin.org/json")
+              if err != nil {
+                  if errors.Is(err, nhttp.ErrCapDenied) {
+                      fmt.Println("denied by sandbox; host not allowlisted")
+                      return "denied", nil
+                  }
+                  return nil, err
+              }
+              fmt.Printf("status=%d body_len=%d\n", resp.Status, len(resp.Body))
+              return resp.Status, nil
+          }
 
   nexus.gate.endless_loop:
     max_iterations: 8
@@ -90,6 +131,10 @@ plugins:
       - "encoding/json"
       - "errors"
       - "time"
+      - "nexus_sdk/http"
+      - "nexus_sdk/fs"
+      - "nexus_sdk/exec"
+      - "nexus_sdk/env"
     sandbox:
       backend: wasm
       timeout: 60s
@@ -104,7 +149,7 @@ plugins:
       fs_mounts:
         # Map the session's files dir to /workspace inside the sandbox.
         # ${session_id} is substituted by the engine at session start.
-        - host: "~/.nexus/sessions/${session_id}/files"
+        - host: "~/.nexus/sandbox-sessions/${session_id}/files"
           guest: "/workspace"
           mode: rw
       exec_allowed:

--- a/configs/test-sandbox-wasm.yaml
+++ b/configs/test-sandbox-wasm.yaml
@@ -1,0 +1,74 @@
+# Test: code_exec under the wasm sandbox compiler.
+#
+# Validates the engine wires `compiler: yaegi-wasm` through ctx.Sandbox to
+# the embedded Yaegi-on-Wasm runner. The snippet does pure compute (no
+# bridge calls) so this test exercises:
+#   - Sandbox interface plumbing (PluginContext.Sandbox)
+#   - WasmBackend boot (wazero runtime + embedded yaegi.wasm.gz)
+#   - Snippet round-trip: bus → run_code tool.invoke → wasm sandbox → result
+#
+# Bridge-SDK paths (HTTP/FS/exec/env) have unit-test coverage in
+# pkg/engine/sandbox/wasm/bridge_test.go — those run real httptest servers
+# and don't fit the static-mock harness shape.
+#
+# Mocked LLM, no API key required.
+#
+# Run:
+#   go test -tags integration ./tests/integration/ -run TestSandboxWasm
+
+core:
+  log_level: warn
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: quick
+    quick:
+      provider: nexus.llm.anthropic
+      model: claude-haiku-4-5-20251001
+      max_tokens: 4096
+  sessions:
+    root: ~/.nexus/test-sessions
+    retention: 30d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.test
+    - nexus.llm.anthropic
+    - nexus.agent.react
+    - nexus.tool.code_exec
+    - nexus.memory.capped
+
+  nexus.io.test:
+    inputs:
+      - "Use run_code to compute the sum of 1..10."
+    input_delay: 200ms
+    approval_mode: approve
+    timeout: 30s
+    mock_responses:
+      - tool_calls:
+          - name: run_code
+            arguments: |
+              {"script":"package main\n\nimport (\n\t\"context\"\n\t\"fmt\"\n)\n\nfunc Run(ctx context.Context) (any, error) {\n\tsum := 0\n\tfor i := 1; i <= 10; i++ { sum += i }\n\tfmt.Println(\"sum=\", sum)\n\treturn sum, nil\n}\n"}
+      - content: "Done. The script computed the sum and returned 55."
+
+  nexus.llm.anthropic:
+    api_key: "sk-mock-not-used"
+
+  nexus.agent.react:
+    system_prompt: "You are a test agent. Use tools when asked."
+
+  nexus.tool.code_exec:
+    compiler: yaegi-wasm
+    timeout_seconds: 30
+    allowed_packages: ["fmt", "context"]
+    sandbox:
+      backend: wasm
+      timeout: 30s
+      # cache_dir omitted intentionally — exercises the cold-start path so
+      # we know first-run on a clean machine works without state. Set a
+      # cache_dir in production configs to amortise the wazero AOT cost.
+
+  nexus.memory.capped:
+    max_messages: 10
+    persist: false

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -83,6 +83,7 @@
 
 - [Event Types](./events/reference.md)
 - [Configuration Reference](./configuration/reference.md)
+- [Sandboxing](./security/sandboxing.md)
 
 # Eval Harness
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -67,7 +67,6 @@
   - [Test IO](./plugins/io/test.md)
   - [Wails Desktop](./plugins/io/wails.md)
 - [Observers](./plugins/observers/index.md)
-  - [Event Logger](./plugins/observers/logger.md)
   - [Thinking Persistence](./plugins/observers/thinking.md)
   - [OpenTelemetry](./plugins/observers/otel.md)
   - [Online Sampler](./plugins/observers/sampler.md)

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -508,15 +508,23 @@ explicitly via the top-level `capabilities:` block.
 
 ### `nexus.tool.shell`
 
-Source: `plugins/tools/shell/plugin.go`.
+Source: `plugins/tools/shell/plugin.go`. Routes commands through
+`pkg/engine/sandbox` so the kernel surface is a single audited boundary.
 
 | Key                | Type     | Default                  | Description |
 |--------------------|----------|--------------------------|-------------|
-| `allowed_commands` | list     | *(none — all allowed)*   | Whitelist of command names (exact match only, despite a misleading code comment). |
 | `working_dir`      | string   | *(session files dir)*    | Working directory for executions. |
-| `path_dirs`        | list     | *(none)*                 | Directories prepended to `PATH` for command resolution. |
 | `timeout`          | duration | `30s`                    | Per-command timeout. |
-| `sandbox`          | bool     | `false`                  | Strip sensitive env vars (AWS, Google, Azure, Anthropic API keys) before execution. |
+| `sandbox.backend`  | string   | `host`                   | Sandbox tier: `host` (current behaviour). Future: `gvisor`, `firecracker`, `landlock`. |
+| `sandbox.allowed_commands` | list | *(none — all allowed)* | Whitelist of base command names. |
+| `sandbox.path_dirs`        | list | *(none)*               | Directories prepended to `PATH`. |
+| `sandbox.env_restrict`     | bool | `false`                | Strip sensitive env vars (AWS, Google, Azure, Anthropic API keys) before execution. |
+| `sandbox.timeout`          | duration | `30s`              | Per-command default; `timeout` above wins per-call. |
+
+**Legacy keys** still accepted for backwards compatibility:
+`allowed_commands`, `path_dirs`, `sandbox: <bool>` at the top level are
+auto-shimmed into the equivalent `sandbox: { ... }` block. Documented as
+deprecated; removal targeted for the milestone after gVisor lands.
 
 ### `nexus.tool.file`
 
@@ -597,16 +605,33 @@ Source: `plugins/tools/ask/plugin.go`. **No configuration.** Registers
 
 ### `nexus.tool.code_exec`
 
-Source: `plugins/tools/codeexec/plugin.go`. Registers `run_code` (Go via Yaegi).
+Source: `plugins/tools/codeexec/plugin.go`. Registers `run_code` (Go).
+Two compilers selected via `compiler`:
 
-| Key                 | Type | Default                    | Description |
-|---------------------|------|----------------------------|-------------|
-| `timeout_seconds`   | int  | `30`                       | Script timeout in seconds. |
-| `max_output_bytes`  | int  | `65536`                    | Maximum captured output. |
-| `max_workers`       | int  | `runtime.NumCPU()`         | Concurrency cap for `parallel.*` constructs. |
-| `persist_scripts`   | bool | `true`                     | Write executed scripts to session files. |
-| `reject_goroutines` | bool | `true`                     | Reject scripts that spawn goroutines. |
-| `allowed_packages`  | list | *(stdlib whitelist)*       | Additional importable packages (must be in stdlib). |
+- `yaegi-host` (default) — in-process Yaegi interpreter. Full dynamic
+  bindings (`tools.*`, `parallel.*`, skill helpers); no kernel isolation.
+- `yaegi-wasm` — embedded Yaegi runner inside a wazero-managed Wasm
+  sandbox. Capability-gated I/O via `nexus_sdk/{http,fs,exec,env}`. v1
+  forfeits `tools.*`, `parallel.*`, and skill helpers — the bridge SDK
+  does not surface them.
+
+| Key                 | Type   | Default                    | Description |
+|---------------------|--------|----------------------------|-------------|
+| `compiler`          | string | `yaegi-host`               | `yaegi-host` or `yaegi-wasm`. The latter requires `sandbox.backend: wasm`. |
+| `timeout_seconds`   | int    | `30`                       | Script timeout in seconds. |
+| `max_output_bytes`  | int    | `65536`                    | Maximum captured output. |
+| `max_workers`       | int    | `runtime.NumCPU()`         | Concurrency cap for `parallel.*` (yaegi-host only). |
+| `persist_scripts`   | bool   | `true`                     | Write executed scripts to session files. |
+| `reject_goroutines` | bool   | `true`                     | Reject scripts that spawn goroutines. |
+| `allowed_packages`  | list   | *(stdlib whitelist)*       | Importable stdlib packages. |
+| `sandbox.backend`   | string | `host`                     | Required `wasm` for `compiler: yaegi-wasm`. Other backends (`host`) reject `KindGoWasm` requests. |
+| `sandbox.cache_dir` | string | *(none)*                   | Persistent wazero compilation cache. Recommended for fast cold-start across processes. |
+| `sandbox.timeout`   | duration | `30s`                    | Default per-call wasm timeout. |
+| `sandbox.net.policy` | string | `deny`                    | `deny` or `allow_hosts`. Empty `allow_hosts` = deny all. |
+| `sandbox.net.allow_hosts` | list | *(empty)*              | Exact-match hostname allowlist for `nexus_sdk/http`. |
+| `sandbox.fs_mounts` | list   | *(empty)*                  | List of `{host, guest, mode}` triples. `mode` is `ro` (default) or `rw`. Backs `nexus_sdk/fs`. |
+| `sandbox.exec_allowed` | list | *(empty)*                | Allowlist of commands invokable from `nexus_sdk/exec.Run`. Empty = deny. |
+| `sandbox.env`       | map    | *(empty)*                  | Sandbox-scoped env values returned by `nexus_sdk/env.Get`. Never the host's real env. |
 
 ---
 

--- a/docs/src/security/sandboxing.md
+++ b/docs/src/security/sandboxing.md
@@ -1,0 +1,145 @@
+# Sandboxing
+
+Nexus tools that shell out (`tools/shell`) or execute agent-emitted code
+(`tools/code_exec`) route through a single execution-isolation abstraction at
+`pkg/engine/sandbox`. Backends slot in via the `Sandbox` interface; the v1
+release ships `host` and `wasm`, with `landlock`, `gvisor`, and
+`firecracker` deferred.
+
+## Threat model
+
+Agent-emitted code is the load-bearing case. Trail of Bits' Oct 2025
+[prompt-injection-to-RCE chain](https://blog.trailofbits.com/2025/10/22/prompt-injection-to-rce-in-ai-agents/)
+documented multiple production incidents where a compromised LLM context
+yielded host shell access through under-isolated tool execution. For
+non-developer end users (the desktop shell ships agents to laptops),
+"sandbox in name only" is a regression to those incidents waiting to
+happen.
+
+The `wasm` backend closes that risk for `tools/code_exec` by interpreting
+agent code inside a wazero-managed Wasm module. The module sees no kernel
+syscalls — every escape is a host-side bridge function with explicit
+capability gates.
+
+## Backends
+
+### `host` (default for `tools/shell`)
+
+Runs commands directly via `os/exec` against the host kernel. The
+configured `allowed_commands` allowlist and `working_dir` apply, but a
+permissive allowlist is a host compromise away from arbitrary code
+execution. Use this only when commands are trusted (developer machines, CI
+runners, allowlists tight enough that escape is implausible).
+
+```yaml
+nexus.tool.shell:
+  sandbox:
+    backend: host
+    allowed_commands: [git, go, npm]
+    working_dir: ~/.nexus/sessions/${session_id}/files
+```
+
+### `wasm` (recommended for `tools/code_exec`)
+
+Embeds a Yaegi-compiled-to-Wasm interpreter into the engine binary at
+build time. The wasm module sees no fs / net / syscalls unless the
+configured policy explicitly grants them, in which case the calls go
+through a host bridge function gated per-operation. Bridge surfaces:
+
+| SDK package | Capability tag | Gate config |
+|---|---|---|
+| `nexus_sdk/http` | `cap_net_http` | `sandbox.net.allow_hosts` (exact-match hostnames) |
+| `nexus_sdk/fs` | `cap_fs_read`, `cap_fs_write` | `sandbox.fs_mounts` (host→guest bindings, ro/rw) |
+| `nexus_sdk/exec` | `cap_exec` | `sandbox.exec_allowed` (command allowlist) |
+| `nexus_sdk/env` | none | `sandbox.env` (sandbox-scoped key/value map) |
+
+```yaml
+nexus.tool.code_exec:
+  compiler: yaegi-wasm
+  sandbox:
+    backend: wasm
+    cache_dir: ~/.nexus/sandbox/wasm/cache
+    timeout: 30s
+    net:
+      allow_hosts: ["api.openai.com", "api.anthropic.com"]
+    fs_mounts:
+      - host: ~/.nexus/sessions/${session_id}/files
+        guest: /workspace
+        mode: rw
+    exec_allowed: [git]
+    env:
+      WORKSPACE: /workspace
+```
+
+Empty `net.allow_hosts` denies all HTTP. Empty `fs_mounts` denies all FS.
+Empty `exec_allowed` denies all subprocess invocation.
+
+## Snippet authoring under `wasm`
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"errors"
+
+	nhttp "nexus_sdk/http"
+	nfs "nexus_sdk/fs"
+)
+
+func Run(ctx context.Context) (any, error) {
+	resp, err := nhttp.Get("https://api.example.com/data")
+	if err != nil {
+		if errors.Is(err, nhttp.ErrCapDenied) {
+			return nil, fmt.Errorf("net.allow_hosts denies api.example.com")
+		}
+		return nil, err
+	}
+	if err := nfs.WriteFile("/workspace/out.json", resp.Body); err != nil {
+		return nil, err
+	}
+	return resp.Status, nil
+}
+```
+
+The `nexus_sdk/*` packages mirror the shape of `net/http`, `os`, `os/exec`,
+and `os.Getenv` so familiar Go reflexes work. The bridge layer flattens
+the ABI: Bodies are `[]byte`, not `io.Reader`. Streaming reads / writes
+are not supported in v1.
+
+## What you give up under `wasm`
+
+- Raw TCP / `net.Dial` — not provided. Add a targeted bridge function
+  (`nexus_sdk/websocket`, etc.) when a real caller needs it.
+- `cgo` — never. Not a Wasm thing.
+- Full `database/sql` driver libraries — most native drivers won't run in
+  Wasm without their own bridges. Use HTTP-shaped database backends
+  (REST, BigQuery) or run database access via `tools/shell` with
+  appropriate gating.
+- `tools.*` typed bindings, `parallel.*` constructs, skill helpers — v1
+  surface forfeits these on the wasm path. They remain available under
+  `compiler: yaegi-host` for trusted skill-author workflows.
+
+## Performance
+
+| Operation | Cost |
+|---|---|
+| WasmBackend cold start (one-time per session) | ~5–9 s wazero AOT compile of the 39 MiB embedded runner |
+| With `cache_dir` set, subsequent process startup | ~50–200 ms |
+| Per-snippet (warm backend) | ~30–50 ms wall, ~5–30 ms interpretation overhead + bridge round-trips |
+
+Set `cache_dir` to a stable path (e.g., `~/.nexus/sandbox/wasm/cache`) to
+amortise the wazero AOT cost across processes.
+
+## Future tiers (not in v1)
+
+- `landlock` — Linux-only hardening below `tools/shell`.
+- `gvisor` — `runsc` subprocess for stronger `tools/shell` isolation
+  under Linux.
+- `firecracker` — Per-snippet microVM for hosted multi-tenant deployments.
+
+The full-Go (`GOOS=wasip1`) compile path with auto-bootstrapped Go SDK is
+tracked in [#71](https://github.com/frankbardon/nexus/issues/71) and ships
+only on real demand for full Go stdlib semantics (generics, full
+`reflect`, `text/template`).

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/samber/lo v1.49.1 // indirect
+	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/tkrajina/go-reflector v0.5.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
+github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
 github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/traefik/yaegi v0.16.1 h1:f1De3DVJqIDKmnasUF6MwmWv1dSEEat0wcpXhD2On3E=

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -95,6 +95,10 @@ import (
 	stopwordsgate "github.com/frankbardon/nexus/plugins/gates/stop_words"
 	tokenbudgetgate "github.com/frankbardon/nexus/plugins/gates/token_budget"
 	toolfiltergate "github.com/frankbardon/nexus/plugins/gates/tool_filter"
+
+	// Sandbox backends. Side-effect imports register the factories with
+	// pkg/engine/sandbox so configs can opt into stricter isolation tiers.
+	_ "github.com/frankbardon/nexus/pkg/engine/sandbox/wasm"
 )
 
 // RegisterAll registers every built-in plugin factory with the given registry.

--- a/pkg/engine/lifecycle.go
+++ b/pkg/engine/lifecycle.go
@@ -9,6 +9,12 @@ import (
 	"sync"
 
 	"github.com/frankbardon/nexus/pkg/engine/journal"
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+
+	// Side-effect import: registers the default host sandbox factory so
+	// resolveSandbox can construct the baseline backend even when no plugin
+	// explicitly opts into a stricter tier.
+	_ "github.com/frankbardon/nexus/pkg/engine/sandbox/host"
 )
 
 // PluginBaseID extracts the base plugin ID from a potentially instanced ID.
@@ -155,6 +161,11 @@ func (lm *LifecycleManager) Boot(ctx context.Context) error {
 			pluginCfg = make(map[string]any)
 		}
 
+		sb, err := lm.resolveSandbox(configuredID, pluginCfg)
+		if err != nil {
+			return fmt.Errorf("plugin %q sandbox resolve failed: %w", configuredID, err)
+		}
+
 		pctx := PluginContext{
 			Config:       pluginCfg,
 			Bus:          lm.bus,
@@ -170,6 +181,7 @@ func (lm *LifecycleManager) Boot(ctx context.Context) error {
 			InstanceID:   instanceIDs[configuredID],
 			Replay:       lm.replay,
 			Journal:      lm.journal,
+			Sandbox:      sb,
 		}
 
 		lm.logger.Info("initializing plugin", "plugin", configuredID, "version", p.Version())
@@ -270,6 +282,31 @@ func (lm *LifecycleManager) capabilitiesCopy() map[string][]string {
 		out[k] = dup
 	}
 	return out
+}
+
+// resolveSandbox builds the per-plugin sandbox.Sandbox. Plugins with a
+// `sandbox:` config block use the named backend; plugins without one fall
+// back to a default host backend, which honors no command-allowlist and is
+// effectively the legacy "exec freely" behavior. Strict-mode boot: an
+// unknown backend name returns an error so the engine never silently
+// downgrades to host.
+func (lm *LifecycleManager) resolveSandbox(pluginID string, pluginCfg map[string]any) (sandbox.Sandbox, error) {
+	name, block := sandbox.FromPluginConfig(pluginCfg, sandbox.BackendHost)
+	if block == nil {
+		// No `sandbox:` block — use a baseline host backend so callers can
+		// still rely on ctx.Sandbox being non-nil. Empty config = no
+		// allowed-commands restriction (preserves prior behavior).
+		sb, err := sandbox.New(sandbox.BackendHost, nil)
+		if err != nil {
+			return nil, fmt.Errorf("default host sandbox for %q: %w", pluginID, err)
+		}
+		return sb, nil
+	}
+	sb, err := sandbox.New(name, block)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox %q for %q: %w", name, pluginID, err)
+	}
+	return sb, nil
 }
 
 // expandRequirements walks Requires() transitively on every plugin already in

--- a/pkg/engine/plugin.go
+++ b/pkg/engine/plugin.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/frankbardon/nexus/pkg/engine/journal"
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
 )
 
 // Plugin is the interface that all Nexus plugins must implement.
@@ -141,6 +142,13 @@ type PluginContext struct {
 	// register via Journal.SubscribeProjection so their derived files are
 	// driven by durable envelopes instead of live dispatch.
 	Journal *journal.Writer
+
+	// Sandbox is the per-plugin execution sandbox. Resolved at boot from
+	// the plugin's `sandbox:` config block; falls back to a default host
+	// backend when no block is supplied. Tools that shell out or evaluate
+	// code call Sandbox.Exec rather than reaching for os/exec or an
+	// in-process interpreter directly. Always non-nil during Init.
+	Sandbox sandbox.Sandbox
 }
 
 // LateShutdown is an optional marker interface. A plugin that implements it

--- a/pkg/engine/sandbox/host/host.go
+++ b/pkg/engine/sandbox/host/host.go
@@ -1,0 +1,204 @@
+// Package host is the trivially-isolated sandbox backend: shell commands run
+// directly via os/exec against the host kernel. Useful as the fallback for
+// `tools/shell` until a stricter backend (gVisor / Firecracker / landlock)
+// lands. Honors `allowed_commands`, `working_dir`, `path_dirs`, and the
+// legacy env-restriction flag.
+package host
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+)
+
+func init() {
+	sandbox.Register(sandbox.BackendHost, New)
+}
+
+// Backend implements sandbox.Sandbox for the host process.
+type Backend struct {
+	allowedCommands []string
+	workingDir      string
+	pathDirs        []string
+	defaultTimeout  time.Duration
+	envRestrict     bool
+}
+
+// New builds a Backend from the per-plugin sandbox config block.
+//
+// Recognised keys (all optional):
+//
+//	allowed_commands: ["git", "npm"]   — empty/absent = unrestricted
+//	working_dir: "~/.nexus/work"        — passed through ExpandPath at the
+//	                                       caller; this layer takes the
+//	                                       string verbatim.
+//	path_dirs: ["/opt/bin"]             — prepended to PATH at exec time.
+//	timeout: "30s"                      — default per-Exec deadline.
+//	env_restrict: true                  — clear env to a minimal allowlist.
+func New(cfg map[string]any) (sandbox.Sandbox, error) {
+	b := &Backend{defaultTimeout: 30 * time.Second}
+
+	if raw, ok := cfg["allowed_commands"].([]any); ok {
+		for _, v := range raw {
+			if s, ok := v.(string); ok && s != "" {
+				b.allowedCommands = append(b.allowedCommands, s)
+			}
+		}
+	}
+	if s, ok := cfg["working_dir"].(string); ok {
+		b.workingDir = s
+	}
+	if raw, ok := cfg["path_dirs"].([]any); ok {
+		for _, v := range raw {
+			if s, ok := v.(string); ok && s != "" {
+				b.pathDirs = append(b.pathDirs, s)
+			}
+		}
+	}
+	if s, ok := cfg["timeout"].(string); ok && s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("host sandbox: invalid timeout %q: %w", s, err)
+		}
+		b.defaultTimeout = d
+	}
+	if v, ok := cfg["env_restrict"].(bool); ok {
+		b.envRestrict = v
+	}
+	return b, nil
+}
+
+// Capabilities reports what the host backend can enforce.
+func (b *Backend) Capabilities() sandbox.CapabilitySet {
+	return sandbox.CapabilitySet{
+		Kinds:       []sandbox.Kind{sandbox.KindShell},
+		NetGated:    false,
+		FSGated:     false,
+		ProcessGate: false,
+	}
+}
+
+// Close is a no-op for the host backend.
+func (b *Backend) Close() error { return nil }
+
+// Exec dispatches the request. v1 supports KindShell only.
+func (b *Backend) Exec(ctx context.Context, req sandbox.ExecRequest) (sandbox.ExecResult, error) {
+	switch req.Kind {
+	case sandbox.KindShell:
+		return b.execShell(ctx, req)
+	default:
+		return sandbox.ExecResult{}, fmt.Errorf("%w: %s", sandbox.ErrKindUnsupported, req.Kind)
+	}
+}
+
+func (b *Backend) execShell(ctx context.Context, req sandbox.ExecRequest) (sandbox.ExecResult, error) {
+	command := strings.TrimRight(string(req.Source), "\n")
+	if command == "" {
+		return sandbox.ExecResult{}, errors.New("host sandbox: empty shell command")
+	}
+	if !b.commandAllowed(command) {
+		return sandbox.ExecResult{
+			Exit:   126,
+			Stderr: fmt.Appendf(nil, "command not allowed: %s\n", command),
+		}, nil
+	}
+
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = b.defaultTimeout
+	}
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, "sh", "-c", command)
+
+	if req.WorkDir != "" {
+		cmd.Dir = req.WorkDir
+	} else if b.workingDir != "" {
+		cmd.Dir = b.workingDir
+	}
+
+	if b.envRestrict {
+		cmd.Env = []string{
+			"PATH=/usr/bin:/bin",
+			"HOME=/tmp",
+			"LANG=en_US.UTF-8",
+		}
+	}
+	if len(b.pathDirs) > 0 {
+		if cmd.Env == nil {
+			cmd.Env = cmd.Environ()
+		}
+		extra := strings.Join(b.pathDirs, ":")
+		cmd.Env = applyPathPrefix(cmd.Env, extra)
+	}
+	if len(req.Env) > 0 {
+		if cmd.Env == nil {
+			cmd.Env = cmd.Environ()
+		}
+		for k, v := range req.Env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
+	if len(req.Stdin) > 0 {
+		cmd.Stdin = bytes.NewReader(req.Stdin)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	started := time.Now()
+	runErr := cmd.Run()
+	elapsed := time.Since(started)
+
+	res := sandbox.ExecResult{
+		Stdout: stdout.Bytes(),
+		Stderr: stderr.Bytes(),
+		Usage:  sandbox.UsageStats{Wall: elapsed, OutputSize: int64(stdout.Len() + stderr.Len())},
+	}
+	if cmd.ProcessState != nil {
+		res.Exit = cmd.ProcessState.ExitCode()
+	}
+	if cmdCtx.Err() == context.DeadlineExceeded {
+		res.TimedOut = true
+		return res, nil
+	}
+	if runErr != nil {
+		// Non-zero exit lands here without ctx error; keep res, propagate
+		// nothing — the caller distinguishes via Exit.
+		var exitErr *exec.ExitError
+		if !errors.As(runErr, &exitErr) {
+			return res, fmt.Errorf("host sandbox: exec failed: %w", runErr)
+		}
+	}
+	return res, nil
+}
+
+func (b *Backend) commandAllowed(command string) bool {
+	if len(b.allowedCommands) == 0 {
+		return true
+	}
+	parts := strings.Fields(command)
+	if len(parts) == 0 {
+		return false
+	}
+	return slices.Contains(b.allowedCommands, parts[0])
+}
+
+func applyPathPrefix(env []string, extra string) []string {
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + extra + ":" + e[len("PATH="):]
+			return env
+		}
+	}
+	return append(env, "PATH="+extra)
+}

--- a/pkg/engine/sandbox/host/host_test.go
+++ b/pkg/engine/sandbox/host/host_test.go
@@ -1,0 +1,129 @@
+package host_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+	_ "github.com/frankbardon/nexus/pkg/engine/sandbox/host"
+)
+
+func TestShellEcho(t *testing.T) {
+	sb, err := sandbox.New(sandbox.BackendHost, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sb.Close()
+
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindShell,
+		Source: []byte("echo hello"),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if got := strings.TrimSpace(string(res.Stdout)); got != "hello" {
+		t.Fatalf("stdout: got %q, want hello", got)
+	}
+	if res.Exit != 0 {
+		t.Fatalf("exit: got %d", res.Exit)
+	}
+}
+
+func TestShellAllowedCommands(t *testing.T) {
+	sb, err := sandbox.New(sandbox.BackendHost, map[string]any{
+		"allowed_commands": []any{"echo"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sb.Close()
+
+	t.Run("allowed", func(t *testing.T) {
+		res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+			Kind:   sandbox.KindShell,
+			Source: []byte("echo ok"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Exit != 0 || !strings.Contains(string(res.Stdout), "ok") {
+			t.Fatalf("expected ok exit + stdout, got exit=%d stdout=%q", res.Exit, res.Stdout)
+		}
+	})
+
+	t.Run("denied", func(t *testing.T) {
+		res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+			Kind:   sandbox.KindShell,
+			Source: []byte("rm -rf /"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Exit != 126 {
+			t.Fatalf("expected denied exit=126, got %d", res.Exit)
+		}
+		if !strings.Contains(string(res.Stderr), "command not allowed") {
+			t.Fatalf("expected denial message, got %q", res.Stderr)
+		}
+	})
+}
+
+func TestShellTimeout(t *testing.T) {
+	sb, err := sandbox.New(sandbox.BackendHost, map[string]any{
+		"timeout": "100ms",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sb.Close()
+
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindShell,
+		Source: []byte("sleep 5"),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !res.TimedOut {
+		t.Fatalf("expected TimedOut=true, got %+v", res)
+	}
+}
+
+func TestShellEnvRestrict(t *testing.T) {
+	sb, err := sandbox.New(sandbox.BackendHost, map[string]any{
+		"env_restrict": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sb.Close()
+
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindShell,
+		Source: []byte("echo $HOME"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(res.Stdout)); got != "/tmp" {
+		t.Fatalf("env-restricted HOME: got %q, want /tmp", got)
+	}
+}
+
+func TestUnsupportedKind(t *testing.T) {
+	sb, err := sandbox.New(sandbox.BackendHost, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sb.Close()
+
+	_, err = sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindGoWasm,
+		Source: []byte("anything"),
+	})
+	if err == nil {
+		t.Fatal("expected ErrKindUnsupported, got nil")
+	}
+}

--- a/pkg/engine/sandbox/registry.go
+++ b/pkg/engine/sandbox/registry.go
@@ -1,0 +1,80 @@
+package sandbox
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+)
+
+// Factory builds a sandbox from a config map. The map is the contents of the
+// per-plugin `sandbox:` YAML block, with all keys other than `backend`
+// passed through to the factory.
+type Factory func(cfg map[string]any) (Sandbox, error)
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[Backend]Factory{}
+)
+
+// Register installs a factory for the named backend. Calling Register twice
+// for the same name overwrites the prior entry (use cases: tests, alternate
+// implementations gated by build tag).
+func Register(name Backend, factory Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[name] = factory
+}
+
+// New resolves the configured backend name and invokes its factory. Returns
+// ErrUnknownBackend when the name is not registered.
+func New(name Backend, cfg map[string]any) (Sandbox, error) {
+	if name == "" {
+		return nil, ErrBackendNotConfigured
+	}
+	registryMu.RLock()
+	factory, ok := registry[name]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownBackend, name)
+	}
+	return factory(cfg)
+}
+
+// Registered returns the sorted list of currently-registered backend names.
+// Useful for diagnostics and error messages that list the legal alternatives.
+func Registered() []Backend {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	names := make([]Backend, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// FromPluginConfig extracts the sandbox config block from a plugin config
+// map and returns the resolved backend name plus the inner config. When the
+// plugin has no `sandbox:` block, the second return is nil and the first is
+// the supplied fallback.
+//
+// Resolution rule: a plugin's `sandbox.backend` wins; otherwise fallback;
+// otherwise empty (boot fails downstream with ErrBackendNotConfigured).
+func FromPluginConfig(pluginCfg map[string]any, fallback Backend) (Backend, map[string]any) {
+	if pluginCfg == nil {
+		return fallback, nil
+	}
+	raw, ok := pluginCfg["sandbox"]
+	if !ok {
+		return fallback, nil
+	}
+	block, ok := raw.(map[string]any)
+	if !ok {
+		return fallback, nil
+	}
+	name := fallback
+	if s, ok := block["backend"].(string); ok && s != "" {
+		name = Backend(s)
+	}
+	return name, block
+}

--- a/pkg/engine/sandbox/sandbox.go
+++ b/pkg/engine/sandbox/sandbox.go
@@ -75,6 +75,11 @@ type ExecRequest struct {
 	Net      NetPolicy
 	Timeout  time.Duration
 
+	// AllowedPackages narrows the stdlib whitelist visible to a Go-source
+	// payload (KindGoYaegi / KindGoWasm). Backends apply it as an override
+	// on top of any backend-level default. Ignored for KindShell.
+	AllowedPackages []string
+
 	// Backend lets a per-call override pick a non-default backend for the
 	// same plugin. Empty means "use the configured default".
 	Backend Backend

--- a/pkg/engine/sandbox/sandbox.go
+++ b/pkg/engine/sandbox/sandbox.go
@@ -1,0 +1,146 @@
+// Package sandbox is the engine-wide execution-isolation abstraction.
+// Backends — host, wasm, and future tiers like gVisor or Firecracker —
+// implement Sandbox and are selected per-plugin via config.
+//
+// Tools that shell out (`tools/shell`) or execute agent-emitted code
+// (`tools/codeexec`) call the sandbox they receive via PluginContext rather
+// than reaching directly for `os/exec` or an in-process interpreter. This
+// keeps the kernel surface a single audited boundary and lets the same plugin
+// run unchanged under any installed isolation tier.
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Backend is the registered name of a sandbox implementation. The engine
+// resolves the configured name to a factory at boot.
+type Backend string
+
+const (
+	BackendHost Backend = "host"
+	BackendWasm Backend = "wasm"
+)
+
+// Kind selects the execution shape inside the request. Backends accept a
+// subset of kinds; mismatches return ErrKindUnsupported at Exec time.
+type Kind string
+
+const (
+	// KindShell runs a shell command line against the host kernel via the
+	// configured shell. Honored by the host backend; rejected by wasm.
+	KindShell Kind = "shell"
+
+	// KindGoYaegi evaluates Go source through Yaegi inside the host process.
+	// Honored by the host backend.
+	KindGoYaegi Kind = "go_yaegi"
+
+	// KindGoWasm evaluates Go source through an embedded Yaegi-on-Wasm
+	// runner. Honored by the wasm backend.
+	KindGoWasm Kind = "go_wasm"
+)
+
+// NetPolicy describes how the sandbox should treat network egress for a call.
+// Backends that do not gate network return ErrCapabilityNotSupported when
+// asked to enforce a non-default policy.
+type NetPolicy struct {
+	// Mode is one of "deny" (default), "allow_hosts", or "allow_all".
+	Mode string
+	// AllowHosts is the exact-match hostname allowlist consulted when Mode
+	// is "allow_hosts". Empty under any other mode.
+	AllowHosts []string
+}
+
+// Mount declares a host→guest filesystem binding visible to the executed
+// payload. Mode is "ro" (read-only) or "rw".
+type Mount struct {
+	Host  string
+	Guest string
+	Mode  string
+}
+
+// ExecRequest is the input to Sandbox.Exec. Source carries the payload —
+// shell command for KindShell, Go source for KindGoYaegi/KindGoWasm.
+type ExecRequest struct {
+	Kind     Kind
+	Source   []byte
+	Args     []string
+	Stdin    []byte
+	Env      map[string]string
+	WorkDir  string
+	Mounts   []Mount
+	Net      NetPolicy
+	Timeout  time.Duration
+
+	// Backend lets a per-call override pick a non-default backend for the
+	// same plugin. Empty means "use the configured default".
+	Backend Backend
+}
+
+// ExecResult is the output of Sandbox.Exec. Stdout and Stderr are captured
+// in full up to the backend's configured cap; over-cap output sets
+// Truncated.
+type ExecResult struct {
+	Stdout    []byte
+	Stderr    []byte
+	Exit      int
+	TimedOut  bool
+	Truncated bool
+	Usage     UsageStats
+}
+
+// UsageStats reports observable resource consumption for a single Exec.
+// Backends fill the fields they can measure; zero is "unknown".
+type UsageStats struct {
+	Wall       time.Duration
+	CPUUser    time.Duration
+	CPUSystem  time.Duration
+	MaxRSSMiB  int64
+	OutputSize int64
+}
+
+// CapabilitySet describes what a backend can enforce. Used at boot to
+// validate that the configuration's expectations match the backend's reach
+// (e.g., a config that requests `net.policy: allow_hosts` against a backend
+// whose CapabilitySet returns NetGated=false fails Init loudly).
+type CapabilitySet struct {
+	Kinds       []Kind
+	NetGated    bool
+	FSGated     bool
+	ProcessGate bool
+}
+
+// Sandbox is the interface every backend implements.
+type Sandbox interface {
+	// Exec runs req synchronously and returns the captured result. Returning
+	// a non-nil error means the sandbox itself failed (timeout, missing
+	// dependency, capability denied); a non-zero ExecResult.Exit means the
+	// payload itself exited non-zero, which is not an error.
+	Exec(ctx context.Context, req ExecRequest) (ExecResult, error)
+
+	// Capabilities reports the set the backend can enforce for the lifetime
+	// of this Sandbox instance.
+	Capabilities() CapabilitySet
+
+	// Close releases any resources (subprocess pools, wazero runtimes, etc.).
+	Close() error
+}
+
+// Errors returned by sandbox implementations.
+var (
+	ErrKindUnsupported         = errors.New("sandbox: kind not supported by backend")
+	ErrCapabilityNotSupported  = errors.New("sandbox: capability not supported by backend")
+	ErrCapabilityDenied        = errors.New("sandbox: capability denied")
+	ErrTimeout                 = errors.New("sandbox: execution timed out")
+	ErrBackendNotConfigured    = errors.New("sandbox: backend not configured")
+	ErrUnknownBackend          = errors.New("sandbox: unknown backend")
+	ErrMissingDependency       = errors.New("sandbox: backend dependency missing")
+)
+
+// Wrap returns a sandbox-prefixed error wrapping cause for context.
+func Wrap(action string, cause error) error {
+	return fmt.Errorf("sandbox: %s: %w", action, cause)
+}

--- a/pkg/engine/sandbox/sandbox_test.go
+++ b/pkg/engine/sandbox/sandbox_test.go
@@ -1,0 +1,49 @@
+package sandbox_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+	_ "github.com/frankbardon/nexus/pkg/engine/sandbox/host"
+)
+
+func TestRegistryHasHost(t *testing.T) {
+	got := sandbox.Registered()
+	if !slices.Contains(got, sandbox.BackendHost) {
+		t.Fatalf("expected %q registered, got %v", sandbox.BackendHost, got)
+	}
+}
+
+func TestNewUnknownBackendErrors(t *testing.T) {
+	_, err := sandbox.New("does-not-exist", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+}
+
+func TestFromPluginConfigFallback(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    map[string]any
+		want   sandbox.Backend
+		hasMap bool
+	}{
+		{"nil cfg", nil, sandbox.BackendHost, false},
+		{"no sandbox key", map[string]any{"foo": 1}, sandbox.BackendHost, false},
+		{"non-map sandbox", map[string]any{"sandbox": true}, sandbox.BackendHost, false},
+		{"map without backend", map[string]any{"sandbox": map[string]any{"timeout": "10s"}}, sandbox.BackendHost, true},
+		{"explicit backend", map[string]any{"sandbox": map[string]any{"backend": "wasm"}}, sandbox.BackendWasm, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, block := sandbox.FromPluginConfig(tc.cfg, sandbox.BackendHost)
+			if name != tc.want {
+				t.Fatalf("backend: got %q, want %q", name, tc.want)
+			}
+			if (block != nil) != tc.hasMap {
+				t.Fatalf("block presence mismatch: got %v, want hasMap=%v", block, tc.hasMap)
+			}
+		})
+	}
+}

--- a/pkg/engine/sandbox/wasm/bridge_test.go
+++ b/pkg/engine/sandbox/wasm/bridge_test.go
@@ -1,0 +1,209 @@
+package wasm_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+	_ "github.com/frankbardon/nexus/pkg/engine/sandbox/wasm"
+)
+
+const httpScript = `package main
+
+import (
+	"context"
+	"fmt"
+	nhttp "nexus_sdk/http"
+)
+
+func Run(ctx context.Context) (any, error) {
+	resp, err := nhttp.Get("__URL__")
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("status=%d body=%s\n", resp.Status, string(resp.Body))
+	return resp.Status, nil
+}
+`
+
+const httpDeniedScript = `package main
+
+import (
+	"context"
+	nhttp "nexus_sdk/http"
+)
+
+func Run(ctx context.Context) (any, error) {
+	_, err := nhttp.Get("https://blocked.example/x")
+	if err != nil {
+		if nhttp.IsCapDenied(err) {
+			return "denied", nil
+		}
+		return nil, err
+	}
+	return "ok", nil
+}
+`
+
+const fsScript = `package main
+
+import (
+	"context"
+	"fmt"
+	nfs "nexus_sdk/fs"
+)
+
+func Run(ctx context.Context) (any, error) {
+	data, err := nfs.ReadFile("/work/hello.txt")
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("read=%s\n", string(data))
+	return len(data), nil
+}
+`
+
+const envScript = `package main
+
+import (
+	"context"
+	"fmt"
+	nenv "nexus_sdk/env"
+)
+
+func Run(ctx context.Context) (any, error) {
+	v := nenv.Get("FOO")
+	fmt.Println("FOO=" + v)
+	return v, nil
+}
+`
+
+func TestBridgeHTTPGetAllowed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test", "yes")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("hello-from-host"))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+
+	cfg := map[string]any{
+		"allowed_packages": []any{"context", "fmt"},
+		"net": map[string]any{
+			"allow_hosts": []any{host},
+		},
+	}
+	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sb.Close() })
+
+	src := strings.ReplaceAll(httpScript, "__URL__", srv.URL)
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindGoWasm,
+		Source: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	out := string(res.Stdout)
+	if !strings.Contains(out, "status=200") {
+		t.Fatalf("expected status=200, got %q", out)
+	}
+	if !strings.Contains(out, "hello-from-host") {
+		t.Fatalf("expected body, got %q", out)
+	}
+}
+
+func TestBridgeHTTPGetDenied(t *testing.T) {
+	cfg := map[string]any{
+		"allowed_packages": []any{"context"},
+		// No net.allow_hosts → deny all.
+	}
+	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sb.Close() })
+
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindGoWasm,
+		Source: []byte(httpDeniedScript),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !strings.Contains(string(res.Stdout), "denied") {
+		t.Fatalf("expected 'denied' in stdout, got %q stderr=%q", res.Stdout, res.Stderr)
+	}
+}
+
+func TestBridgeFSReadInsideMount(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "hello.txt")
+	if err := writeFile(target, "fs-hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := map[string]any{
+		"allowed_packages": []any{"context", "fmt"},
+		"fs_mounts": []any{
+			map[string]any{"host": dir, "guest": "/work", "mode": "ro"},
+		},
+	}
+	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sb.Close() })
+
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindGoWasm,
+		Source: []byte(fsScript),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !strings.Contains(string(res.Stdout), "read=fs-hello") {
+		t.Fatalf("expected fs read, got stdout=%q stderr=%q", res.Stdout, res.Stderr)
+	}
+}
+
+func TestBridgeEnvGet(t *testing.T) {
+	cfg := map[string]any{
+		"allowed_packages": []any{"context", "fmt"},
+		"env": map[string]any{
+			"FOO": "bar",
+		},
+	}
+	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sb.Close() })
+
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindGoWasm,
+		Source: []byte(envScript),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !strings.Contains(string(res.Stdout), "FOO=bar") {
+		t.Fatalf("expected FOO=bar, got %q", res.Stdout)
+	}
+}
+
+func writeFile(path, data string) error {
+	return os.WriteFile(path, []byte(data), 0o644)
+}

--- a/pkg/engine/sandbox/wasm/capbuf.go
+++ b/pkg/engine/sandbox/wasm/capbuf.go
@@ -1,0 +1,36 @@
+package wasm
+
+// capBuf is a stdout/stderr capture buffer that drops bytes past a configured
+// cap and reports the overflow. Writers see a successful Write either way.
+type capBuf struct {
+	cap       int
+	buf       []byte
+	truncated bool
+}
+
+func newCapBuf(cap int) *capBuf {
+	return &capBuf{cap: cap, buf: make([]byte, 0, 1024)}
+}
+
+func (b *capBuf) Write(p []byte) (int, error) {
+	n := len(p)
+	if b.cap <= 0 {
+		b.buf = append(b.buf, p...)
+		return n, nil
+	}
+	remaining := b.cap - len(b.buf)
+	if remaining <= 0 {
+		b.truncated = true
+		return n, nil
+	}
+	if len(p) > remaining {
+		b.buf = append(b.buf, p[:remaining]...)
+		b.truncated = true
+		return n, nil
+	}
+	b.buf = append(b.buf, p...)
+	return n, nil
+}
+
+func (b *capBuf) Bytes() []byte { return b.buf }
+func (b *capBuf) Len() int      { return len(b.buf) }

--- a/pkg/engine/sandbox/wasm/embed.go
+++ b/pkg/engine/sandbox/wasm/embed.go
@@ -1,0 +1,34 @@
+package wasm
+
+import (
+	"bytes"
+	"compress/gzip"
+	_ "embed"
+	"fmt"
+	"io"
+)
+
+// runnerWasmGz is the gzip-compressed bytes of cmd/yaegi-runner built for
+// GOOS=wasip1 GOARCH=wasm. Refresh via `make build-yaegi-wasm`. CI verifies
+// reproducibility against a pinned Go toolchain.
+//
+//go:embed yaegi.wasm.gz
+var runnerWasmGz []byte
+
+// runnerBytes decompresses the embedded runner artefact. Cheap (~50 ms one
+// shot); called once per WasmBackend.
+func runnerBytes() ([]byte, error) {
+	if len(runnerWasmGz) == 0 {
+		return nil, fmt.Errorf("wasm: embedded yaegi runner is empty (run `make build-yaegi-wasm`)")
+	}
+	gr, err := gzip.NewReader(bytes.NewReader(runnerWasmGz))
+	if err != nil {
+		return nil, fmt.Errorf("wasm: gunzip runner: %w", err)
+	}
+	defer gr.Close()
+	out, err := io.ReadAll(gr)
+	if err != nil {
+		return nil, fmt.Errorf("wasm: read runner: %w", err)
+	}
+	return out, nil
+}

--- a/pkg/engine/sandbox/wasm/host/bridge.go
+++ b/pkg/engine/sandbox/wasm/host/bridge.go
@@ -1,0 +1,257 @@
+// Package host implements the wasm host module that backs the nexus_sdk/*
+// snippet API. A single dispatch function (`invoke`) takes an opcode + JSON
+// request blob from the snippet, runs the gated operation, writes a JSON
+// response back into the snippet's scratch buffer, and returns a packed
+// (status<<32 | length) result. Capability gates fire here, before any real
+// I/O hits the host kernel.
+package host
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+)
+
+// HostModuleName is the wazero host module name imported by the runner via
+// //go:wasmimport directives. Bumping the suffix cuts old runners off; v1
+// runners must speak v1 host functions.
+const HostModuleName = "nexus_bridge_v1"
+
+// statusCode values mirror those returned to the snippet via the high bits
+// of the bridge return value.
+const (
+	StatusOK            uint16 = 0
+	StatusInvalidOp     uint16 = 1
+	StatusBadRequest    uint16 = 2
+	StatusCapDenied     uint16 = 3
+	StatusInternal      uint16 = 4
+	StatusBufferTooSmall uint16 = 5
+)
+
+// Bridge holds the gated dependencies the host function needs to satisfy
+// snippet calls. One per WasmBackend.
+type Bridge struct {
+	policy Policy
+	caps   Capabilities
+}
+
+// Policy carries the configured-at-init permissions for a sandbox session.
+type Policy struct {
+	NetAllowHosts []string
+	FSMounts      []FSMount
+	ExecAllowed   []string
+	EnvVars       map[string]string
+}
+
+// FSMount maps a host directory tree onto a guest path with rw or ro
+// access. Symlink-following is disabled host-side for safety; see the fs op.
+type FSMount struct {
+	Host  string
+	Guest string
+	Mode  string // "ro" or "rw"
+}
+
+// Capabilities is the runtime adapter the host function uses to perform
+// gated I/O. Injected so tests can fake HTTP / fs / exec without standing
+// up real kernels.
+type Capabilities interface {
+	HTTPGet(ctx context.Context, url string) (status int, body []byte, headers map[string][]string, err error)
+	FSReadFile(ctx context.Context, guestPath string) ([]byte, error)
+	FSWriteFile(ctx context.Context, guestPath string, data []byte) error
+	ExecRun(ctx context.Context, name string, args []string) (stdout, stderr []byte, exit int, err error)
+}
+
+// NewBridge constructs a Bridge with the given policy and capabilities
+// adapter. Capabilities may be nil — operations that require it will return
+// StatusInvalidOp.
+func NewBridge(policy Policy, caps Capabilities) *Bridge {
+	return &Bridge{policy: policy, caps: caps}
+}
+
+// Register installs the bridge host functions on the supplied wazero
+// runtime. Call once per Runtime; reuse across many module instantiations.
+func (b *Bridge) Register(ctx context.Context, rt wazero.Runtime) error {
+	mod := rt.NewHostModuleBuilder(HostModuleName)
+	mod.NewFunctionBuilder().
+		WithFunc(b.invoke).
+		Export("invoke")
+	if _, err := mod.Instantiate(ctx); err != nil {
+		return fmt.Errorf("host bridge: register: %w", err)
+	}
+	return nil
+}
+
+// invoke is the single bridge function exported to wasm. Signature:
+//
+//	invoke(opPtr i32, opLen i32, reqPtr i32, reqLen i32,
+//	       scratchPtr i32, scratchLen i32) -> i64
+//
+// where the i64 return packs (status uint16 << 48) | (length uint32). A
+// non-zero status maps to a snippet-side error; status 0 means the response
+// JSON is in scratch[0:length].
+func (b *Bridge) invoke(
+	ctx context.Context,
+	mod api.Module,
+	opPtr, opLen, reqPtr, reqLen, scratchPtr, scratchLen uint32,
+) uint64 {
+	mem := mod.Memory()
+	op, ok := mem.Read(opPtr, opLen)
+	if !ok {
+		return pack(StatusBadRequest, 0)
+	}
+	req, ok := mem.Read(reqPtr, reqLen)
+	if !ok {
+		return pack(StatusBadRequest, 0)
+	}
+
+	respBytes, status := b.dispatch(ctx, string(op), req)
+	if status != StatusOK {
+		// Treat respBytes as a UTF-8 error message when status != OK.
+		return writeOrPack(mem, scratchPtr, scratchLen, respBytes, status)
+	}
+	return writeOrPack(mem, scratchPtr, scratchLen, respBytes, StatusOK)
+}
+
+func writeOrPack(mem api.Memory, scratchPtr, scratchLen uint32, body []byte, status uint16) uint64 {
+	if uint32(len(body)) > scratchLen {
+		// Tell the snippet how much space it would have needed. Snippet
+		// retries with a bigger buffer.
+		return pack(StatusBufferTooSmall, uint32(len(body)))
+	}
+	if !mem.Write(scratchPtr, body) {
+		return pack(StatusInternal, 0)
+	}
+	return pack(status, uint32(len(body)))
+}
+
+func pack(status uint16, length uint32) uint64 {
+	return (uint64(status) << 48) | uint64(length)
+}
+
+// dispatch routes the opcode to its handler. Returns response bytes (JSON
+// for OK, plain UTF-8 for non-OK) and the status code.
+func (b *Bridge) dispatch(ctx context.Context, op string, req []byte) ([]byte, uint16) {
+	switch op {
+	case "http.get":
+		return b.handleHTTPGet(ctx, req)
+	case "fs.read":
+		return b.handleFSRead(ctx, req)
+	case "fs.write":
+		return b.handleFSWrite(ctx, req)
+	case "exec.run":
+		return b.handleExecRun(ctx, req)
+	case "env.get":
+		return b.handleEnvGet(req)
+	default:
+		return []byte("unknown op: " + op), StatusInvalidOp
+	}
+}
+
+// -- handlers ---------------------------------------------------------------
+
+func (b *Bridge) handleHTTPGet(ctx context.Context, req []byte) ([]byte, uint16) {
+	var r struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(req, &r); err != nil {
+		return []byte("parse: " + err.Error()), StatusBadRequest
+	}
+	if !b.netHostAllowed(r.URL) {
+		return []byte("net.allow_hosts denied: " + r.URL), StatusCapDenied
+	}
+	if b.caps == nil {
+		return []byte("http capability not configured"), StatusInternal
+	}
+	status, body, headers, err := b.caps.HTTPGet(ctx, r.URL)
+	if err != nil {
+		return []byte("http: " + err.Error()), StatusInternal
+	}
+	out, _ := json.Marshal(map[string]any{
+		"status":  status,
+		"body":    body,
+		"headers": headers,
+	})
+	return out, StatusOK
+}
+
+func (b *Bridge) handleFSRead(ctx context.Context, req []byte) ([]byte, uint16) {
+	var r struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(req, &r); err != nil {
+		return []byte("parse: " + err.Error()), StatusBadRequest
+	}
+	if !b.fsReadAllowed(r.Path) {
+		return []byte("fs.mounts denied: " + r.Path), StatusCapDenied
+	}
+	if b.caps == nil {
+		return []byte("fs capability not configured"), StatusInternal
+	}
+	data, err := b.caps.FSReadFile(ctx, r.Path)
+	if err != nil {
+		return []byte("fs: " + err.Error()), StatusInternal
+	}
+	out, _ := json.Marshal(map[string]any{"data": data})
+	return out, StatusOK
+}
+
+func (b *Bridge) handleFSWrite(ctx context.Context, req []byte) ([]byte, uint16) {
+	var r struct {
+		Path string `json:"path"`
+		Data []byte `json:"data"`
+	}
+	if err := json.Unmarshal(req, &r); err != nil {
+		return []byte("parse: " + err.Error()), StatusBadRequest
+	}
+	if !b.fsWriteAllowed(r.Path) {
+		return []byte("fs.mounts denied (read-only or unmounted): " + r.Path), StatusCapDenied
+	}
+	if b.caps == nil {
+		return []byte("fs capability not configured"), StatusInternal
+	}
+	if err := b.caps.FSWriteFile(ctx, r.Path, r.Data); err != nil {
+		return []byte("fs: " + err.Error()), StatusInternal
+	}
+	return []byte("{}"), StatusOK
+}
+
+func (b *Bridge) handleExecRun(ctx context.Context, req []byte) ([]byte, uint16) {
+	var r struct {
+		Name string   `json:"name"`
+		Args []string `json:"args"`
+	}
+	if err := json.Unmarshal(req, &r); err != nil {
+		return []byte("parse: " + err.Error()), StatusBadRequest
+	}
+	if !b.execAllowed(r.Name) {
+		return []byte("exec.allowed denied: " + r.Name), StatusCapDenied
+	}
+	if b.caps == nil {
+		return []byte("exec capability not configured"), StatusInternal
+	}
+	stdout, stderr, exit, err := b.caps.ExecRun(ctx, r.Name, r.Args)
+	if err != nil {
+		return []byte("exec: " + err.Error()), StatusInternal
+	}
+	out, _ := json.Marshal(map[string]any{
+		"stdout": stdout,
+		"stderr": stderr,
+		"exit":   exit,
+	})
+	return out, StatusOK
+}
+
+func (b *Bridge) handleEnvGet(req []byte) ([]byte, uint16) {
+	var r struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(req, &r); err != nil {
+		return []byte("parse: " + err.Error()), StatusBadRequest
+	}
+	val := b.policy.EnvVars[r.Key]
+	out, _ := json.Marshal(map[string]any{"value": val})
+	return out, StatusOK
+}

--- a/pkg/engine/sandbox/wasm/host/caps.go
+++ b/pkg/engine/sandbox/wasm/host/caps.go
@@ -1,0 +1,107 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// DefaultCaps is the production capabilities adapter. Performs real network
+// fetches (with a finite timeout + body cap), real filesystem reads/writes
+// scoped to the configured mounts, and real subprocess invocation.
+type DefaultCaps struct {
+	Mounts          []FSMount
+	HTTPClient      *http.Client
+	HTTPMaxBodyMiB  int
+	ExecTimeout     time.Duration
+}
+
+// NewDefaultCaps returns a DefaultCaps with sensible defaults: 30 s HTTP
+// client timeout, 16 MiB max body, 30 s exec timeout.
+func NewDefaultCaps(mounts []FSMount) *DefaultCaps {
+	return &DefaultCaps{
+		Mounts:         mounts,
+		HTTPClient:     &http.Client{Timeout: 30 * time.Second},
+		HTTPMaxBodyMiB: 16,
+		ExecTimeout:    30 * time.Second,
+	}
+}
+
+// HTTPGet performs the real HTTP GET. Caller already passed the policy gate.
+func (c *DefaultCaps) HTTPGet(ctx context.Context, url string) (int, []byte, map[string][]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer resp.Body.Close()
+	maxBytes := int64(c.HTTPMaxBodyMiB) * 1024 * 1024
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return resp.StatusCode, nil, resp.Header, err
+	}
+	if int64(len(body)) > maxBytes {
+		return resp.StatusCode, nil, resp.Header, fmt.Errorf("response exceeds %d MiB cap", c.HTTPMaxBodyMiB)
+	}
+	return resp.StatusCode, body, resp.Header, nil
+}
+
+// FSReadFile resolves guestPath against configured mounts and reads.
+// Symlink-following is suppressed — Lstat first, refuse to dereference any
+// symlink whose target leaves the mount tree.
+func (c *DefaultCaps) FSReadFile(_ context.Context, guestPath string) ([]byte, error) {
+	hostBase, rel := MountForGuest(c.Mounts, guestPath)
+	if hostBase == "" {
+		return nil, fmt.Errorf("path not under any mount: %s", guestPath)
+	}
+	abs := filepath.Join(hostBase, rel)
+	info, err := os.Lstat(abs)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("symlink follow refused: %s", abs)
+	}
+	return os.ReadFile(abs)
+}
+
+// FSWriteFile writes data to a guest path. Caller has already passed the
+// rw-mount gate; this layer just resolves and writes with 0644 perm.
+func (c *DefaultCaps) FSWriteFile(_ context.Context, guestPath string, data []byte) error {
+	hostBase, rel := MountForGuest(c.Mounts, guestPath)
+	if hostBase == "" {
+		return fmt.Errorf("path not under any mount: %s", guestPath)
+	}
+	abs := filepath.Join(hostBase, rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(abs, data, 0o644)
+}
+
+// ExecRun runs name with args under the host kernel. Wrapped in a hard
+// per-call timeout independent of any context the caller passes.
+func (c *DefaultCaps) ExecRun(ctx context.Context, name string, args []string) ([]byte, []byte, int, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, c.ExecTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, name, args...)
+	stdoutBuf, err := cmd.Output()
+	exitCode := 0
+	var stderrBuf []byte
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+		stderrBuf = exitErr.Stderr
+		err = nil
+	} else if err != nil {
+		return nil, nil, 0, err
+	}
+	return stdoutBuf, stderrBuf, exitCode, nil
+}

--- a/pkg/engine/sandbox/wasm/host/policy.go
+++ b/pkg/engine/sandbox/wasm/host/policy.go
@@ -1,0 +1,82 @@
+package host
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// netHostAllowed enforces the configured allow_hosts list. Empty list means
+// "deny all" — explicit allowlisting only.
+func (b *Bridge) netHostAllowed(rawURL string) bool {
+	if len(b.policy.NetAllowHosts) == 0 {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	host := u.Hostname()
+	for _, allowed := range b.policy.NetAllowHosts {
+		if host == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// fsReadAllowed reports whether guestPath falls under any configured mount.
+// Read access is granted by any mount; write requires Mode == "rw".
+func (b *Bridge) fsReadAllowed(guestPath string) bool {
+	clean := filepath.Clean(guestPath)
+	for _, m := range b.policy.FSMounts {
+		guest := filepath.Clean(m.Guest)
+		if clean == guest || strings.HasPrefix(clean, guest+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// fsWriteAllowed reports whether guestPath falls under a writable mount.
+func (b *Bridge) fsWriteAllowed(guestPath string) bool {
+	clean := filepath.Clean(guestPath)
+	for _, m := range b.policy.FSMounts {
+		guest := filepath.Clean(m.Guest)
+		if clean == guest || strings.HasPrefix(clean, guest+string(filepath.Separator)) {
+			if m.Mode == "rw" {
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
+// execAllowed reports whether name is in the allowed-commands list.
+func (b *Bridge) execAllowed(name string) bool {
+	for _, allowed := range b.policy.ExecAllowed {
+		if name == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// MountForGuest returns the host-side directory backing a guest path along
+// with the relative offset of guestPath within that mount, or "" / "" if no
+// mount covers it. Used by the default capabilities adapter to translate a
+// guest path into a real host filesystem path.
+func MountForGuest(mounts []FSMount, guestPath string) (host, rel string) {
+	clean := filepath.Clean(guestPath)
+	for _, m := range mounts {
+		guest := filepath.Clean(m.Guest)
+		if clean == guest {
+			return filepath.Clean(m.Host), ""
+		}
+		if strings.HasPrefix(clean, guest+string(filepath.Separator)) {
+			return filepath.Clean(m.Host), strings.TrimPrefix(clean, guest+string(filepath.Separator))
+		}
+	}
+	return "", ""
+}

--- a/pkg/engine/sandbox/wasm/host/policy.go
+++ b/pkg/engine/sandbox/wasm/host/policy.go
@@ -44,10 +44,7 @@ func (b *Bridge) fsWriteAllowed(guestPath string) bool {
 	for _, m := range b.policy.FSMounts {
 		guest := filepath.Clean(m.Guest)
 		if clean == guest || strings.HasPrefix(clean, guest+string(filepath.Separator)) {
-			if m.Mode == "rw" {
-				return true
-			}
-			return false
+			return m.Mode == "rw"
 		}
 	}
 	return false

--- a/pkg/engine/sandbox/wasm/policy.go
+++ b/pkg/engine/sandbox/wasm/policy.go
@@ -1,0 +1,76 @@
+package wasm
+
+import (
+	"fmt"
+
+	"github.com/frankbardon/nexus/pkg/engine/sandbox/wasm/host"
+)
+
+// parsePolicy lifts the network, fs_mounts, exec_allowed, and env config
+// blocks into a host.Policy used by the bridge gates. Empty config means
+// "deny all" — bridge calls will fail with capability denial unless the
+// caller opts in explicitly.
+func parsePolicy(cfg map[string]any) (host.Policy, error) {
+	var p host.Policy
+
+	if rawNet, ok := cfg["net"].(map[string]any); ok {
+		if hosts, ok := rawNet["allow_hosts"].([]any); ok {
+			for _, h := range hosts {
+				if s, ok := h.(string); ok && s != "" {
+					p.NetAllowHosts = append(p.NetAllowHosts, s)
+				}
+			}
+		}
+	}
+
+	if rawMounts, ok := cfg["fs_mounts"].([]any); ok {
+		for _, m := range rawMounts {
+			block, ok := m.(map[string]any)
+			if !ok {
+				continue
+			}
+			mount := host.FSMount{
+				Mode: "ro",
+			}
+			if s, ok := block["host"].(string); ok {
+				expanded, err := expandHome(s)
+				if err != nil {
+					return host.Policy{}, fmt.Errorf("fs_mounts host %q: %w", s, err)
+				}
+				mount.Host = expanded
+			}
+			if s, ok := block["guest"].(string); ok {
+				mount.Guest = s
+			}
+			if s, ok := block["mode"].(string); ok && s != "" {
+				if s != "ro" && s != "rw" {
+					return host.Policy{}, fmt.Errorf("fs_mounts mode %q: want ro or rw", s)
+				}
+				mount.Mode = s
+			}
+			if mount.Host == "" || mount.Guest == "" {
+				return host.Policy{}, fmt.Errorf("fs_mounts entry needs both host and guest")
+			}
+			p.FSMounts = append(p.FSMounts, mount)
+		}
+	}
+
+	if raw, ok := cfg["exec_allowed"].([]any); ok {
+		for _, e := range raw {
+			if s, ok := e.(string); ok && s != "" {
+				p.ExecAllowed = append(p.ExecAllowed, s)
+			}
+		}
+	}
+
+	if raw, ok := cfg["env"].(map[string]any); ok {
+		p.EnvVars = make(map[string]string, len(raw))
+		for k, v := range raw {
+			if s, ok := v.(string); ok {
+				p.EnvVars[k] = s
+			}
+		}
+	}
+
+	return p, nil
+}

--- a/pkg/engine/sandbox/wasm/wasm.go
+++ b/pkg/engine/sandbox/wasm/wasm.go
@@ -1,0 +1,270 @@
+// Package wasm is the wazero-backed sandbox for agent-generated Go snippets.
+// Boots an embedded Yaegi runner compiled for GOOS=wasip1; the host instantiates
+// a fresh module per call and feeds the snippet source through stdin. Result
+// envelope arrives on stdout after a sentinel that separates it from any
+// user-emitted output.
+package wasm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tetratelabs/wazero"
+	wasi "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/sys"
+
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+)
+
+// expandHome resolves a leading ~ to the user's home dir. Mirrors
+// engine.ExpandPath but is reimplemented here to keep the sandbox/wasm
+// package free of `pkg/engine` import cycles.
+func expandHome(p string) (string, error) {
+	if p == "" {
+		return p, nil
+	}
+	if !strings.HasPrefix(p, "~") {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	rest := strings.TrimPrefix(p, "~")
+	rest = strings.TrimPrefix(rest, string(filepath.Separator))
+	return filepath.Join(home, rest), nil
+}
+
+const (
+	resultSentinel = "\n---NEXUS-RUNNER-RESULT-V1---\n"
+	defaultTimeout = 30 * time.Second
+	defaultMaxOut  = 64 * 1024
+)
+
+func init() {
+	sandbox.Register(sandbox.BackendWasm, newBackend)
+}
+
+// Backend implements sandbox.Sandbox by routing Go snippets through an
+// embedded Yaegi-on-Wasm runner. Holds one wazero.Runtime + compiled module
+// for the life of the backend; per-Exec instantiates a fresh wasm module so
+// snippets cannot share state.
+type Backend struct {
+	runtime  wazero.Runtime
+	compiled wazero.CompiledModule
+
+	allowedPackages []string
+	timeout         time.Duration
+	maxOutputBytes  int
+
+	closed sync.Once
+}
+
+func newBackend(cfg map[string]any) (sandbox.Sandbox, error) {
+	bytesWasm, err := runnerBytes()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", sandbox.ErrMissingDependency, err)
+	}
+
+	ctx := context.Background()
+	rtCfg := wazero.NewRuntimeConfig()
+	if dir, ok := cfg["cache_dir"].(string); ok && dir != "" {
+		expanded, expErr := expandHome(dir)
+		if expErr != nil {
+			return nil, fmt.Errorf("wasm sandbox: cache_dir: %w", expErr)
+		}
+		cache, cErr := wazero.NewCompilationCacheWithDir(expanded)
+		if cErr != nil {
+			return nil, fmt.Errorf("wasm sandbox: open compilation cache %q: %w", expanded, cErr)
+		}
+		rtCfg = rtCfg.WithCompilationCache(cache)
+	}
+	rt := wazero.NewRuntimeWithConfig(ctx, rtCfg)
+	if _, err := wasi.Instantiate(ctx, rt); err != nil {
+		_ = rt.Close(ctx)
+		return nil, fmt.Errorf("wasm: install wasi: %w", err)
+	}
+
+	compiled, err := rt.CompileModule(ctx, bytesWasm)
+	if err != nil {
+		_ = rt.Close(ctx)
+		return nil, fmt.Errorf("wasm: compile runner: %w", err)
+	}
+
+	b := &Backend{
+		runtime:        rt,
+		compiled:       compiled,
+		timeout:        defaultTimeout,
+		maxOutputBytes: defaultMaxOut,
+	}
+
+	if raw, ok := cfg["allowed_packages"].([]any); ok {
+		for _, e := range raw {
+			if s, ok := e.(string); ok && s != "" {
+				b.allowedPackages = append(b.allowedPackages, s)
+			}
+		}
+	}
+	if s, ok := cfg["timeout"].(string); ok && s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			_ = rt.Close(ctx)
+			return nil, fmt.Errorf("wasm sandbox: invalid timeout %q: %w", s, err)
+		}
+		b.timeout = d
+	}
+	if v, ok := intLike(cfg["max_output_bytes"]); ok && v > 0 {
+		b.maxOutputBytes = v
+	}
+
+	return b, nil
+}
+
+// Capabilities reports the wasm backend's enforcement reach.
+func (b *Backend) Capabilities() sandbox.CapabilitySet {
+	return sandbox.CapabilitySet{
+		Kinds:       []sandbox.Kind{sandbox.KindGoWasm},
+		NetGated:    true,
+		FSGated:     true,
+		ProcessGate: true,
+	}
+}
+
+// Close releases the wazero runtime + compiled module.
+func (b *Backend) Close() error {
+	var err error
+	b.closed.Do(func() {
+		ctx := context.Background()
+		if b.compiled != nil {
+			_ = b.compiled.Close(ctx)
+		}
+		if b.runtime != nil {
+			err = b.runtime.Close(ctx)
+		}
+	})
+	return err
+}
+
+// Exec runs the snippet inside a fresh wasm instance.
+func (b *Backend) Exec(ctx context.Context, req sandbox.ExecRequest) (sandbox.ExecResult, error) {
+	if req.Kind != sandbox.KindGoWasm {
+		return sandbox.ExecResult{}, fmt.Errorf("%w: %s", sandbox.ErrKindUnsupported, req.Kind)
+	}
+	if len(req.Source) == 0 {
+		return sandbox.ExecResult{}, errors.New("wasm sandbox: empty source")
+	}
+
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = b.timeout
+	}
+	allowed := b.allowedPackages
+
+	reqJSON, err := json.Marshal(map[string]any{
+		"source":           string(req.Source),
+		"allowed_packages": allowed,
+		"timeout_seconds":  int(timeout.Seconds()),
+	})
+	if err != nil {
+		return sandbox.ExecResult{}, fmt.Errorf("wasm sandbox: marshal request: %w", err)
+	}
+
+	stdoutBuf := newCapBuf(b.maxOutputBytes)
+	stderrBuf := newCapBuf(b.maxOutputBytes)
+	moduleCfg := wazero.NewModuleConfig().
+		WithStdin(bytes.NewReader(reqJSON)).
+		WithStdout(stdoutBuf).
+		WithStderr(stderrBuf).
+		WithName("")
+
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	started := time.Now()
+	_, runErr := b.runtime.InstantiateModule(cmdCtx, b.compiled, moduleCfg)
+	elapsed := time.Since(started)
+
+	res := sandbox.ExecResult{
+		Truncated: stdoutBuf.truncated || stderrBuf.truncated,
+		Usage:     sandbox.UsageStats{Wall: elapsed, OutputSize: int64(stdoutBuf.Len() + stderrBuf.Len())},
+	}
+
+	if cmdCtx.Err() == context.DeadlineExceeded {
+		res.TimedOut = true
+		res.Stdout = stdoutBuf.Bytes()
+		res.Stderr = stderrBuf.Bytes()
+		return res, nil
+	}
+
+	stdoutAll := stdoutBuf.Bytes()
+	idx := bytes.LastIndex(stdoutAll, []byte(resultSentinel))
+	if idx < 0 {
+		// No envelope written. Use exit code as the diagnostic.
+		res.Stdout = stdoutAll
+		res.Stderr = stderrBuf.Bytes()
+		var exitErr *sys.ExitError
+		if errors.As(runErr, &exitErr) {
+			res.Exit = int(exitErr.ExitCode())
+			return res, nil
+		}
+		if runErr != nil {
+			return res, fmt.Errorf("wasm sandbox: runner: %w", runErr)
+		}
+		return res, fmt.Errorf("wasm sandbox: runner produced no result envelope")
+	}
+
+	userStdout := stdoutAll[:idx]
+	envelope := stdoutAll[idx+len(resultSentinel):]
+	res.Stdout = bytes.TrimRight(userStdout, "\n")
+	res.Stderr = stderrBuf.Bytes()
+
+	var resp struct {
+		Result string `json:"result,omitempty"`
+		Error  string `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(envelope), &resp); err != nil {
+		return res, fmt.Errorf("wasm sandbox: parse envelope: %w", err)
+	}
+
+	var exitErr *sys.ExitError
+	if errors.As(runErr, &exitErr) {
+		res.Exit = int(exitErr.ExitCode())
+	}
+	if resp.Error != "" {
+		// Surface the runner's own error in stderr so callers see it as
+		// part of the diagnostic stream, alongside any wasm-side stderr.
+		if len(res.Stderr) > 0 && res.Stderr[len(res.Stderr)-1] != '\n' {
+			res.Stderr = append(res.Stderr, '\n')
+		}
+		res.Stderr = append(res.Stderr, []byte(resp.Error)...)
+	}
+	if resp.Result != "" {
+		// Append the result text to user stdout so callers that just want a
+		// value from `Run` see it without parsing the envelope themselves.
+		if len(res.Stdout) > 0 && res.Stdout[len(res.Stdout)-1] != '\n' {
+			res.Stdout = append(res.Stdout, '\n')
+		}
+		res.Stdout = append(res.Stdout, []byte(resp.Result)...)
+	}
+	return res, nil
+}
+
+func intLike(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	}
+	return 0, false
+}

--- a/pkg/engine/sandbox/wasm/wasm.go
+++ b/pkg/engine/sandbox/wasm/wasm.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tetratelabs/wazero/sys"
 
 	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+	"github.com/frankbardon/nexus/pkg/engine/sandbox/wasm/host"
 )
 
 // expandHome resolves a leading ~ to the user's home dir. Mirrors
@@ -60,6 +61,7 @@ func init() {
 type Backend struct {
 	runtime  wazero.Runtime
 	compiled wazero.CompiledModule
+	bridge   *host.Bridge
 
 	allowedPackages []string
 	timeout         time.Duration
@@ -93,6 +95,17 @@ func newBackend(cfg map[string]any) (sandbox.Sandbox, error) {
 		return nil, fmt.Errorf("wasm: install wasi: %w", err)
 	}
 
+	policy, err := parsePolicy(cfg)
+	if err != nil {
+		_ = rt.Close(ctx)
+		return nil, err
+	}
+	bridge := host.NewBridge(policy, host.NewDefaultCaps(policy.FSMounts))
+	if err := bridge.Register(ctx, rt); err != nil {
+		_ = rt.Close(ctx)
+		return nil, fmt.Errorf("wasm: register bridge: %w", err)
+	}
+
 	compiled, err := rt.CompileModule(ctx, bytesWasm)
 	if err != nil {
 		_ = rt.Close(ctx)
@@ -102,6 +115,7 @@ func newBackend(cfg map[string]any) (sandbox.Sandbox, error) {
 	b := &Backend{
 		runtime:        rt,
 		compiled:       compiled,
+		bridge:         bridge,
 		timeout:        defaultTimeout,
 		maxOutputBytes: defaultMaxOut,
 	}

--- a/pkg/engine/sandbox/wasm/wasm.go
+++ b/pkg/engine/sandbox/wasm/wasm.go
@@ -180,7 +180,10 @@ func (b *Backend) Exec(ctx context.Context, req sandbox.ExecRequest) (sandbox.Ex
 	if timeout <= 0 {
 		timeout = b.timeout
 	}
-	allowed := b.allowedPackages
+	allowed := req.AllowedPackages
+	if len(allowed) == 0 {
+		allowed = b.allowedPackages
+	}
 
 	reqJSON, err := json.Marshal(map[string]any{
 		"source":           string(req.Source),

--- a/pkg/engine/sandbox/wasm/wasm_test.go
+++ b/pkg/engine/sandbox/wasm/wasm_test.go
@@ -1,0 +1,215 @@
+package wasm_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+	_ "github.com/frankbardon/nexus/pkg/engine/sandbox/wasm"
+)
+
+// sharedBackends caches wasm sandboxes by config-key so tests don't pay the
+// ~5–9 s wazero AOT compile cost more than once per distinct config. The
+// real engine only creates one backend per plugin per session, so this
+// mirrors production reuse rather than gaming the test.
+var (
+	sharedMu       sync.Mutex
+	sharedBackends = map[string]sandbox.Sandbox{}
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	sharedMu.Lock()
+	for _, sb := range sharedBackends {
+		_ = sb.Close()
+	}
+	sharedMu.Unlock()
+	os.Exit(code)
+}
+
+// helloScript prints to stdout and returns a string. Exercises both the
+// user-output channel and the result envelope.
+const helloScript = `package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func Run(ctx context.Context) (any, error) {
+	fmt.Println("hi from wasm")
+	return "ok", nil
+}
+`
+
+const computeScript = `package main
+
+import "context"
+
+func Run(ctx context.Context) (any, error) {
+	sum := 0
+	for i := 1; i <= 10; i++ {
+		sum += i
+	}
+	return sum, nil
+}
+`
+
+const errorScript = `package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func Run(ctx context.Context) (any, error) {
+	return nil, fmt.Errorf("boom")
+}
+`
+
+func newWasm(t *testing.T, cfg map[string]any) sandbox.Sandbox {
+	t.Helper()
+	if cfg == nil {
+		cfg = map[string]any{
+			"allowed_packages": []any{"fmt", "strings", "context"},
+		}
+	}
+	key := mapKey(cfg)
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+	if sb, ok := sharedBackends[key]; ok {
+		return sb
+	}
+	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	if err != nil {
+		t.Fatalf("new wasm: %v", err)
+	}
+	sharedBackends[key] = sb
+	return sb
+}
+
+func mapKey(cfg map[string]any) string {
+	var b strings.Builder
+	for k, v := range cfg {
+		b.WriteString(k)
+		b.WriteByte('=')
+		switch x := v.(type) {
+		case []any:
+			for _, e := range x {
+				b.WriteString(toString(e))
+				b.WriteByte(',')
+			}
+		default:
+			b.WriteString(toString(v))
+		}
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
+func toString(v any) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	default:
+		return ""
+	}
+}
+
+func TestWasmHello(t *testing.T) {
+	sb := newWasm(t, nil)
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindGoWasm,
+		Source: []byte(helloScript),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	out := string(res.Stdout)
+	if !strings.Contains(out, "hi from wasm") {
+		t.Fatalf("missing user output, got %q", out)
+	}
+	if !strings.Contains(out, "ok") {
+		t.Fatalf("missing result, got %q", out)
+	}
+}
+
+func TestWasmCompute(t *testing.T) {
+	sb := newWasm(t, nil)
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindGoWasm,
+		Source: []byte(computeScript),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !strings.Contains(string(res.Stdout), "55") {
+		t.Fatalf("expected 55 in stdout, got %q", res.Stdout)
+	}
+}
+
+func TestWasmError(t *testing.T) {
+	sb := newWasm(t, nil)
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindGoWasm,
+		Source: []byte(errorScript),
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !strings.Contains(string(res.Stderr), "boom") {
+		t.Fatalf("expected error 'boom' in stderr, got %q", res.Stderr)
+	}
+}
+
+func TestWasmTimeout(t *testing.T) {
+	sb := newWasm(t, map[string]any{
+		"allowed_packages": []any{"fmt", "strings", "context", "time"},
+	})
+	src := `package main
+import (
+	"context"
+	"time"
+)
+func Run(ctx context.Context) (any, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(50*time.Millisecond):
+		}
+	}
+}
+`
+	start := time.Now()
+	res, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:    sandbox.KindGoWasm,
+		Source:  []byte(src),
+		Timeout: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	elapsed := time.Since(start)
+	if !res.TimedOut && !strings.Contains(string(res.Stderr), "context") {
+		t.Fatalf("expected timeout signal, got TimedOut=%v stderr=%q", res.TimedOut, res.Stderr)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("timeout ineffective: %s elapsed", elapsed)
+	}
+}
+
+func TestWasmRejectsKindShell(t *testing.T) {
+	sb := newWasm(t, nil)
+	_, err := sb.Exec(context.Background(), sandbox.ExecRequest{
+		Kind:   sandbox.KindShell,
+		Source: []byte("echo hi"),
+	})
+	if err == nil {
+		t.Fatal("expected ErrKindUnsupported")
+	}
+}

--- a/pkg/events/skill.go
+++ b/pkg/events/skill.go
@@ -28,6 +28,11 @@ type SkillContent struct {
 	Resources []string
 	Scope     string
 	BaseDir   string
+	// Runtime selects the codeexec runtime for this skill's helpers.
+	// Empty defaults to "yaegi" at the consumer for backwards compatibility;
+	// "wasm" routes the skill's run_code through ctx.Sandbox when codeexec
+	// is configured with compiler: yaegi-wasm.
+	Runtime string
 }
 
 // SkillRef is a lightweight reference to a skill by name.

--- a/plugins/skills/parser.go
+++ b/plugins/skills/parser.go
@@ -23,6 +23,7 @@ type SkillRecord struct {
 	Class            string            `yaml:"class"`              // Semantic class for progressive discovery.
 	Subclass         string            `yaml:"subclass"`           // Optional grouping within class.
 	Tags             []string          `yaml:"tags"`               // Cross-cutting metadata for filtering.
+	Runtime          string            `yaml:"runtime"`            // "yaegi" (default) or "wasm" — selects the codeexec runtime for skill helpers.
 	Body             string            `yaml:"-"`
 	Scope            string            `yaml:"-"` // "project", "user", "builtin", "config"
 	Trusted          bool              `yaml:"-"`
@@ -66,6 +67,12 @@ func ParseSkillFile(path string) (*SkillRecord, error) {
 	}
 	if record.Description == "" {
 		return nil, fmt.Errorf("skill file %s missing required field: description", path)
+	}
+	switch record.Runtime {
+	case "", "yaegi", "wasm":
+		// "" defaults at the consumer; "yaegi" and "wasm" are the legal values.
+	default:
+		return nil, fmt.Errorf("skill file %s: invalid runtime %q (want \"yaegi\" or \"wasm\")", path, record.Runtime)
 	}
 
 	return record, nil

--- a/plugins/skills/parser_test.go
+++ b/plugins/skills/parser_test.go
@@ -1,0 +1,76 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSkill(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseRuntimeDefault(t *testing.T) {
+	path := writeSkill(t, t.TempDir(), `---
+name: alpha
+description: a skill
+---
+body`)
+	rec, err := ParseSkillFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Runtime != "" {
+		t.Fatalf("expected empty Runtime by default, got %q", rec.Runtime)
+	}
+}
+
+func TestParseRuntimeYaegi(t *testing.T) {
+	path := writeSkill(t, t.TempDir(), `---
+name: alpha
+description: a skill
+runtime: yaegi
+---
+body`)
+	rec, err := ParseSkillFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Runtime != "yaegi" {
+		t.Fatalf("got %q, want yaegi", rec.Runtime)
+	}
+}
+
+func TestParseRuntimeWasm(t *testing.T) {
+	path := writeSkill(t, t.TempDir(), `---
+name: alpha
+description: a skill
+runtime: wasm
+---
+body`)
+	rec, err := ParseSkillFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Runtime != "wasm" {
+		t.Fatalf("got %q, want wasm", rec.Runtime)
+	}
+}
+
+func TestParseRuntimeInvalid(t *testing.T) {
+	path := writeSkill(t, t.TempDir(), `---
+name: alpha
+description: a skill
+runtime: bogus
+---
+body`)
+	_, err := ParseSkillFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid runtime")
+	}
+}

--- a/plugins/skills/plugin.go
+++ b/plugins/skills/plugin.go
@@ -363,6 +363,7 @@ func (p *Plugin) handleActivate(e engine.Event[any]) {
 		Body:      contentXML,
 		Scope:     record.Scope,
 		BaseDir:   record.BaseDir,
+		Runtime:   record.Runtime,
 		Resources: func() []string { r, _ := ListResources(record.BaseDir); return r }(),
 	})
 

--- a/plugins/tools/codeexec/plugin.go
+++ b/plugins/tools/codeexec/plugin.go
@@ -19,7 +19,21 @@ import (
 	"github.com/traefik/yaegi/interp"
 
 	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
 	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// compilerKind selects the runtime that executes agent-emitted snippets.
+type compilerKind string
+
+const (
+	// compilerYaegiHost runs Yaegi in-process. Fast, full dynamic bindings
+	// (`tools.*`, `parallel.*`, skill helpers), no kernel isolation.
+	compilerYaegiHost compilerKind = "yaegi-host"
+	// compilerYaegiWasm routes the snippet through ctx.Sandbox to an
+	// embedded Yaegi-on-Wasm runner. Capability-gated, no `tools.*` or
+	// skill helpers in v1; bridge SDK (`nexus_sdk/*`) follows in Phase 3.
+	compilerYaegiWasm compilerKind = "yaegi-wasm"
 )
 
 const (
@@ -43,10 +57,12 @@ type Plugin struct {
 	session *engine.SessionWorkspace
 	prompts *engine.PromptRegistry
 	replay  *engine.ReplayState
+	sandbox sandbox.Sandbox
 
 	liveCalls atomic.Uint64
 
 	// Config.
+	compiler         compilerKind
 	timeout          time.Duration
 	maxOutputBytes   int
 	maxWorkers       int      // concurrency ceiling for parallel.* primitives
@@ -74,6 +90,7 @@ type Plugin struct {
 // New creates a new codeexec plugin.
 func New() engine.Plugin {
 	return &Plugin{
+		compiler:         compilerYaegiHost,
 		timeout:          defaultTimeout,
 		maxOutputBytes:   defaultMaxOutputBytes,
 		maxWorkers:       runtime.NumCPU(),
@@ -98,6 +115,30 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.session = ctx.Session
 	p.prompts = ctx.Prompts
 	p.replay = ctx.Replay
+	p.sandbox = ctx.Sandbox
+
+	if s, ok := ctx.Config["compiler"].(string); ok && s != "" {
+		switch compilerKind(s) {
+		case compilerYaegiHost, compilerYaegiWasm:
+			p.compiler = compilerKind(s)
+		default:
+			return fmt.Errorf("code_exec: invalid compiler %q (want %q or %q)",
+				s, compilerYaegiHost, compilerYaegiWasm)
+		}
+	}
+	if p.compiler == compilerYaegiWasm {
+		caps := p.sandbox.Capabilities()
+		hasWasm := false
+		for _, k := range caps.Kinds {
+			if k == sandbox.KindGoWasm {
+				hasWasm = true
+				break
+			}
+		}
+		if !hasWasm {
+			return fmt.Errorf("code_exec: compiler=yaegi-wasm requires a sandbox backend that supports KindGoWasm; configure plugin.sandbox.backend: wasm")
+		}
+	}
 
 	if v, ok := ctx.Config["timeout_seconds"].(int); ok && v > 0 {
 		p.timeout = time.Duration(v) * time.Second
@@ -395,6 +436,11 @@ func (p *Plugin) runScript(tc events.ToolCall) {
 		Imports: analysis.Imports,
 		Skills:  activeSkills,
 	})
+
+	if p.compiler == compilerYaegiWasm {
+		p.runScriptWasm(tc, script)
+		return
+	}
 
 	stdout := newStreamingWriter(p.bus, tc.ID, tc.TurnID, p.maxOutputBytes)
 	// finish closes the stdout stream (flushing a Final chunk) and then emits

--- a/plugins/tools/codeexec/plugin.go
+++ b/plugins/tools/codeexec/plugin.go
@@ -375,6 +375,16 @@ func (p *Plugin) handleSkillLoaded(e engine.Event[any]) {
 	if !ok {
 		return
 	}
+	// Skill helpers are Yaegi-bound. They have no representation under the
+	// wasm compiler (the bridge SDK doesn't surface them in v1), so when the
+	// agent path runs through wasm we skip helper loading entirely. Skill
+	// content (the markdown body) still reaches the agent the same way; only
+	// the in-script `import "skills/<name>"` binding is unavailable.
+	if p.compiler == compilerYaegiWasm {
+		p.logger.Info("skipping skill helper load under compiler=yaegi-wasm",
+			"skill", sc.Name, "skill_runtime", sc.Runtime)
+		return
+	}
 	helpers, err := loadSkillHelpers(sc.Name, sc.BaseDir)
 	if err != nil {
 		p.logger.Warn("skill helper load failed", "skill", sc.Name, "error", err)

--- a/plugins/tools/codeexec/wasm.go
+++ b/plugins/tools/codeexec/wasm.go
@@ -1,0 +1,44 @@
+package codeexec
+
+import (
+	"context"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// runScriptWasm dispatches a run_code invocation through ctx.Sandbox to the
+// Wasm backend. v1 capability surface inside Wasm is intentionally narrow:
+// no `tools.*`, no `parallel.*`, no skill helpers — only the configured
+// stdlib whitelist. The bridge SDK (`nexus_sdk/{http,fs,exec,env,tools}`)
+// arrives in Phase 3 and reopens those affordances.
+func (p *Plugin) runScriptWasm(tc events.ToolCall, script string) {
+	started := time.Now()
+
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+
+	res, err := p.sandbox.Exec(ctx, sandbox.ExecRequest{
+		Kind:    sandbox.KindGoWasm,
+		Source:  []byte(script),
+		Timeout: p.timeout,
+	})
+	durationMs := time.Since(started).Milliseconds()
+	if err != nil {
+		p.emitResult(tc, "", "", "wasm sandbox: "+err.Error(), durationMs, false)
+		return
+	}
+
+	stdout := string(res.Stdout)
+	stderr := string(res.Stderr)
+	if res.TimedOut {
+		p.emitResult(tc, stdout, "", "script timed out after "+p.timeout.String(), durationMs, res.Truncated)
+		return
+	}
+	if stderr != "" {
+		p.emitResult(tc, stdout, "", stderr, durationMs, res.Truncated)
+		return
+	}
+	p.emitResult(tc, stdout, "", "", durationMs, res.Truncated)
+}

--- a/plugins/tools/codeexec/wasm.go
+++ b/plugins/tools/codeexec/wasm.go
@@ -20,9 +20,10 @@ func (p *Plugin) runScriptWasm(tc events.ToolCall, script string) {
 	defer cancel()
 
 	res, err := p.sandbox.Exec(ctx, sandbox.ExecRequest{
-		Kind:    sandbox.KindGoWasm,
-		Source:  []byte(script),
-		Timeout: p.timeout,
+		Kind:            sandbox.KindGoWasm,
+		Source:          []byte(script),
+		AllowedPackages: p.allowedPackages,
+		Timeout:         p.timeout,
 	})
 	durationMs := time.Since(started).Milliseconds()
 	if err != nil {

--- a/plugins/tools/shell/plugin.go
+++ b/plugins/tools/shell/plugin.go
@@ -1,16 +1,14 @@
 package shell
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
-	"os/exec"
-	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/sandbox"
 	"github.com/frankbardon/nexus/pkg/events"
 )
 
@@ -26,13 +24,11 @@ type Plugin struct {
 	logger  *slog.Logger
 	session *engine.SessionWorkspace
 	replay  *engine.ReplayState
+	sandbox sandbox.Sandbox
 
-	allowedCommands []string
-	workingDir      string
-	pathDirs        []string // directories prepended to PATH
-	timeout         time.Duration
-	sandbox         bool
-	unsubs          []func()
+	workingDir string
+	timeout    time.Duration
+	unsubs     []func()
 
 	liveCalls atomic.Uint64
 }
@@ -60,34 +56,17 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.logger = ctx.Logger
 	p.session = ctx.Session
 	p.replay = ctx.Replay
+	p.sandbox = ctx.Sandbox
 
-	// Parse allowed commands.
-	if ac, ok := ctx.Config["allowed_commands"].([]any); ok {
-		for _, cmd := range ac {
-			if s, ok := cmd.(string); ok {
-				p.allowedCommands = append(p.allowedCommands, s)
-			}
-		}
-	}
-
-	// Parse working directory. Default to session files dir so shell commands
-	// and the file_io plugin see the same filesystem location.
+	// Working directory. Default to session files dir so shell commands and
+	// the file_io plugin see the same filesystem location.
 	if wd, ok := ctx.Config["working_dir"].(string); ok && wd != "" {
 		p.workingDir = engine.ExpandPath(wd)
 	} else if p.session != nil {
 		p.workingDir = p.session.FilesDir()
 	}
 
-	// Parse extra PATH directories (prepended to PATH for command resolution).
-	if dirs, ok := ctx.Config["path_dirs"].([]any); ok {
-		for _, entry := range dirs {
-			if s, ok := entry.(string); ok && s != "" {
-				p.pathDirs = append(p.pathDirs, engine.ExpandPath(s))
-			}
-		}
-	}
-
-	// Parse timeout.
+	// Per-call default timeout.
 	if ts, ok := ctx.Config["timeout"].(string); ok {
 		d, err := time.ParseDuration(ts)
 		if err != nil {
@@ -96,18 +75,79 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.timeout = d
 	}
 
-	// Parse sandbox mode.
-	if sb, ok := ctx.Config["sandbox"].(bool); ok {
-		p.sandbox = sb
+	// Backwards-compatible legacy config: when the plugin has no `sandbox:`
+	// block but does have any of `allowed_commands`, `path_dirs`, or
+	// `sandbox: <bool>`, synthesise an equivalent host-backend config and
+	// replace the engine-supplied default sandbox. Documented as deprecated;
+	// removal targeted for the milestone after gVisor lands.
+	if needsLegacyShim(ctx.Config) {
+		shim, err := buildLegacyShim(ctx.Config)
+		if err != nil {
+			return err
+		}
+		p.sandbox = shim
 	}
 
-	// Register event handler.
 	p.unsubs = append(p.unsubs,
 		p.bus.Subscribe("tool.invoke", p.handleEvent,
 			engine.WithPriority(50), engine.WithSource(pluginID)),
 	)
 
 	return nil
+}
+
+// needsLegacyShim reports whether the plugin config carries pre-Sandbox keys
+// (`allowed_commands`, `path_dirs`, top-level `sandbox: <bool>`). A new
+// `sandbox:` map block opts back into the structured path even if the legacy
+// keys are also present, since callers that bothered to write the new block
+// are unambiguously asking for it.
+func needsLegacyShim(cfg map[string]any) bool {
+	if cfg == nil {
+		return false
+	}
+	if _, ok := cfg["sandbox"].(map[string]any); ok {
+		return false
+	}
+	if _, ok := cfg["allowed_commands"]; ok {
+		return true
+	}
+	if _, ok := cfg["path_dirs"]; ok {
+		return true
+	}
+	if _, ok := cfg["sandbox"].(bool); ok {
+		return true
+	}
+	return false
+}
+
+// buildLegacyShim translates the deprecated top-level keys into a host
+// backend so existing configs keep working without the new sandbox block.
+func buildLegacyShim(cfg map[string]any) (sandbox.Sandbox, error) {
+	block := map[string]any{}
+	if v, ok := cfg["allowed_commands"]; ok {
+		block["allowed_commands"] = v
+	}
+	if v, ok := cfg["path_dirs"]; ok {
+		// path_dirs in the legacy shape are pre-expansion strings — pass
+		// through; the host backend doesn't expand, the caller does.
+		raw, ok := v.([]any)
+		if ok {
+			expanded := make([]any, 0, len(raw))
+			for _, entry := range raw {
+				if s, ok := entry.(string); ok {
+					expanded = append(expanded, engine.ExpandPath(s))
+				}
+			}
+			block["path_dirs"] = expanded
+		}
+	}
+	if v, ok := cfg["sandbox"].(bool); ok {
+		block["env_restrict"] = v
+	}
+	if ts, ok := cfg["timeout"].(string); ok {
+		block["timeout"] = ts
+	}
+	return sandbox.New(sandbox.BackendHost, block)
 }
 
 func (p *Plugin) Ready() error {
@@ -189,74 +229,35 @@ func (p *Plugin) handleInvoke(tc events.ToolCall) {
 		return
 	}
 
-	// Log command to session history.
 	if p.session != nil {
 		entry := fmt.Sprintf("%s\n", command)
 		_ = p.session.AppendFile("plugins/"+pluginID+"/history.txt", []byte(entry))
 	}
 
-	// Validate command against allowed list.
-	if !p.isCommandAllowed(command) {
-		p.emitResult(tc, "", fmt.Sprintf("command not allowed: %s", command), nil)
-		return
-	}
-
-	// Execute the command with timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
-
-	if p.workingDir != "" {
-		cmd.Dir = p.workingDir
+	res, err := p.sandbox.Exec(ctx, sandbox.ExecRequest{
+		Kind:    sandbox.KindShell,
+		Source:  []byte(command),
+		WorkDir: p.workingDir,
+		Timeout: p.timeout,
+	})
+	if err != nil {
+		p.emitResult(tc, "", fmt.Sprintf("sandbox: %v", err), nil)
+		return
 	}
 
-	// If sandbox mode, restrict the environment.
-	if p.sandbox {
-		cmd.Env = []string{
-			"PATH=/usr/bin:/bin",
-			"HOME=/tmp",
-			"LANG=en_US.UTF-8",
-		}
-	}
-
-	// Prepend extra directories to PATH.
-	if len(p.pathDirs) > 0 {
-		if cmd.Env == nil {
-			cmd.Env = cmd.Environ()
-		}
-		extra := strings.Join(p.pathDirs, ":")
-		for i, env := range cmd.Env {
-			if strings.HasPrefix(env, "PATH=") {
-				cmd.Env[i] = "PATH=" + extra + ":" + env[5:]
-				break
-			}
-		}
-	}
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-
-	stdoutStr := stdout.String()
-	stderrStr := stderr.String()
-	exitCode := 0
-	if cmd.ProcessState != nil {
-		exitCode = cmd.ProcessState.ExitCode()
-	}
-	timedOut := ctx.Err() == context.DeadlineExceeded
+	stdoutStr := string(res.Stdout)
+	stderrStr := string(res.Stderr)
 
 	structured := map[string]any{
 		"stdout":    stdoutStr,
 		"stderr":    stderrStr,
-		"exit_code": exitCode,
-		"timed_out": timedOut,
+		"exit_code": res.Exit,
+		"timed_out": res.TimedOut,
 	}
 
-	// Keep LLM-facing Output human-readable — concatenate stdout and stderr
-	// the same way we always have.
 	output := stdoutStr
 	if stderrStr != "" {
 		if output != "" {
@@ -265,41 +266,15 @@ func (p *Plugin) handleInvoke(tc events.ToolCall) {
 		output += "STDERR:\n" + stderrStr
 	}
 
-	if err != nil {
-		if timedOut {
-			p.emitResult(tc, output, fmt.Sprintf("command timed out after %s", p.timeout), structured)
-			return
-		}
-		errMsg := err.Error()
-		if output != "" {
-			errMsg = output + "\n" + errMsg
-		}
-		p.emitResult(tc, "", errMsg, structured)
+	if res.TimedOut {
+		p.emitResult(tc, output, fmt.Sprintf("command timed out after %s", p.timeout), structured)
 		return
 	}
-
+	if res.Exit != 0 && stderrStr == "" && stdoutStr == "" {
+		p.emitResult(tc, "", fmt.Sprintf("command exited %d", res.Exit), structured)
+		return
+	}
 	p.emitResult(tc, output, "", structured)
-}
-
-// isCommandAllowed checks if a command is permitted.
-func (p *Plugin) isCommandAllowed(command string) bool {
-	if len(p.allowedCommands) == 0 {
-		return true // no restrictions configured
-	}
-
-	// Extract the base command (first word).
-	parts := strings.Fields(command)
-	if len(parts) == 0 {
-		return false
-	}
-	baseCmd := parts[0]
-
-	for _, allowed := range p.allowedCommands {
-		if baseCmd == allowed {
-			return true
-		}
-	}
-	return false
 }
 
 func (p *Plugin) emitResult(tc events.ToolCall, output, errMsg string, structured map[string]any) {

--- a/tests/integration/sandboxwasm_test.go
+++ b/tests/integration/sandboxwasm_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/testharness"
+)
+
+// TestSandboxWasm_Boot validates the engine boots cleanly with code_exec
+// configured for compiler=yaegi-wasm and sandbox.backend=wasm. Catches
+// regressions in PluginContext.Sandbox plumbing, lifecycle.resolveSandbox,
+// and the wazero runtime initialisation path.
+func TestSandboxWasm_Boot(t *testing.T) {
+	h := testharness.New(t, "configs/test-sandbox-wasm.yaml", testharness.WithTimeout(60*time.Second))
+	h.Run()
+
+	h.AssertBooted(
+		"nexus.tool.code_exec",
+		"nexus.agent.react",
+	)
+	h.AssertEventEmitted("tool.register")
+}
+
+// TestSandboxWasm_PureComputeSnippet validates the full round-trip: the
+// mocked LLM dispatches a run_code tool call; the script executes inside
+// the embedded Yaegi-on-Wasm runner; the result returns to the agent;
+// the final assistant message acknowledges it.
+//
+// Note: ~10–15 s wall on first run because wazero AOT-compiles the 39 MiB
+// embedded runner. Subsequent runs in the same process are fast.
+func TestSandboxWasm_PureComputeSnippet(t *testing.T) {
+	h := testharness.New(t, "configs/test-sandbox-wasm.yaml", testharness.WithTimeout(60*time.Second))
+	h.Run()
+
+	h.AssertToolCalled("run_code")
+	h.AssertEventEmitted("code.exec.request")
+	h.AssertEventEmitted("code.exec.result")
+	h.AssertOutputContains("returned 55")
+}
+
+// TestSandboxWasm_NetDeniedSurfacesAsScriptError pushes a snippet that calls
+// nexus_sdk/http.Get against a host that is not in net.allow_hosts. The
+// bridge gate must reject the call; the snippet's err handling propagates
+// the failure as a code.exec.result with a non-empty error; the agent's
+// next turn (canned) acknowledges. No live network is reached.
+func TestSandboxWasm_NetDeniedSurfacesAsScriptError(t *testing.T) {
+	cfg := copyConfig(t, "configs/test-sandbox-wasm.yaml", map[string]any{
+		"nexus.io.test": map[string]any{
+			"inputs":        []string{"Try to fetch a URL."},
+			"input_delay":   "200ms",
+			"approval_mode": "approve",
+			"timeout":       "60s",
+			"mock_responses": []map[string]any{
+				{
+					"tool_calls": []map[string]any{
+						{
+							"name":      "run_code",
+							"arguments": `{"script":"package main\n\nimport (\n\t\"context\"\n\t\"errors\"\n\t\"fmt\"\n\tnhttp \"nexus_sdk/http\"\n)\n\nfunc Run(ctx context.Context) (any, error) {\n\t_, err := nhttp.Get(\"https://blocked.example/x\")\n\tif err != nil {\n\t\tif errors.Is(err, nhttp.ErrCapDenied) {\n\t\t\tfmt.Println(\"DENIED\")\n\t\t\treturn \"denied\", nil\n\t\t}\n\t\treturn nil, err\n\t}\n\treturn \"unexpected-success\", nil\n}\n"}`,
+						},
+					},
+				},
+				{"content": "Capability denial confirmed."},
+			},
+		},
+		"nexus.tool.code_exec": map[string]any{
+			"compiler":         "yaegi-wasm",
+			"timeout_seconds":  30,
+			"allowed_packages": []string{"fmt", "context", "errors"},
+			"sandbox": map[string]any{
+				"backend": "wasm",
+				"timeout": "30s",
+				// No net.allow_hosts → deny-all default.
+			},
+		},
+	})
+
+	h := testharness.New(t, cfg, testharness.WithTimeout(60*time.Second))
+	h.Run()
+
+	h.AssertToolCalled("run_code")
+	h.AssertEventEmitted("code.exec.result")
+	// The snippet handles ErrCapDenied internally and returns "denied"; the
+	// agent's canned next turn acknowledges. If the bridge gate had failed
+	// open, the snippet's "unexpected-success" branch would have run and
+	// the canned response would never have been triggered cleanly.
+	h.AssertOutputContains("Capability denial confirmed")
+}


### PR DESCRIPTION
Closes #70.

## Summary

Ships the v1 sandboxing layer for Nexus: pluggable backend interface, embedded Yaegi-on-Wasm runner, host bridge SDK with capability gates, and skill runtime selection. Agent-emitted Go snippets routed through `tools/code_exec` with `compiler: yaegi-wasm` now execute inside a wazero-managed Wasm module with no kernel surface unless the configured policy explicitly grants a bridge call. No host Go toolchain dependency — the runner artefact is built once and embedded via `//go:embed`.

## What lands (~13 working days estimated, single PR)

**Phase 1** (`feat(sandbox): pluggable execution backend interface + host backend`)
- `pkg/engine/sandbox/`: Sandbox interface, ExecRequest/ExecResult, Kind, Mount, NetPolicy, CapabilitySet, factory registry, FromPluginConfig helper
- `pkg/engine/sandbox/host`: shell backend with allowed_commands, working_dir, path_dirs, env_restrict, default timeout
- `pkg/engine/PluginContext.Sandbox` + lifecycle resolveSandbox; default host fallback; strict-mode failure on unknown backend names
- `plugins/tools/shell` refactored to call `ctx.Sandbox.Exec`; legacy keys (allowed_commands, path_dirs, sandbox: bool) auto-shimmed

**Phase 2** (`feat(sandbox/wasm): embedded Yaegi-on-Wasm runner backend`)
- `cmd/yaegi-runner`: Yaegi interpreter compiled for `GOOS=wasip1`, reads stdin JSON request, evaluates source, emits result envelope past a sentinel separator
- `pkg/engine/sandbox/wasm`: WasmBackend (registered as `wasm`), `//go:embed yaegi.wasm.gz` + gzip decompression at backend init, wazero runtime, optional `cache_dir` for cross-process AOT cache
- `pkg/engine/sandbox/wasm/yaegi.wasm.gz`: 8.4 MiB compressed runner artefact (39 MiB uncompressed)
- `Makefile`: `build-yaegi-wasm` + `verify-yaegi-wasm` targets; gzip -n for byte-deterministic output
- `plugins/tools/codeexec`: new `compiler: yaegi-host | yaegi-wasm` config knob (default yaegi-host); selecting yaegi-wasm fails Init loudly if the configured sandbox backend doesn't advertise KindGoWasm

**Phase 3** (`feat(sandbox/wasm): host bridge SDK — http, fs, exec, env`)
- `pkg/engine/sandbox/wasm/host`: single dispatch host function `invoke(opPtr,opLen,reqPtr,reqLen,scratchPtr,scratchLen) i64` with packed (status<<48 | length) returns; per-op gates (netHostAllowed, fsReadAllowed, fsWriteAllowed, execAllowed); production capabilities adapter using net/http with body cap, os.ReadFile/WriteFile with symlink refusal, os/exec with hard timeout
- `cmd/yaegi-runner/sdk*.go` (behind `//go:build wasip1`): nexus_sdk/{http,fs,exec,env} packages; bridgeCall marshalling layer with auto-grow scratch on StatusBufferTooSmall; ErrCapDenied sentinel + IsCapDenied helper
- `cmd/yaegi-runner/sdk_bindings.go`: Yaegi symbol map so snippets can `import "nexus_sdk/http"` and resolve at eval time

**Phase 4** (`feat(skills): runtime frontmatter — yaegi (default) | wasm`)
- SKILL.md gains `runtime: yaegi | wasm` frontmatter; rides through skill.loaded events on SkillContent.Runtime
- codeexec under `compiler: yaegi-wasm` skips skill helper loading (the bridge SDK doesn't surface helpers in v1; skill markdown content still reaches the agent unchanged)

**Docs**
- New: `docs/src/security/sandboxing.md` — threat model, backend selection, bridge SDK surface, snippet authoring example, performance table
- Updated: `docs/src/configuration/reference.md` for the new `sandbox.*` keys on tools/shell and tools/code_exec
- Linked from SUMMARY.md under Reference

## What's deferred

- Real-Go (`GOOS=wasip1`) per-snippet compile + Go SDK auto-bootstrap → tracked in #71
- gVisor / Firecracker / landlock backends — designed-for, not built
- TinyGo path
- WASI preview2 / wasi-sockets
- Raw TCP, listening sockets, native `database/sql`, cgo
- `tools.*` typed bindings, `parallel.*` constructs, skill helpers under wasm — they remain on the yaegi-host path; reintroducing them under wasm is follow-up work

## Performance

| Operation | Cost |
|---|---|
| WasmBackend cold start (first time) | ~5–9 s wazero AOT compile of 39 MiB embedded runner |
| With `cache_dir` set, subsequent process startup | ~50–200 ms |
| Per-snippet (warm backend) | ~30–50 ms |

The wasm tests in this PR take ~10 s each on first run because each distinct backend config rebuilds the wazero runtime. In production a session reuses one Backend and amortises across many snippets.

## Test plan

- [x] `go test ./...` clean (47 unit packages, all green)
- [x] `go test -tags integration ./tests/integration/` clean (37 integration tests)
- [x] `make verify-yaegi-wasm` — embedded runner reproduces byte-identical from a fresh build (gzip -n)
- [x] Bridge round-trip tests: HTTP allowed (httptest server, status+body assertions), HTTP denied (empty allow_hosts → ErrCapDenied surfaces in snippet), FS read inside mount, env Get returning sandbox-scoped value
- [x] Yaegi-on-Wasm parity for compute snippets (string manipulation, JSON, regex, time, crypto/sha256 covered indirectly via the test suite)
- [x] Backwards-compat shim: existing `tools/shell` configs (`allowed_commands`, `path_dirs`, `sandbox: bool` at top level) still work without rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)