### PR TITLE
feat(hitl): canonical before:hitl.requested vetoable entry point (#79)

### DIFF
--- a/configs/demo-hitl-synthesizer.yaml
+++ b/configs/demo-hitl-synthesizer.yaml
@@ -1,0 +1,136 @@
+# Demo: LLM-rendered HITL approval prompts (issue #79)
+# Validates: nexus.control.hitl_synthesizer firing for non-tool emitters
+# (the approval policy gate) via the canonical before:hitl.requested entry
+# point.
+#
+# Run:
+#   bin/nexus -config configs/demo-hitl-synthesizer.yaml
+#
+# Prerequisites:
+#   - ANTHROPIC_API_KEY set in env or .env
+#
+# What to test:
+#   1. Synthesized destructive-shell prompt: ask the agent to "delete
+#      old build artifacts in /tmp using rm". The shell tool match
+#      triggers the destructive_shell rule, which sets
+#      prompt_synthesizer: hitl.prompt_synthesizer and leaves prompt
+#      empty. The synthesizer (haiku) renders a concrete one-liner
+#      mentioning the actual command, e.g.
+#        "Approve `rm -rf /tmp/build-*`?"
+#      before the TUI presents the prompt.
+#   2. Cache hit on second identical action: re-run the same command.
+#      The synthesizer answers from disk cache (no LLM call) — check
+#      the session's hitl_synthesizer/cache.jsonl after the run.
+#   3. Static prompt rule still works: the sensitive_path rule keeps
+#      the literal prompt: template (no synthesizer set), confirming
+#      both paths coexist in the same gate.
+#   4. Synthesizer fallback on LLM failure: kill your network mid-run
+#      and trigger the destructive_shell rule. The synthesizer falls
+#      back to its template ("Approve action: tool.invoke") rather
+#      than blocking forever.
+#
+# What to watch for:
+#   - The TUI receives a single rendered string in either path —
+#     synthesis is invisible to IO.
+#   - In the journal (~/.nexus/sessions/<id>/journal/), each
+#     hitl.requested for a synthesized rule is preceded by a
+#     before:hitl.requested record with the same payload.
+#   - llm.request entries tagged with
+#     metadata._source=nexus.control.hitl_synthesizer correspond to
+#     synthesis calls (not the agent's main loop).
+
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: balanced
+    balanced:
+      provider: nexus.llm.anthropic
+      model: claude-sonnet-4-6
+      max_tokens: 4096
+    haiku:
+      provider: nexus.llm.anthropic
+      model: claude-haiku-4-5-20251001
+      max_tokens: 512
+  sessions:
+    root: ~/.nexus/demo-sessions
+    retention: 30d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.tui
+    - nexus.llm.anthropic
+    - nexus.agent.react
+    - nexus.tool.shell
+    - nexus.tool.file
+    - nexus.control.hitl
+    - nexus.control.hitl_synthesizer
+    - nexus.gate.approval_policy
+    - nexus.memory.capped
+
+  nexus.llm.anthropic:
+    api_key_env: ANTHROPIC_API_KEY
+
+  nexus.control.hitl:
+    registry:
+      enabled: false
+
+  nexus.control.hitl_synthesizer:
+    model: haiku                       # cheap; resolved via core.models
+    max_action_ref_chars: 1500
+    cache_enabled: true
+    fallback_prompt: "Approve action: {{.action_kind}}"
+
+  nexus.agent.react:
+    system_prompt: |
+      You are a sysadmin assistant. Be concise. Use shell + file tools
+      to investigate and modify the filesystem. The user has guarded
+      destructive actions behind an approval gate; if a tool result is
+      vetoed, explain what was blocked and ask the user how to proceed.
+
+  nexus.tool.shell:
+    allowed_commands: ["ls", "cat", "grep", "find", "rm", "mkdir", "touch", "echo"]
+    timeout: 10s
+    sandbox: true
+
+  nexus.tool.file:
+    base_dir: ~
+
+  nexus.gate.approval_policy:
+    rules:
+      # Destructive shell: any rm command needs approval, with the
+      # operator-facing prompt rendered by the LLM synthesizer.
+      - match:
+          action_kind: tool.invoke
+          tool: shell
+          args.command: "rm*"
+        mode: choices
+        choices:
+          - { id: allow,  label: "Run as-is", kind: allow }
+          - { id: reject, label: "Block",     kind: reject }
+        default_choice: reject
+        timeout: 30s
+        # No prompt: here — the synthesizer fills it in via the
+        # before:hitl.requested handler. The synthesizer sees the
+        # rule's ActionRef (tool name + arguments) and writes a
+        # concrete approval question.
+        prompt_synthesizer: hitl.prompt_synthesizer
+
+      # Sensitive paths: writing under /etc keeps the literal prompt
+      # template — proves static and synthesized rules coexist.
+      - match:
+          action_kind: tool.invoke
+          tool: file
+          args.path: "/etc/*"
+        mode: choices
+        choices:
+          - { id: allow,  label: "Write", kind: allow }
+          - { id: reject, label: "Block", kind: reject }
+        default_choice: reject
+        prompt: "Write to system path {{.args.path}}? This may affect other software."
+
+  nexus.memory.capped:
+    max_messages: 40
+    persist: true

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -1372,7 +1372,8 @@ Each rule is a map with the following keys:
 | `mode`           | string | `choices` | One of `free_text`, `choices`, `both`. |
 | `choices`        | list   | *(see)*   | List of `{id, label, kind}` (or bare-string id). When omitted in `choices` mode, defaults to `[{id: allow, kind: allow}, {id: reject, kind: reject}]`. |
 | `default_choice` | string | *(empty)* | Choice id auto-selected when the timeout elapses. Without a default, a timeout vetoes the action. |
-| `prompt`         | string | *(auto)*  | Go `text/template` string rendered against the action payload. Falls back to `Approve <kind>: <target>` when unset. |
+| `prompt`         | string | *(auto)*  | Go `text/template` string rendered against the action payload. Falls back to `Approve <kind>: <target>` when unset (or empty when `prompt_synthesizer` is set so the synthesizer can fill it in). |
+| `prompt_synthesizer` | string | *(none)* | Capability ID of a registered prompt synthesizer (e.g. `hitl.prompt_synthesizer`). When set, the gate emits the request with `HITLRequest.PromptSynthesizer` populated and an empty `Prompt`, letting the synthesizer render an LLM-authored approval question via the canonical `before:hitl.requested` entry point. |
 | `timeout`        | string | *(none)*  | Go duration (e.g. `5m`). When unset, the gate blocks indefinitely. |
 
 Match keys recognized by the runtime payload:

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -628,9 +628,11 @@ prompts via a small/cheap LLM. Advertises the
 `hitl.prompt_synthesizer` capability; emitters opt in by setting
 `HITLRequest.PromptSynthesizer = "hitl.prompt_synthesizer"` and
 leaving `Prompt` empty. Subscribes to `before:hitl.requested`
-(vetoable, pointer payload) and to `hitl.requested` (mutates only when
-the emitter passed `*HITLRequest`) ahead of every IO plugin so the
-rendered text is in place before the operator sees the prompt.
+(canonical vetoable entry point, pointer payload — every in-tree HITL
+emitter publishes here first) and to `hitl.requested` as a backward
+compat fallback for out-of-tree emitters that publish a `*HITLRequest`
+pointer directly, ahead of every IO plugin so the rendered text is in
+place before the operator sees the prompt.
 Synthesised prompts are cached on disk under
 `<session>/plugins/nexus.control.hitl_synthesizer/cache.jsonl`, keyed by
 `(action_kind, sha256(action_ref))`. See

--- a/docs/src/operations/hitl.md
+++ b/docs/src/operations/hitl.md
@@ -10,9 +10,18 @@ Every interaction that needs an operator's input — clarification
 questions, approvals, plan picks, memory-write sign-offs — flows
 through one event family:
 
-- **`hitl.requested`** — emitted by the requesting plugin, payload is a
+- **`before:hitl.requested`** — canonical vetoable entry point, payload
+  is a `*engine.VetoablePayload` wrapping `*events.HITLRequest`. Every
+  in-tree HITL emitter calls `bus.EmitVetoable("before:hitl.requested",
+  &req)` first so that pre-IO subscribers (e.g. the
+  [HITL prompt synthesizer](../plugins/control/hitl_synthesizer.md)) can
+  mutate `Prompt` or block the request outright. A veto resolves the
+  request as cancelled/rejected without ever reaching IO.
+- **`hitl.requested`** — emitted by the requesting plugin after a
+  non-veto result on `before:hitl.requested`. Payload is a value
   `events.HITLRequest` carrying prompt, mode, optional choices,
-  default-on-deadline, and an opaque `ActionRef` for context.
+  default-on-deadline, and an opaque `ActionRef` for context. IO plugins
+  subscribe to this form.
 - **`hitl.responded`** — emitted by the IO plugin (or, eventually, an
   out-of-band channel), payload is a `events.HITLResponse` carrying the
   picked choice and/or freeform answer.

--- a/docs/src/plugins/control/hitl.md
+++ b/docs/src/plugins/control/hitl.md
@@ -63,7 +63,8 @@ Tool result is structured JSON, not a bare string:
 
 | Event | When |
 |-------|------|
-| `hitl.requested` | A plugin (or the LLM via `ask_user`) needs human input. |
+| `before:hitl.requested` | Canonical vetoable entry point with `*HITLRequest` payload. Subscribers (e.g. the prompt synthesizer) can mutate `Prompt` or veto. |
+| `hitl.requested` | After a non-veto result, value-shape emission consumed by IO plugins. |
 | `tool.register` | Registers the `ask_user` tool at boot. |
 | `tool.result` | After the operator responds (carries the structured JSON). |
 
@@ -84,7 +85,11 @@ will consume it. Conventional values:
 
 ## How It Works
 
-1. Plugin emits `hitl.requested` with prompt + mode + choices.
+1. Plugin calls `bus.EmitVetoable("before:hitl.requested", &req)` so
+   `before:hitl.requested` subscribers (notably the prompt synthesizer)
+   can mutate `req.Prompt` or veto. On veto, the request resolves as
+   rejected/cancelled without reaching IO. On non-veto, the plugin
+   follows up with `bus.Emit("hitl.requested", req)`.
 2. The active IO plugin (TUI, Browser, Wails, oneshot, test) renders
    the prompt and collects the operator's answer.
 3. IO plugin emits `hitl.responded` with `{request_id, choice_id?, free_text?}`.

--- a/docs/src/plugins/control/hitl_synthesizer.md
+++ b/docs/src/plugins/control/hitl_synthesizer.md
@@ -27,12 +27,12 @@ prompt or `text/template`.
 
 1. An emitter (gate, memory plugin, agent) builds a `HITLRequest`
    with `PromptSynthesizer: "hitl.prompt_synthesizer"` and an empty
-   `Prompt`. It either:
-   - Calls `bus.EmitVetoable("before:hitl.requested", &req)` first,
-     then `bus.Emit("hitl.requested", req)` once the synthesizer has
-     mutated `Prompt`, or
-   - Calls `bus.Emit("hitl.requested", &req)` directly with a
-     pointer payload.
+   `Prompt`, then publishes via the canonical entry point:
+   `bus.EmitVetoable("before:hitl.requested", &req)`. On a non-veto
+   result the emitter follows up with `bus.Emit("hitl.requested", req)`
+   for IO consumers to render. All in-tree HITL emitters
+   (`nexus.control.hitl` ask_user, `nexus.gate.approval_policy`,
+   the shared memory approval helper) follow this pattern.
 2. The synthesizer's handler runs at priority `-100`, ahead of every
    IO plugin (priorities 0/10/50). It checks the opt-in conditions,
    consults the cache, and if there's no hit emits an `llm.request`
@@ -40,8 +40,8 @@ prompt or `text/template`.
 3. The active LLM provider returns an `llm.response` synchronously;
    the synthesizer extracts the rendered text, writes it back into
    `req.Prompt`, and persists it to disk for next time.
-4. Subsequent IO plugins receive the pointer-shared payload (or the
-   value re-emitted by the wrapper) with `Prompt` already populated.
+4. The follow-up `Emit("hitl.requested", req)` value emission carries
+   the synthesized prompt to IO plugins.
 
 If the LLM call fails (provider error, empty response, missing
 `llm.response`), the synthesizer never blocks indefinitely: it falls
@@ -85,27 +85,32 @@ cache is hydrated at boot and written through on every store.
 To force a re-render (e.g. while iterating on the system prompt) set
 `cache_enabled: false` or delete `cache.jsonl`.
 
-## Pointer-vs-Value Payloads
+## Canonical Emission Pattern
 
-The synthesizer mutates the request in place. That requires the
-emitter to publish a `*HITLRequest`, not a value. The recommended
-pattern is to use the vetoable path:
+Every HITL emitter in the tree calls `EmitVetoable` on the canonical
+`before:hitl.requested` event first, then dispatches the value-shape
+`hitl.requested` for IO consumption:
 
 ```go
-// Future-proof emitter (gate or memory plugin):
-req := &events.HITLRequest{ /* … */ }
-if _, err := bus.EmitVetoable("before:hitl.requested", req); err != nil {
+req := events.HITLRequest{ /* … */ }
+veto, err := bus.EmitVetoable("before:hitl.requested", &req)
+if err != nil {
     return err
 }
-_ = bus.Emit("hitl.requested", *req)  // dereference once Prompt is filled
+if veto.Vetoed {
+    // Treat as rejected/cancelled per emitter semantics.
+    return nil
+}
+_ = bus.Emit("hitl.requested", req) // Prompt now reflects synthesizer mutations
 ```
 
-When the emitter publishes a value to `hitl.requested` (the legacy
-path), the synthesizer logs and skips — it cannot propagate
-mutations through a copy. In practice the legacy emitters either set
-`Prompt` themselves (the `ask_user` tool) or supply a `PromptTemplate`
-the requesting plugin renders inline, so the pointer-only constraint
-mostly affects new code that explicitly opts into LLM rendering.
+The pointer-payload first leg lets `before:hitl.requested` subscribers
+(notably this plugin) mutate `req.Prompt` in place, while keeping the
+non-vetoable `hitl.requested` form value-shaped — the type IO plugins
+expect. Out-of-tree emitters that emit `hitl.requested` directly with a
+pointer payload still work for backward compatibility (the synthesizer
+keeps the `hitl.requested` subscription as a fallback), but new code
+should use the canonical pattern above.
 
 ## Events
 
@@ -113,8 +118,8 @@ mostly affects new code that explicitly opts into LLM rendering.
 
 | Event | Priority | Purpose |
 |-------|----------|---------|
-| `before:hitl.requested` | -100 | Vetoable opt-in path; mutates `*HITLRequest.Prompt` via `*VetoablePayload`. Never vetoes. |
-| `hitl.requested` | -100 | Legacy path; mutates only when the payload is `*HITLRequest`. |
+| `before:hitl.requested` | -100 | Canonical entry point; mutates `*HITLRequest.Prompt` via `*VetoablePayload`. Never vetoes. |
+| `hitl.requested` | -100 | Backward-compat fallback for out-of-tree emitters that publish a pointer payload directly. In-tree emitters use the `before:` form. |
 | `llm.response` | 50 | Routes responses tagged with this plugin's `_source` to the awaiting synthesis call. |
 
 ### Emits

--- a/docs/src/plugins/gates/index.md
+++ b/docs/src/plugins/gates/index.md
@@ -20,7 +20,7 @@ providers.
 | `nexus.gate.content_safety`       | `before:io.output`      | Block or redact PII / secrets / sensitive content. |
 | `nexus.gate.context_window`       | `before:llm.request`    | Estimate context size; trigger compaction when approaching the limit. |
 | `nexus.gate.tool_filter`          | `before:llm.request`    | Modify the tool list (allowlist / blocklist). |
-| `nexus.gate.approval_policy`      | `before:tool.invoke`, `before:llm.request` | Policy-driven HITL approvals; emits `hitl.requested` and applies the operator's allow/reject/edit. |
+| `nexus.gate.approval_policy`      | `before:tool.invoke`, `before:llm.request` | Policy-driven HITL approvals; emits `before:hitl.requested` then `hitl.requested` and applies the operator's allow/reject/edit. |
 
 ## Configuration
 

--- a/plugins/control/hitl/plugin.go
+++ b/plugins/control/hitl/plugin.go
@@ -177,6 +177,7 @@ func (p *Plugin) Emissions() []string {
 		"before:tool.result",
 		"tool.result",
 		"tool.register",
+		"before:hitl.requested",
 		"hitl.requested",
 	}
 }
@@ -206,6 +207,26 @@ func (p *Plugin) handleToolInvoke(event engine.Event[any]) {
 	p.mu.Lock()
 	p.pending[req.ID] = ch
 	p.mu.Unlock()
+
+	// Canonical Option B emission: vetoable pointer-payload first so
+	// before:hitl.requested subscribers (notably nexus.control.hitl_synthesizer)
+	// see the request and can mutate Prompt or veto. The non-vetoable value
+	// emission below is what IO plugins consume.
+	veto, vetoErr := p.bus.EmitVetoable("before:hitl.requested", &req)
+	if vetoErr != nil {
+		p.logger.Warn("emit before:hitl.requested failed", "error", vetoErr, "request_id", req.ID)
+	}
+	if veto.Vetoed {
+		p.mu.Lock()
+		delete(p.pending, req.ID)
+		p.mu.Unlock()
+		reason := veto.Reason
+		if reason == "" {
+			reason = "ask_user vetoed by before:hitl.requested handler"
+		}
+		p.emitResult(tc, "", reason)
+		return
+	}
 
 	_ = p.bus.Emit("hitl.requested", req)
 

--- a/plugins/control/hitl_synthesizer/plugin.go
+++ b/plugins/control/hitl_synthesizer/plugin.go
@@ -9,16 +9,18 @@
 //
 // The synthesizer subscribes to two channels:
 //
-//   - before:hitl.requested — vetoable, pointer-payload. Future
-//     emitters call EmitVetoable on this event before their non-vetoable
-//     Emit so the synthesizer can mutate req.Prompt in place. The bus
-//     guarantees handlers see the same *VetoablePayload pointer.
+//   - before:hitl.requested — canonical, vetoable, pointer-payload entry
+//     point. Every in-tree HITL emitter (nexus.control.hitl ask_user,
+//     nexus.gate.approval_policy, the shared memory approval helper)
+//     calls EmitVetoable on this event before publishing the value-shape
+//     hitl.requested so the synthesizer can mutate req.Prompt in place.
+//     The bus guarantees handlers see the same *VetoablePayload pointer.
 //
-//   - hitl.requested — non-vetoable. The existing nexus.control.hitl
-//     plugin and gates emit values here. Synthesis only succeeds for
-//     pointer payloads; value payloads are skipped (a copy can't carry
-//     mutations back). In practice this is fine: the existing emitters
-//     either set Prompt directly or pass pointers explicitly.
+//   - hitl.requested — non-vetoable. Kept as a backward-compat fallback
+//     for out-of-tree emitters that publish a *HITLRequest pointer
+//     directly. Value payloads are skipped (a copy can't carry mutations
+//     back); all in-tree value emissions follow the before: path first
+//     so by the time IO plugins see the value form, Prompt is populated.
 //
 // Synthesised prompts are cached on disk (write-through JSONL) keyed by
 // (ActionKind, hash(ActionRef)) so identical actions don't pay the LLM

--- a/plugins/control/hitl_synthesizer/plugin_test.go
+++ b/plugins/control/hitl_synthesizer/plugin_test.go
@@ -267,6 +267,59 @@ func TestSynthesize_ValuePayloadIgnored(t *testing.T) {
 	}
 }
 
+// TestSynthesize_NonToolEmitter_BeforePath simulates the canonical
+// Option B emission flow used by the approval_policy gate and the
+// memory/internal/approval helper: the emitter calls EmitVetoable on
+// before:hitl.requested first (so the synthesizer can mutate Prompt),
+// then the value-payload Emit on hitl.requested for IO consumers. The
+// test asserts synthesis fires for an approval-gate-shaped action even
+// though the emitter is not the ask_user tool.
+func TestSynthesize_NonToolEmitter_BeforePath(t *testing.T) {
+	_, bus := newTestPlugin(t)
+	stub := newStubProvider(bus, "Approve memory write to user_pref/theme?")
+
+	// IO-side stand-in: subscribe to the non-vetoable hitl.requested form
+	// so we can assert the value emission carries the synthesized prompt.
+	var ioSeen events.HITLRequest
+	bus.Subscribe("hitl.requested", func(ev engine.Event[any]) {
+		if r, ok := ev.Payload.(events.HITLRequest); ok {
+			ioSeen = r
+		}
+	}, engine.WithPriority(50))
+
+	req := events.HITLRequest{
+		ID:                "approval-1",
+		RequesterPlugin:   "nexus.gate.approval_policy",
+		ActionKind:        "memory.longterm.write",
+		PromptSynthesizer: CapabilityName,
+		ActionRef: map[string]any{
+			"key":   "user_pref/theme",
+			"value": "dark",
+		},
+	}
+
+	veto, err := bus.EmitVetoable("before:hitl.requested", &req)
+	if err != nil {
+		t.Fatalf("emit before:hitl.requested: %v", err)
+	}
+	if veto.Vetoed {
+		t.Fatalf("synthesizer must never veto, got reason=%q", veto.Reason)
+	}
+	if req.Prompt != "Approve memory write to user_pref/theme?" {
+		t.Fatalf("expected synthesized prompt on req, got %q", req.Prompt)
+	}
+
+	if err := bus.Emit("hitl.requested", req); err != nil {
+		t.Fatalf("emit hitl.requested: %v", err)
+	}
+	if ioSeen.Prompt != "Approve memory write to user_pref/theme?" {
+		t.Fatalf("expected IO subscriber to see synthesized prompt, got %q", ioSeen.Prompt)
+	}
+	if len(stub.seen) != 1 {
+		t.Errorf("expected 1 llm.request from non-tool emitter, got %d", len(stub.seen))
+	}
+}
+
 func TestBuildCacheKey_DeterministicAndPartitioned(t *testing.T) {
 	a := buildCacheKey("tool.invoke", map[string]any{"a": 1, "b": 2})
 	b := buildCacheKey("tool.invoke", map[string]any{"b": 2, "a": 1}) // same content, different literal order

--- a/plugins/gates/approval_policy/match.go
+++ b/plugins/gates/approval_policy/match.go
@@ -14,6 +14,7 @@ type rule struct {
 	choices          []choiceCfg
 	defaultChoice    string
 	prompt           string
+	promptSynthesizer string
 	timeoutSeconds   int
 }
 

--- a/plugins/gates/approval_policy/plugin.go
+++ b/plugins/gates/approval_policy/plugin.go
@@ -221,14 +221,15 @@ func (p *Plugin) requestApproval(r rule, payload map[string]any, actionKind, tar
 	requestID := fmt.Sprintf("approval-%d-%d", time.Now().UnixNano(), p.requestCounter.Add(1))
 
 	req := events.HITLRequest{
-		ID:              requestID,
-		RequesterPlugin: pluginID,
-		ActionKind:      actionKind,
-		ActionRef:       payload,
-		Mode:            events.HITLMode(r.mode),
-		Choices:         choices,
-		DefaultChoiceID: defaultID,
-		Prompt:          prompt,
+		ID:                requestID,
+		RequesterPlugin:   pluginID,
+		ActionKind:        actionKind,
+		ActionRef:         payload,
+		Mode:              events.HITLMode(r.mode),
+		Choices:           choices,
+		DefaultChoiceID:   defaultID,
+		Prompt:            prompt,
+		PromptSynthesizer: r.promptSynthesizer,
 	}
 	if r.timeoutSeconds > 0 {
 		req.Deadline = time.Now().Add(time.Duration(r.timeoutSeconds) * time.Second)
@@ -434,9 +435,14 @@ func applyLLMEdit(req *events.LLMRequest, edits map[string]any) {
 
 // renderPrompt returns the rendered approval prompt. Falls back to a
 // generic "Approve <kind>: <target>" message when no template was set
-// or the template fails to parse/execute.
+// or the template fails to parse/execute. When the rule names a
+// prompt_synthesizer, an empty prompt template stays empty so the
+// synthesizer can fill it in via the before:hitl.requested handler.
 func renderPrompt(r rule, payload map[string]any, actionKind, target string) string {
 	if strings.TrimSpace(r.prompt) == "" {
+		if r.promptSynthesizer != "" {
+			return ""
+		}
 		return fmt.Sprintf("Approve %s: %s", actionKind, target)
 	}
 	tmpl, err := template.New("approval").Option("missingkey=zero").Parse(r.prompt)
@@ -551,6 +557,10 @@ func parseRule(obj map[string]any) (rule, error) {
 
 	if v, ok := obj["prompt"].(string); ok {
 		r.prompt = v
+	}
+
+	if v, ok := obj["prompt_synthesizer"].(string); ok {
+		r.promptSynthesizer = v
 	}
 
 	if v, ok := obj["timeout"].(string); ok && v != "" {

--- a/plugins/gates/approval_policy/plugin.go
+++ b/plugins/gates/approval_policy/plugin.go
@@ -107,7 +107,7 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 }
 
 func (p *Plugin) Emissions() []string {
-	return []string{"hitl.requested"}
+	return []string{"before:hitl.requested", "hitl.requested"}
 }
 
 // handleBeforeToolInvoke evaluates rules against pending tool-invoke
@@ -243,6 +243,21 @@ func (p *Plugin) requestApproval(r rule, payload map[string]any, actionKind, tar
 		delete(p.pending, requestID)
 		p.mu.Unlock()
 	}()
+
+	// Canonical Option B emission: vetoable pointer-payload first so
+	// before:hitl.requested subscribers (notably nexus.control.hitl_synthesizer)
+	// can mutate Prompt or veto the request, then the non-vetoable value
+	// emission consumed by IO plugins.
+	if veto, err := p.bus.EmitVetoable("before:hitl.requested", &req); err != nil {
+		p.logger.Error("emit before:hitl.requested failed", "error", err, "action", actionKind)
+		return approvalOutcome{rejected: true, reason: fmt.Sprintf("approval gate emit failed: %v", err)}
+	} else if veto.Vetoed {
+		reason := veto.Reason
+		if reason == "" {
+			reason = "approval vetoed by before:hitl.requested handler"
+		}
+		return approvalOutcome{rejected: true, reason: reason}
+	}
 
 	if err := p.bus.Emit("hitl.requested", req); err != nil {
 		p.logger.Error("emit hitl.requested failed", "error", err, "action", actionKind)

--- a/plugins/gates/approval_policy/plugin_test.go
+++ b/plugins/gates/approval_policy/plugin_test.go
@@ -378,6 +378,96 @@ func TestParseRules_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestApprovalPolicy_BeforeHandlerSynthesizesPrompt verifies the gate
+// emits before:hitl.requested with a pointer payload first, so the
+// HITL prompt synthesizer (or any other before:hitl.requested handler)
+// can mutate Prompt before IO sees the request.
+func TestApprovalPolicy_BeforeHandlerSynthesizesPrompt(t *testing.T) {
+	rules := []rule{{
+		match: map[string]any{"action_kind": "tool.invoke", "tool": "shell"},
+		mode:  string(events.HITLModeChoices),
+	}}
+	_, bus := newTestPlugin(t, rules)
+
+	bus.Subscribe("before:hitl.requested", func(ev engine.Event[any]) {
+		vp, ok := ev.Payload.(*engine.VetoablePayload)
+		if !ok {
+			return
+		}
+		req, ok := vp.Original.(*events.HITLRequest)
+		if !ok {
+			return
+		}
+		req.Prompt = "synthesized: " + req.ActionKind
+	}, engine.WithPriority(-100))
+
+	resp := newScriptedResponder(bus, events.HITLResponse{ChoiceID: "allow"})
+
+	tc := events.ToolCall{
+		ID:        "t1",
+		Name:      "shell",
+		Arguments: map[string]any{"command": "ls"},
+	}
+	veto, err := bus.EmitVetoable("before:tool.invoke", &tc)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if veto.Vetoed {
+		t.Fatalf("expected allow, got veto: %s", veto.Reason)
+	}
+	if len(resp.seen) != 1 {
+		t.Fatalf("expected 1 hitl.requested, got %d", len(resp.seen))
+	}
+	if resp.seen[0].Prompt != "synthesized: tool.invoke" {
+		t.Errorf("expected synthesized prompt to reach IO, got %q", resp.seen[0].Prompt)
+	}
+}
+
+// TestApprovalPolicy_BeforeHandlerVetoRejects asserts a veto on the
+// canonical before:hitl.requested entry point translates into a veto
+// on the original before:tool.invoke without ever firing IO.
+func TestApprovalPolicy_BeforeHandlerVetoRejects(t *testing.T) {
+	rules := []rule{{
+		match: map[string]any{"action_kind": "tool.invoke", "tool": "shell"},
+		mode:  string(events.HITLModeChoices),
+	}}
+	_, bus := newTestPlugin(t, rules)
+
+	bus.Subscribe("before:hitl.requested", func(ev engine.Event[any]) {
+		vp, ok := ev.Payload.(*engine.VetoablePayload)
+		if !ok {
+			return
+		}
+		vp.Veto = engine.VetoResult{Vetoed: true, Reason: "approval auditor rejected"}
+	}, engine.WithPriority(-100))
+
+	var ioCalls int
+	bus.Subscribe("hitl.requested", func(ev engine.Event[any]) {
+		if _, ok := ev.Payload.(events.HITLRequest); ok {
+			ioCalls++
+		}
+	}, engine.WithPriority(50))
+
+	tc := events.ToolCall{
+		ID:        "t1",
+		Name:      "shell",
+		Arguments: map[string]any{"command": "ls"},
+	}
+	veto, err := bus.EmitVetoable("before:tool.invoke", &tc)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !veto.Vetoed {
+		t.Fatal("expected gate to veto tool.invoke when before:hitl.requested vetoes")
+	}
+	if veto.Reason != "approval auditor rejected" {
+		t.Errorf("expected veto reason forwarded, got %q", veto.Reason)
+	}
+	if ioCalls != 0 {
+		t.Errorf("vetoed approval must not emit hitl.requested to IO, got %d", ioCalls)
+	}
+}
+
 func TestParseRules_InvalidMode(t *testing.T) {
 	raw := []any{
 		map[string]any{"mode": "bogus"},

--- a/plugins/gates/approval_policy/plugin_test.go
+++ b/plugins/gates/approval_policy/plugin_test.go
@@ -423,6 +423,38 @@ func TestApprovalPolicy_BeforeHandlerSynthesizesPrompt(t *testing.T) {
 	}
 }
 
+// TestApprovalPolicy_PromptSynthesizerOptIn asserts a rule with the
+// prompt_synthesizer key set propagates the capability ID onto the
+// emitted HITLRequest and leaves Prompt empty so the
+// before:hitl.requested subscriber can render it.
+func TestApprovalPolicy_PromptSynthesizerOptIn(t *testing.T) {
+	rules := []rule{{
+		match:             map[string]any{"action_kind": "tool.invoke", "tool": "shell"},
+		mode:              string(events.HITLModeChoices),
+		promptSynthesizer: "hitl.prompt_synthesizer",
+	}}
+	_, bus := newTestPlugin(t, rules)
+	resp := newScriptedResponder(bus, events.HITLResponse{ChoiceID: "allow"})
+
+	tc := events.ToolCall{
+		ID:        "t1",
+		Name:      "shell",
+		Arguments: map[string]any{"command": "rm -rf /tmp"},
+	}
+	if _, err := bus.EmitVetoable("before:tool.invoke", &tc); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if len(resp.seen) != 1 {
+		t.Fatalf("expected 1 hitl.requested, got %d", len(resp.seen))
+	}
+	if resp.seen[0].PromptSynthesizer != "hitl.prompt_synthesizer" {
+		t.Errorf("PromptSynthesizer not propagated, got %q", resp.seen[0].PromptSynthesizer)
+	}
+	if resp.seen[0].Prompt != "" {
+		t.Errorf("expected empty Prompt to leave synthesis room, got %q", resp.seen[0].Prompt)
+	}
+}
+
 // TestApprovalPolicy_BeforeHandlerVetoRejects asserts a veto on the
 // canonical before:hitl.requested entry point translates into a veto
 // on the original before:tool.invoke without ever firing IO.

--- a/plugins/memory/compaction/plugin.go
+++ b/plugins/memory/compaction/plugin.go
@@ -149,6 +149,7 @@ func (p *Plugin) Emissions() []string {
 		"memory.compacted",
 		"thinking.step",
 		"io.status",
+		"before:hitl.requested",
 		"hitl.requested",
 	}
 }

--- a/plugins/memory/internal/approval/approval.go
+++ b/plugins/memory/internal/approval/approval.go
@@ -130,6 +130,30 @@ func RequestApproval(ctx context.Context, req Request) (events.HITLResponse, boo
 		hitlReq.Deadline = time.Now().Add(req.Timeout)
 	}
 
+	// Canonical Option B emission: vetoable pointer-payload first so
+	// before:hitl.requested subscribers (notably the HITL prompt synthesizer)
+	// can mutate hitlReq.Prompt or veto outright. The non-vetoable value
+	// emission below is the one IO plugins consume.
+	if veto, err := req.Bus.EmitVetoable("before:hitl.requested", &hitlReq); err != nil {
+		return events.HITLResponse{}, false, fmt.Errorf("approval: emit before:hitl.requested: %w", err)
+	} else if veto.Vetoed {
+		reason := veto.Reason
+		if reason == "" {
+			reason = "approval vetoed by before:hitl.requested handler"
+		}
+		logger.Warn("approval: request vetoed",
+			"plugin", req.PluginID,
+			"action_kind", req.ActionKind,
+			"request_id", id,
+			"reason", reason,
+		)
+		return events.HITLResponse{
+			RequestID:    id,
+			Cancelled:    true,
+			CancelReason: reason,
+		}, false, nil
+	}
+
 	if err := req.Bus.Emit("hitl.requested", hitlReq); err != nil {
 		return events.HITLResponse{}, false, fmt.Errorf("approval: emit hitl.requested: %w", err)
 	}

--- a/plugins/memory/internal/approval/approval_test.go
+++ b/plugins/memory/internal/approval/approval_test.go
@@ -291,6 +291,103 @@ func TestRequestApproval_UnknownChoiceIDNotAllowed(t *testing.T) {
 	}
 }
 
+// TestRequestApproval_BeforeHandlerMutatesPrompt asserts that a
+// before:hitl.requested subscriber sees the request as a pointer and
+// can mutate its Prompt before the value-emission reaches IO. This is
+// the contract the HITL prompt synthesizer relies on.
+func TestRequestApproval_BeforeHandlerMutatesPrompt(t *testing.T) {
+	bus := engine.NewEventBus()
+
+	bus.Subscribe("before:hitl.requested", func(ev engine.Event[any]) {
+		vp, ok := ev.Payload.(*engine.VetoablePayload)
+		if !ok {
+			return
+		}
+		req, ok := vp.Original.(*events.HITLRequest)
+		if !ok {
+			return
+		}
+		req.Prompt = "synthesized: " + req.Prompt
+	}, engine.WithPriority(-100))
+
+	var captured events.HITLRequest
+	bus.Subscribe("hitl.requested", func(ev engine.Event[any]) {
+		req, ok := ev.Payload.(events.HITLRequest)
+		if !ok {
+			return
+		}
+		captured = req
+		go func() {
+			_ = bus.Emit("hitl.responded", events.HITLResponse{
+				RequestID: req.ID,
+				ChoiceID:  "allow",
+			})
+		}()
+	}, engine.WithPriority(50))
+
+	_, allowed, err := RequestApproval(context.Background(), Request{
+		Bus:        bus,
+		Logger:     testLogger,
+		PluginID:   "test.plugin",
+		ActionKind: "memory.longterm.write",
+		Prompt:     "raw",
+		Timeout:    2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Errorf("expected allowed=true, got false")
+	}
+	if captured.Prompt != "synthesized: raw" {
+		t.Errorf("expected IO subscriber to see mutated prompt, got %q", captured.Prompt)
+	}
+}
+
+// TestRequestApproval_BeforeHandlerVetoCancels confirms that a veto on
+// before:hitl.requested aborts the approval round-trip with a cancelled
+// response and never reaches the non-vetoable hitl.requested form.
+func TestRequestApproval_BeforeHandlerVetoCancels(t *testing.T) {
+	bus := engine.NewEventBus()
+
+	bus.Subscribe("before:hitl.requested", func(ev engine.Event[any]) {
+		vp, ok := ev.Payload.(*engine.VetoablePayload)
+		if !ok {
+			return
+		}
+		vp.Veto = engine.VetoResult{Vetoed: true, Reason: "policy: deny memory writes"}
+	}, engine.WithPriority(-100))
+
+	var ioCalls int
+	bus.Subscribe("hitl.requested", func(ev engine.Event[any]) {
+		ioCalls++
+	}, engine.WithPriority(50))
+
+	resp, allowed, err := RequestApproval(context.Background(), Request{
+		Bus:        bus,
+		Logger:     testLogger,
+		PluginID:   "test.plugin",
+		ActionKind: "memory.longterm.write",
+		Prompt:     "Approve?",
+		Timeout:    1 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("vetoed request must not be allowed")
+	}
+	if !resp.Cancelled {
+		t.Error("vetoed request should resolve as cancelled")
+	}
+	if resp.CancelReason != "policy: deny memory writes" {
+		t.Errorf("expected veto reason forwarded, got %q", resp.CancelReason)
+	}
+	if ioCalls != 0 {
+		t.Errorf("vetoed request must not emit hitl.requested, got %d", ioCalls)
+	}
+}
+
 func TestRequestApproval_MapPayloadResponseDecoded(t *testing.T) {
 	bus := engine.NewEventBus()
 	bus.Subscribe("hitl.requested", func(ev engine.Event[any]) {

--- a/plugins/memory/longterm/plugin.go
+++ b/plugins/memory/longterm/plugin.go
@@ -99,6 +99,7 @@ func (p *Plugin) Emissions() []string {
 		"tool.register",
 		"before:tool.result",
 		"tool.result",
+		"before:hitl.requested",
 		"hitl.requested",
 	}
 }

--- a/plugins/memory/vector/plugin.go
+++ b/plugins/memory/vector/plugin.go
@@ -201,6 +201,7 @@ func (p *Plugin) Emissions() []string {
 		"hybrid.query",
 		"vector.upsert",
 		"rag.retrieved",
+		"before:hitl.requested",
 		"hitl.requested",
 	}
 }


### PR DESCRIPTION
## Summary

Resolves #79 via Option B: every in-tree HITL emitter publishes the canonical vetoable `before:hitl.requested` first (pointer payload, lets `nexus.control.hitl_synthesizer` mutate `Prompt` or veto), then follows up with `hitl.requested` (value payload, what IO plugins consume). Synthesis now fires for the approval gate and memory plugins that previously emitted by value and silently no-op'd.

- `nexus.control.hitl` (ask_user): veto returns rejection to the LLM tool result.
- `nexus.gate.approval_policy`: veto translates to a `before:tool.invoke` / `before:llm.request` veto on the original gated action.
- `plugins/memory/internal/approval` helper (covers `longterm`, `vector`, `compaction`): veto resolves as `Cancelled=true` with the veto reason forwarded.
- Synthesizer keeps the `hitl.requested` subscription as a backward-compat fallback for out-of-tree pointer emitters.
- Pointer-vs-value caveat removed from synthesizer plugin doc, `docs/src/operations/hitl.md`, `docs/src/plugins/control/hitl.md`, gates index, and `docs/src/configuration/reference.md`.

## Test plan

- [x] `go test ./plugins/control/hitl_synthesizer/ ./plugins/gates/approval_policy/ ./plugins/memory/internal/approval/ ./plugins/control/hitl/ ./plugins/memory/{longterm,vector,compaction}/` — all pass
- [x] `make test` — full suite green
- [x] `make vet` / `make lint` (vet + staticcheck) — clean
- [x] New tests: synthesis mutation + veto rejection for both the approval gate and the memory approval helper, plus a synthesizer test that drives the canonical Option B flow end-to-end with an approval-shaped (non-tool) emitter.
- [ ] Smoke-test a config that wires `nexus.control.hitl_synthesizer` + `nexus.gate.approval_policy` and confirm a synthesized prompt reaches the operator. (Manual; CI doesn't cover this path live.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)