### PR TITLE
docs: drop ask_user tool page from sidebar

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -44,7 +44,6 @@
   - [File I/O](./plugins/tools/file.md)
   - [PDF Reader](./plugins/tools/pdf.md)
   - [File Opener](./plugins/tools/opener.md)
-  - [Ask User](./plugins/tools/ask.md)
   - [Code Exec (run_code)](./plugins/tools/code_exec.md)
   - [Knowledge Search](./plugins/tools/knowledge_search.md)
 - [Memory](./plugins/memory/index.md)


### PR DESCRIPTION
## Summary
- `ask_user` was folded into `nexus.control.hitl` and is documented at `plugins/control/hitl.md`
- Removes the empty `plugins/tools/ask.md` stub and its SUMMARY.md entry; `plugins/tools/index.md` already routes the tool to the hitl page

## Test plan
- [x] `mdbook build docs` renders without dead links
- [x] Sidebar no longer shows "Ask User" under Tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)