### PR TITLE
fix: session recall + codeexec persistence

### DIFF
--- a/docs/src/architecture/sessions.md
+++ b/docs/src/architecture/sessions.md
@@ -119,6 +119,13 @@ On shutdown, the engine:
 2. Updates status to `"ended"`
 3. Saves a config snapshot for future recall
 
+The snapshot is the original config YAML bytes verbatim, not a re-serialization
+of the typed `Config` struct. `core.models` and per-plugin configs are parsed
+via a second-pass raw map (`yaml:"-"` on the typed fields), so re-marshaling
+would silently drop them and break recall. Configs constructed in-memory via
+`DefaultConfig()` (no source bytes) fall back to `yaml.Marshal` of the typed
+struct.
+
 ## Configuration
 
 Session behavior is configured in the `core.sessions` section:

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -633,6 +633,10 @@ Two compilers selected via `compiler`:
 | `sandbox.exec_allowed` | list | *(empty)*                | Allowlist of commands invokable from `nexus_sdk/exec.Run`. Empty = deny. |
 | `sandbox.env`       | map    | *(empty)*                  | Sandbox-scoped env values returned by `nexus_sdk/env.Get`. Never the host's real env. |
 
+The engine substitutes `${session_id}` in any string under the `sandbox:`
+block at session start, so per-session host paths can be hard-coded:
+`host: ~/.nexus/sessions/${session_id}/files`.
+
 ---
 
 ## Memory

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -20,6 +20,14 @@ type Config struct {
 	// disabled — it is core, not a plugin — but its fsync, retention, and
 	// rotation thresholds are exposed here for ops trade-offs.
 	Journal JournalConfig `yaml:"journal"`
+
+	// Raw is the original config YAML bytes the engine was loaded from.
+	// Populated by LoadConfigFromBytes (and by extension LoadConfig). Empty
+	// for configs constructed in-memory via DefaultConfig. Used by Engine
+	// to write a bytes-faithful session config snapshot — re-marshaling the
+	// typed Config drops fields parsed via the second-pass raw map (core.models
+	// and per-plugin configs both have yaml:"-").
+	Raw []byte `yaml:"-"`
 }
 
 // JournalConfig tunes the durable per-session event log. Defaults are picked
@@ -167,6 +175,11 @@ func LoadConfigFromBytes(data []byte) (*Config, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
+
+	// Stash the input bytes so the engine can write a bytes-faithful config
+	// snapshot at session start. yaml.Marshal(cfg) loses core.models and
+	// per-plugin configs (both yaml:"-"), which breaks session recall.
+	cfg.Raw = append([]byte(nil), data...)
 
 	return cfg, nil
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -724,8 +724,13 @@ func (e *Engine) StartSession() error {
 
 	session := e.Session
 
-	// Write config snapshot to metadata.
-	if cfgData, err := yaml.Marshal(e.Config); err == nil {
+	// Write config snapshot to metadata. Prefer the original raw YAML bytes
+	// over yaml.Marshal(e.Config): the typed Config drops core.models and
+	// per-plugin configs (yaml:"-"), so re-marshaling would produce a snapshot
+	// that fails on recall.
+	if len(e.Config.Raw) > 0 {
+		_ = session.WriteFile("metadata/config-snapshot.yaml", e.Config.Raw)
+	} else if cfgData, err := yaml.Marshal(e.Config); err == nil {
 		_ = session.WriteFile("metadata/config-snapshot.yaml", cfgData)
 	}
 

--- a/pkg/engine/lifecycle.go
+++ b/pkg/engine/lifecycle.go
@@ -302,11 +302,44 @@ func (lm *LifecycleManager) resolveSandbox(pluginID string, pluginCfg map[string
 		}
 		return sb, nil
 	}
+	if lm.session != nil {
+		block = substituteSessionPlaceholders(block, lm.session.ID).(map[string]any)
+	}
 	sb, err := sandbox.New(name, block)
 	if err != nil {
 		return nil, fmt.Errorf("sandbox %q for %q: %w", name, pluginID, err)
 	}
 	return sb, nil
+}
+
+// substituteSessionPlaceholders walks a config tree and replaces ${session_id}
+// in every string with sessionID. Returns a new tree — the input is not
+// mutated. Used so configs can hard-code session-scoped paths like
+// `~/.nexus/sessions/${session_id}/files` and have the engine resolve the
+// real session ID at boot time. Strings without the placeholder pass through
+// unchanged; non-string scalars are returned as-is.
+func substituteSessionPlaceholders(v any, sessionID string) any {
+	switch x := v.(type) {
+	case string:
+		if !strings.Contains(x, "${session_id}") {
+			return x
+		}
+		return strings.ReplaceAll(x, "${session_id}", sessionID)
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = substituteSessionPlaceholders(vv, sessionID)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, vv := range x {
+			out[i] = substituteSessionPlaceholders(vv, sessionID)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // expandRequirements walks Requires() transitively on every plugin already in

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -483,3 +483,47 @@ func TestCapability_PluginContextReceivesMap(t *testing.T) {
 		t.Errorf("consumer ctx.Capabilities[memory.history] = %v, want [provider-a]", got)
 	}
 }
+
+func TestSubstituteSessionPlaceholders(t *testing.T) {
+	in := map[string]any{
+		"backend": "wasm",
+		"fs_mounts": []any{
+			map[string]any{
+				"host":  "~/.nexus/sessions/${session_id}/files",
+				"guest": "/workspace",
+				"mode":  "rw",
+			},
+			map[string]any{
+				"host": "/etc/static",
+			},
+		},
+		"env": map[string]any{
+			"WORKSPACE":  "/workspace",
+			"SESSION_ID": "${session_id}",
+		},
+		"timeout_seconds": 60,
+	}
+	out := substituteSessionPlaceholders(in, "abc123").(map[string]any)
+
+	mounts := out["fs_mounts"].([]any)
+	first := mounts[0].(map[string]any)
+	if got := first["host"].(string); got != "~/.nexus/sessions/abc123/files" {
+		t.Errorf("fs_mounts[0].host = %q, want substituted path", got)
+	}
+	second := mounts[1].(map[string]any)
+	if got := second["host"].(string); got != "/etc/static" {
+		t.Errorf("fs_mounts[1].host changed unexpectedly: %q", got)
+	}
+	if got := out["env"].(map[string]any)["SESSION_ID"].(string); got != "abc123" {
+		t.Errorf("env.SESSION_ID = %q, want abc123", got)
+	}
+	if got := out["timeout_seconds"]; got != 60 {
+		t.Errorf("non-string scalar mutated: %v", got)
+	}
+
+	// Input untouched.
+	origHost := in["fs_mounts"].([]any)[0].(map[string]any)["host"].(string)
+	if origHost != "~/.nexus/sessions/${session_id}/files" {
+		t.Errorf("input mutated: %q", origHost)
+	}
+}

--- a/pkg/engine/sandbox/wasm/bridge_test.go
+++ b/pkg/engine/sandbox/wasm/bridge_test.go
@@ -102,7 +102,7 @@ func TestBridgeHTTPGetAllowed(t *testing.T) {
 			"allow_hosts": []any{host},
 		},
 	}
-	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	sb, err := sandbox.New(sandbox.BackendWasm, withSharedCache(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestBridgeHTTPGetDenied(t *testing.T) {
 		"allowed_packages": []any{"context"},
 		// No net.allow_hosts → deny all.
 	}
-	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	sb, err := sandbox.New(sandbox.BackendWasm, withSharedCache(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestBridgeFSReadInsideMount(t *testing.T) {
 			map[string]any{"host": dir, "guest": "/work", "mode": "ro"},
 		},
 	}
-	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	sb, err := sandbox.New(sandbox.BackendWasm, withSharedCache(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +186,7 @@ func TestBridgeEnvGet(t *testing.T) {
 			"FOO": "bar",
 		},
 	}
-	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	sb, err := sandbox.New(sandbox.BackendWasm, withSharedCache(cfg))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/engine/sandbox/wasm/wasm_test.go
+++ b/pkg/engine/sandbox/wasm/wasm_test.go
@@ -2,6 +2,7 @@ package wasm_test
 
 import (
 	"context"
+	"maps"
 	"os"
 	"strings"
 	"sync"
@@ -21,14 +22,40 @@ var (
 	sharedBackends = map[string]sandbox.Sandbox{}
 )
 
+// sharedCacheDir is a wazero compilation cache shared across every wasm
+// sandbox built during the test run. The first sandbox pays the ~5–9 s AOT
+// compile; subsequent sandboxes (including those with distinct policies)
+// load the precompiled module from disk in ~50–200 ms. Without this the
+// bridge tests, which need a fresh backend per test for distinct policies,
+// each rebuilt from scratch and dominated CI time.
+var sharedCacheDir string
+
 func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "nexus-wasm-test-cache-*")
+	if err != nil {
+		panic("wasm test cache: " + err.Error())
+	}
+	sharedCacheDir = dir
+
 	code := m.Run()
+
 	sharedMu.Lock()
 	for _, sb := range sharedBackends {
 		_ = sb.Close()
 	}
 	sharedMu.Unlock()
+	_ = os.RemoveAll(sharedCacheDir)
 	os.Exit(code)
+}
+
+// withSharedCache returns a shallow copy of cfg with cache_dir set to the
+// shared wazero compilation cache. Tests that build a fresh sandbox per
+// case use this so they amortize AOT compile across the package.
+func withSharedCache(cfg map[string]any) map[string]any {
+	out := make(map[string]any, len(cfg)+1)
+	maps.Copy(out, cfg)
+	out["cache_dir"] = sharedCacheDir
+	return out
 }
 
 // helloScript prints to stdout and returns a string. Exercises both the
@@ -84,7 +111,7 @@ func newWasm(t *testing.T, cfg map[string]any) sandbox.Sandbox {
 	if sb, ok := sharedBackends[key]; ok {
 		return sb
 	}
-	sb, err := sandbox.New(sandbox.BackendWasm, cfg)
+	sb, err := sandbox.New(sandbox.BackendWasm, withSharedCache(cfg))
 	if err != nil {
 		t.Fatalf("new wasm: %v", err)
 	}

--- a/plugins/observe/sampler/plugin_test.go
+++ b/plugins/observe/sampler/plugin_test.go
@@ -3,6 +3,7 @@ package sampler
 import (
 	"bufio"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -84,7 +85,7 @@ func fixtureSession(t *testing.T, status string) *engine.SessionWorkspace {
 func randomTag() string {
 	b := make([]byte, 4)
 	_, _ = io.ReadFull(rand.New(rand.NewSource(time.Now().UnixNano())), b)
-	return strings.ToLower(strings.TrimSpace(string(b)))
+	return hex.EncodeToString(b)
 }
 
 func newTestLogger() *slog.Logger {

--- a/plugins/tools/codeexec/plugin.go
+++ b/plugins/tools/codeexec/plugin.go
@@ -447,6 +447,11 @@ func (p *Plugin) runScript(tc events.ToolCall) {
 		Skills:  activeSkills,
 	})
 
+	// Persist the script up-front so it lands on disk regardless of compiler
+	// or success. Output artifacts (stdout, result, error) are written by the
+	// per-backend paths once they exist.
+	p.persist(tc, script, "", "", "")
+
 	if p.compiler == compilerYaegiWasm {
 		p.runScriptWasm(tc, script)
 		return
@@ -562,10 +567,10 @@ func (p *Plugin) runScript(tc events.ToolCall) {
 		return
 	}
 
-	// Persist uses the aggregated stdout — close the writer first so the tail
-	// lands in the buffer before we snapshot it.
+	// Persist output artifacts. Script was written up-front in runScript.
+	// Close the writer first so the tail lands in the buffer before snapshot.
 	stdout.Close()
-	p.persist(tc, script, stdout.String(), resultJSON, "")
+	p.persist(tc, "", stdout.String(), resultJSON, "")
 	finish(resultJSON, "", elapsedMs(started))
 }
 
@@ -668,14 +673,18 @@ func marshalReturn(v any) (string, error) {
 
 func elapsedMs(started time.Time) int64 { return time.Since(started).Milliseconds() }
 
-// persist writes script + artifacts to the session workspace. No-op when
-// session is absent or persist_scripts is disabled.
+// persist writes script + artifacts to the session workspace. Each field is
+// independent: empty values are skipped so callers can persist the script
+// up-front and the output artifacts later without clobbering script.go.
+// No-op when session is absent or persist_scripts is disabled.
 func (p *Plugin) persist(tc events.ToolCall, script, stdout, result, errMsg string) {
 	if p.session == nil || !p.persistScripts {
 		return
 	}
 	base := fmt.Sprintf("plugins/%s/%s", pluginID, tc.ID)
-	_ = p.session.WriteFile(base+"/script.go", []byte(script))
+	if script != "" {
+		_ = p.session.WriteFile(base+"/script.go", []byte(script))
+	}
 	if stdout != "" {
 		_ = p.session.WriteFile(base+"/stdout.txt", []byte(stdout))
 	}

--- a/plugins/tools/codeexec/plugin_test.go
+++ b/plugins/tools/codeexec/plugin_test.go
@@ -207,6 +207,35 @@ func Run(ctx context.Context) (any, error) {
 	}
 }
 
+// TestPlugin_PersistsScriptOnRuntimeFailure pins the regression where the
+// script never landed on disk if execution failed (and, for the wasm path,
+// even on success). Persistence now happens up-front in runScript before
+// backend dispatch, so the script is recoverable regardless of outcome.
+func TestPlugin_PersistsScriptOnRuntimeFailure(t *testing.T) {
+	h := newHarness(t, nil)
+
+	script := `package main
+import "context"
+func Run(ctx context.Context) (any, error) {
+	notAVariable.Call()
+	return nil, nil
+}
+`
+	res := h.runCode(script)
+	if res.Error == "" {
+		t.Fatalf("expected runtime/compile error, got success: %q", res.Output)
+	}
+
+	scriptPath := filepath.Join(h.session.RootDir, "plugins", pluginID, res.ID, "script.go")
+	got, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("script.go missing on failure path: %v", err)
+	}
+	if string(got) != script {
+		t.Errorf("persisted script differs from input")
+	}
+}
+
 func TestPlugin_RejectsGoroutines(t *testing.T) {
 	h := newHarness(t, nil)
 

--- a/plugins/tools/codeexec/wasm.go
+++ b/plugins/tools/codeexec/wasm.go
@@ -33,6 +33,10 @@ func (p *Plugin) runScriptWasm(tc events.ToolCall, script string) {
 
 	stdout := string(res.Stdout)
 	stderr := string(res.Stderr)
+	// Persist stdout regardless of outcome so a failing script's output is
+	// inspectable. Script was already written by runScript; error.txt is
+	// written by emitResult when errMsg is non-empty.
+	p.persist(tc, "", stdout, "", "")
 	if res.TimedOut {
 		p.emitResult(tc, stdout, "", "script timed out after "+p.timeout.String(), durationMs, res.Truncated)
 		return


### PR DESCRIPTION
## Summary

Three independent bugs surfaced while testing wasm-sandbox session recall, fixed in three commits:

- **`fix(engine): preserve raw config bytes for recall snapshot`** — `core.models` and per-plugin configs are parsed via a second-pass raw map (`yaml:"-"` on the typed fields). `yaml.Marshal(e.Config)` dropped them, so recalled sessions booted with an empty `ModelRegistry` and Anthropic returned `400 model: String should have at least 1 character` on the first message. Now stash the original YAML bytes on `Config.Raw` and write them verbatim to `metadata/config-snapshot.yaml`.
- **`fix(engine): substitute ${session_id} in sandbox config`** — `configs/demo-sandbox-wasm.yaml` documented `${session_id}` as engine-resolved, but no code did the substitution. Files written through `nexus_sdk/fs` landed under a literal `${session_id}` directory. Resolved in `resolveSandbox` via a recursive walk before backend construction.
- **`fix(codeexec): persist scripts on wasm path and on failure`** — `runScriptWasm` never called `p.persist`, and the host path skipped persistence on script-runtime-error. Moved script persistence up-front in `runScript` so it lands regardless of compiler or outcome; `persist` now skips empty fields so artifact writes don't clobber `script.go`.

## Test plan

- [x] `go test ./...` (engine + plugins + integration)
- [x] New regression tests:
  - `TestSubstituteSessionPlaceholders` — recursive walk, untouched non-strings, no input mutation
  - `TestPlugin_PersistsScriptOnRuntimeFailure` — script.go lands on disk even when execution errors
- [ ] Manual: run `bin/nexus -config configs/demo-sandbox-wasm.yaml`, send a prompt, exit, recall the session, send another prompt — first message after recall should now succeed and any `run_code` invocations should leave `script.go` + `stdout.txt` under `~/.nexus/sandbox-sessions/<id>/plugins/nexus.tool.code_exec/<call_id>/`.
- [ ] Manual: confirm `metadata/config-snapshot.yaml` for new sessions is bytes-identical to the source config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)