### PR TITLE
Idea 30: live context curation primitives

### DIFF
--- a/configs/demo-tool-result-clear.yaml
+++ b/configs/demo-tool-result-clear.yaml
@@ -1,0 +1,79 @@
+# Demo: tool-result clearing (Idea 30, layer 1).
+#
+# Aggressive thresholds make a single tool call followed by ONE additional
+# user turn enough to trigger clearing. Watch the `memory.tool_result_cleared`
+# event and the `<tool_result … cleared="true" …/>` envelope replacing the
+# original body in the next outgoing LLM request.
+#
+# Run:
+#   bin/nexus -config configs/demo-tool-result-clear.yaml
+#
+# Suggested transcript (two user messages):
+#   1. "List files in /tmp using shell"
+#        → ReAct calls `shell` with `ls /tmp` (or similar). Tool result body
+#          lands verbatim in history.
+#   2. "Switch topic — tell me a joke."
+#        → Second turn fires. tool_result_clear sees the prior tool result is
+#          1 turn old AND larger than 50 bytes; it replaces the body with the
+#          envelope marker before the request leaves the agent.
+#
+# Inspect the swap by tailing the session journal:
+#   tail -f ~/.nexus/sessions/<session-id>/journal/*.jsonl | grep -E \
+#       'memory\.tool_result_cleared|memory\.curated|tool\.result'
+#
+# Or enable info-level logging (already set below) and look for
+# "tool_result_clear" entries in the run output.
+
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: quick
+    quick:
+      provider: nexus.llm.anthropic
+      model: claude-haiku-4-5-20251001
+      max_tokens: 2048
+  sessions:
+    root: ~/.nexus/sessions
+    retention: 7d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.tui
+    - nexus.llm.anthropic
+    - nexus.agent.react
+    - nexus.gate.endless_loop
+    - nexus.memory.capped
+    - nexus.memory.tool_result_clear
+    - nexus.tool.shell
+
+  nexus.llm.anthropic:
+    api_key_env: ANTHROPIC_API_KEY
+
+  nexus.agent.react:
+    system_prompt: |
+      You are a demo assistant. When the user asks for files or directory
+      listings, use the shell tool. Keep responses short.
+
+  nexus.gate.endless_loop:
+    max_iterations: 5
+
+  nexus.memory.capped:
+    max_messages: 50
+    persist: true
+
+  # Aggressive thresholds — clear anything older than 1 turn + over 50 bytes.
+  # Production defaults are 5 turns / 1000 bytes; this config exists to make
+  # the layer easy to observe with a short transcript.
+  nexus.memory.tool_result_clear:
+    enabled: true
+    age_turns: 1
+    size_bytes_threshold: 50
+    preserve_recent_kinds: ["error"]
+    drop_strategy: replace_with_envelope
+
+  nexus.tool.shell:
+    allowed_commands: [ls, cat, pwd, echo, head, wc, find]
+    timeout: 10s

--- a/configs/test-tool-result-clear.yaml
+++ b/configs/test-tool-result-clear.yaml
@@ -1,0 +1,82 @@
+# Test: tool-result clearing fires after a tool call ages past the
+# configured threshold and the next user turn arrives.
+#
+# Mocked LLM — no API key. Sequence:
+#   user msg #1: tool call → tool result (1500-byte payload)
+#   user msg #2: assistant text (turn ends, p.turn = 1)
+#                tool_result_clear sees the prior result is age >= 1 + size
+#                >= 50 bytes; replaces body with envelope marker.
+#
+# Run:
+#   go test -tags integration ./tests/integration/ -run TestToolResultClear
+
+core:
+  log_level: warn
+  tick_interval: 5s
+  max_concurrent_events: 100
+  models:
+    default: mock
+    mock:
+      provider: nexus.llm.anthropic
+      model: mock
+      max_tokens: 4096
+  sessions:
+    root: ~/.nexus/test-sessions
+    retention: 30d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.test
+    - nexus.llm.anthropic
+    - nexus.agent.react
+    - nexus.gate.endless_loop
+    - nexus.tool.shell
+    - nexus.memory.capped
+    - nexus.memory.tool_result_clear
+
+  nexus.io.test:
+    inputs:
+      - "Run echo to produce a long string."
+      - "Tell me a joke."
+    input_delay: 200ms
+    approval_mode: approve
+    timeout: 30s
+    # Turn 1 (user msg #1):
+    #   #1: tool_call shell → echo a long string (well over 50 bytes)
+    #   #2: final assistant content closes the turn
+    # Turn 2 (user msg #2):
+    #   #3: final assistant content closes the turn — at this point
+    #       tool_result_clear sees the prior tool result is age >= 1 +
+    #       size >= 50 and replaces its body with the envelope marker.
+    mock_responses:
+      - tool_calls:
+          - name: shell
+            arguments: '{"command":"echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
+      - content: "Echoed."
+      - content: "Two cows in a field, one says to the other..."
+
+  nexus.llm.anthropic:
+    api_key: "sk-mock-not-used"
+
+  nexus.agent.react:
+    system_prompt: "Use the tools when asked."
+
+  nexus.gate.endless_loop:
+    max_iterations: 4
+
+  nexus.tool.shell:
+    allowed_commands: [echo]
+    timeout: 5s
+
+  nexus.memory.capped:
+    max_messages: 50
+    persist: false
+
+  # Aggressive thresholds: age 1 turn, 50 bytes — guaranteed to fire
+  # after one tool call followed by one extra user turn.
+  nexus.memory.tool_result_clear:
+    enabled: true
+    age_turns: 1
+    size_bytes_threshold: 50
+    drop_strategy: replace_with_envelope

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,7 @@
 - [Model Registry](./architecture/models.md)
 - [Prompt Registry](./architecture/prompts.md)
 - [Hot Reload](./architecture/hot-reload.md)
+- [Context Engineering](./architecture/context-engineering.md)
 
 # Desktop Shell
 
@@ -53,6 +54,9 @@
   - [Capped History](./plugins/memory/capped.md)
   - [Summary-Buffer History](./plugins/memory/summary_buffer.md)
   - [Context Compaction](./plugins/memory/compaction.md)
+  - [Tool-Result Clearing](./plugins/memory/tool_result_clear.md)
+  - [Tool-Definition Pruner](./plugins/memory/tool_def_pruner.md)
+  - [Topic-Aware Pruner](./plugins/memory/topic_pruner.md)
   - [Long-Term Memory](./plugins/memory/longterm.md)
   - [Vector Memory](./plugins/memory/vector.md)
 - [Embeddings](./plugins/embeddings/index.md)

--- a/docs/src/architecture/context-engineering.md
+++ b/docs/src/architecture/context-engineering.md
@@ -1,0 +1,92 @@
+# Context Engineering
+
+The conversation history is the LLM's working memory. Every byte costs
+tokens, slows the model, and competes with other content for attention.
+Nexus exposes a layered context-curation stack so operators can shed
+weight aggressively without losing the reasoning chain.
+
+## Layers
+
+The stack runs in cost order on every `before:llm.request`. Cheaper
+deterministic layers fire first; LLM-touching layers run only when the
+prior layers leave the request still over budget.
+
+| # | Layer | Plugin | Cost | Cache Impact |
+|---|-------|--------|------|--------------|
+| 1 | Tool-result clearing | [`nexus.memory.tool_result_clear`](../plugins/memory/tool_result_clear.md) | None (heuristic) | volatile |
+| 2 | Tool-def pruning | [`nexus.memory.tool_def_pruner`](../plugins/memory/tool_def_pruner.md) | None (heuristic) | session (re-cache once) |
+| 3 | Topic-shift detection | [`nexus.memory.topic_pruner`](../plugins/memory/topic_pruner.md) | One classifier or phrase match | volatile |
+| 4 | Reasoning-preserving summary | [`nexus.memory.summary_buffer`](../plugins/memory/summary_buffer.md) | One LLM call | session (re-cache once) |
+| 5 | Compaction-and-restart | [`nexus.memory.compaction`](../plugins/memory/compaction.md) | One LLM call (full reset) | session (re-cache once) |
+
+Curators never edit the static section — system prompt and operator-set
+content are off-limits.
+
+## Stability Descriptor
+
+Every layer emits a `memory.curated` envelope event carrying a
+stability-impact descriptor:
+
+```go
+type MemoryCurated struct {
+    Layer            string             // which layer ran
+    SectionsTouched  []CurationSection  // section_id, kind, tokens_delta
+    CacheInvalidates bool               // does any touched section cross the cache prefix?
+    AtTurn           int                // turn boundary
+}
+```
+
+`CurationSection.Kind` is one of:
+
+- `volatile` — recent turns; no cache impact.
+- `session` — session-long content (compaction summary, tool definitions);
+  controlled re-cache, charged once and amortised.
+- `static` — system prompt / tool defs (forbidden — curator must not
+  touch).
+
+A future cache-aware prompt builder (Idea 05) consumes this descriptor
+to scope re-cache cost. Until that lands, curations batch at turn
+boundaries to keep cache invalidations predictable.
+
+## Replay Determinism
+
+Curation is heuristic and classifier-driven, so curators emit one
+event per decision (`memory.tool_result_cleared`,
+`memory.tool_def_pruned`, `memory.topic_shift_detected`,
+`memory.summary_replaced`). The durable journal (Idea 01) records every
+envelope so replay reproduces curation by replaying decisions, not by
+re-running heuristics.
+
+## Provider-side vs Harness-side
+
+Anthropic's server-side `tool_result_clear` and `system_message_edit`
+primitives, and OpenAI Responses API truncation policies, do similar
+work in-provider. Nexus defaults to harness-side curation for
+portability — every layer works the same regardless of which provider
+the request lands on. Provider-native primitives can be enabled as an
+opt-in optimisation when the configured provider supports them.
+
+## Eval-Driven Tuning
+
+The eval harness (Idea 07) supports curation-on/off pivots so operators
+can compare task-success-rate against the cost savings of an aggressive
+preset. Keep defaults conservative until eval data justifies tightening.
+
+## Composing the Stack
+
+A typical full stack:
+
+```yaml
+plugins:
+  active:
+    - nexus.agent.react
+    - nexus.memory.summary_buffer       # base history with reasoning-preserving summary
+    - nexus.memory.tool_result_clear    # layer 1
+    - nexus.memory.tool_def_pruner      # layer 2
+    - nexus.memory.topic_pruner         # layer 3
+    - nexus.discovery.progressive       # complements layer 2 (class-level scoping)
+    - nexus.gate.context_window         # last-resort compaction trigger
+```
+
+Layer 5 (compaction-and-restart) is implicit when the context-window
+gate fires the existing `nexus.memory.compaction` coordinator.

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -848,8 +848,10 @@ Source: `plugins/memory/summary_buffer/plugin.go`. Provides both
 | `max_recent`        | int    | `8`              | Messages kept verbatim; older messages are summarized. |
 | `model_role`        | string | `quick`          | Role used for the summary call. |
 | `model`             | string | *(none)*         | Explicit model ID (ignored if `model_role` is set). |
-| `prompt`            | string | *(default)*      | Inline summary prompt. |
+| `prompt`            | string | *(default)*      | Inline summary prompt. The default prompt is reasoning-preservation aware: it instructs the summariser to wrap segments in `<summary topic="…" compressed-from-turns="…">…</summary>` and end with a `## Preserved Kinds:` trailer. Overriding loses both behaviours. |
 | `prompt_file`       | string | *(none)*         | Path to a summary prompt file (overrides `prompt`). |
+| `quality_retry`     | bool   | `false`          | When `true`, the plugin re-runs the summariser once with a stricter prompt if the trailer omits any required preserved kind. Off by default for backwards compatibility. |
+| `require_preserved_kinds` | []string | `["decision", "rationale"]` | Kinds whose presence in the trailer is required when `quality_retry: true`. Allowed values: `decision`, `rationale`, `error`, `next_step`, `technical_detail`. |
 
 ### `nexus.memory.compaction`
 
@@ -913,6 +915,69 @@ Source: `plugins/memory/vector/plugin.go`. Provides `memory.vector`. Requires
 | `require_approval.timeout`                    | duration | *(none)*  | Optional deadline (`5m`, `30s`, …). |
 | `require_approval.match.namespace_glob`       | string   | *(any)*   | Only require approval when the configured `namespace` matches this glob. |
 | `require_approval.match.size_threshold_bytes` | int      | *(any)*   | Only require approval when the document content is at least this many bytes. |
+
+### `nexus.memory.tool_result_clear`
+
+Source: `plugins/memory/tool_result_clear/plugin.go`. Live curator that
+replaces stale tool-result bodies in outgoing `LLMRequest.Messages` with an
+inline `<tool_result … cleared="true" …/>` envelope. The original
+call/result pairing stays in history so the agent retains the fact of the
+call. Runs at priority 12 on `before:llm.request` (after
+`nexus.discovery.progressive`).
+
+| Key                    | Type     | Default                          | Description |
+|------------------------|----------|----------------------------------|-------------|
+| `enabled`              | bool     | `true`                           | Toggle the curator. |
+| `age_turns`            | int      | `5`                              | Clear tool results older than this many turns when also exceeding the size threshold. |
+| `size_bytes_threshold` | int      | `1000`                           | Skip clearing for result bodies smaller than this many bytes. |
+| `preserve_recent_kinds`| []string | `["error", "user_question"]`     | Result kinds that are never cleared regardless of age. |
+| `drop_strategy`        | string   | `replace_with_envelope`          | `replace_with_envelope` keeps the call/result pair with a marker body; `full_drop` removes the message entirely (risks tool_use/tool_result pairing breakage). |
+
+Emits `memory.tool_result_cleared` (per cleared call) and `memory.curated`
+(stability descriptor for the cache-aware prompt builder).
+
+### `nexus.memory.tool_def_pruner`
+
+Source: `plugins/memory/tool_def_pruner/plugin.go`. Drops individual tool
+definitions from outgoing `LLMRequest.Tools` when they have been idle past
+`unused_turns_threshold`. Pairs with `nexus.discovery.progressive` —
+progressive scopes by class, this scopes per tool. Runs at priority 14 on
+`before:llm.request`.
+
+| Key                      | Type     | Default                  | Description |
+|--------------------------|----------|--------------------------|-------------|
+| `enabled`                | bool     | `true`                   | Toggle the pruner. |
+| `unused_turns_threshold` | int      | `6`                      | Drop a tool definition after this many consecutive turns without an invocation. |
+| `never_prune`            | []string | `["discover","ask_user"]`| Tool names exempt from pruning (e.g. discovery's meta-tool, HITL ask-user). |
+
+Emits `memory.tool_def_pruned` and `memory.curated`. The `MemoryCurated`
+event marks `cache_invalidates: true` because the tool list is part of the
+session-cached prefix.
+
+### `nexus.memory.topic_pruner`
+
+Source: `plugins/memory/topic_pruner/plugin.go`. Detects topic boundaries
+in user input and emits `memory.topic_shift_detected`. Two signals are
+combined:
+
+- Explicit-phrase matching ("different question", "new topic", "let's
+  move on", …) — cheap, deterministic.
+- Embedding similarity drop against the rolling topic centroid — runs only
+  when an `embeddings.provider` is active.
+
+The plugin does not itself rewrite history; it surfaces the shift so other
+plugins (summary buffer, compaction) can react. Topic boundaries are
+journalled for replay determinism.
+
+| Key                    | Type     | Default                                 | Description |
+|------------------------|----------|-----------------------------------------|-------------|
+| `enabled`              | bool     | `true`                                  | Toggle the pruner. |
+| `similarity_threshold` | float    | `0.55`                                  | Cosine similarity below which a new user input flags a topic shift. Used only when an `embeddings.provider` is active. |
+| `keep_last_topic_full` | bool     | `true`                                  | Reserved — informs downstream consumers whether the most recent topic should remain verbatim. |
+| `explicit_phrases`     | []string | `["different question", "different topic", "new topic", "new question", "let's move on", "moving on", "change of subject", "switching gears", "unrelated:", "separately,", "on a different note"]` | Lowercase substrings that signal a topic shift. Replacing the list disables the defaults. |
+
+Emits `memory.topic_shift_detected` and `memory.curated`. Same-turn
+duplicate signals are debounced.
 
 ---
 

--- a/docs/src/plugins/memory/summary_buffer.md
+++ b/docs/src/plugins/memory/summary_buffer.md
@@ -34,8 +34,10 @@ summarised view is what the ReAct agent sees on the next request.
 | `max_recent` | int | `8` | Number of recent messages kept verbatim after summarisation |
 | `model_role` | string | `"quick"` | Role used to dispatch the summarisation LLM request |
 | `model` | string | `""` | Explicit model override; otherwise inferred from the role |
-| `prompt` | string | _built-in_ | Inline override of the summarisation system prompt |
+| `prompt` | string | _built-in_ | Inline override of the summarisation system prompt. The default prompt is reasoning-preservation aware: it instructs the summariser to wrap segments in `<summary topic="…" compressed-from-turns="…">…</summary>` and end with a `## Preserved Kinds:` trailer. Overriding loses both behaviours. |
 | `prompt_file` | string | _unset_ | Path to a file containing the summarisation prompt (takes precedence over `prompt`) |
+| `quality_retry` | bool | `false` | Re-run the summariser once with a stricter prompt when the trailer omits any required preserved kind. Off by default for backwards compatibility. |
+| `require_preserved_kinds` | []string | `["decision","rationale"]` | Trailer kinds whose presence is required when `quality_retry: true`. Allowed values: `decision`, `rationale`, `error`, `next_step`, `technical_detail`. |
 
 ## Events
 
@@ -58,6 +60,8 @@ summarised view is what the ReAct agent sees on the next request.
 | `llm.request` | When a summarisation trigger fires. Tagged `Metadata["_source"] = "nexus.memory.summary_buffer"` |
 | `memory.compaction.triggered` | Start of each summarisation cycle |
 | `memory.compacted` | End of each summarisation cycle, with the new buffer contents |
+| `memory.summary_replaced` | Span-level replacement event with from-turn range, original/summary token estimates, and the trailer-reported preserved kinds |
+| `memory.curated` | Stability descriptor for the cache-aware prompt builder (`Layer: "summary_buffer"`, `CacheInvalidates: true`) |
 | `io.status` | UI status updates: `"Summarising context..."` / `"idle"` |
 
 ## Behaviour

--- a/docs/src/plugins/memory/tool_def_pruner.md
+++ b/docs/src/plugins/memory/tool_def_pruner.md
@@ -1,0 +1,69 @@
+# Tool-Definition Pruner
+
+Removes individual tool definitions from outgoing `LLMRequest.Tools`
+when those tools have been idle past a turn threshold. Pairs with
+[`nexus.discovery.progressive`](../tools/discovery.md): progressive scopes
+by class, this scopes per individual tool.
+
+For sessions where the agent loaded 30 tool definitions in turn 4 but
+only uses 3 of them, the pruner keeps the unused 27 from paying tokens
+on every subsequent request.
+
+## Details
+
+| | |
+|---|---|
+| **ID** | `nexus.memory.tool_def_pruner` |
+| **Capabilities** | _none_ |
+| **Dependencies** | _none_ |
+
+Operates at priority 14 on `before:llm.request` — after both
+`nexus.discovery.progressive` (8) and `nexus.memory.tool_result_clear`
+(12) have shaped the request.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Toggle the pruner. |
+| `unused_turns_threshold` | int | `6` | Drop a tool definition after this many consecutive turns without an invocation. |
+| `never_prune` | []string | `["discover","ask_user"]` | Tool names exempt from pruning. |
+
+## Behaviour
+
+- Subscribes to `tool.invoke` to reset the per-tool last-used counter on
+  every successful call. A pruned tool that the agent invokes again is
+  un-pruned automatically — typically by going back through
+  `discovery/progressive`'s `discover` meta-tool.
+- First sight of a tool registers it at the current turn rather than
+  zero, so freshly-loaded tools aren't pruned the moment they appear.
+
+## Events
+
+### Subscribes To
+
+| Event | Priority | Purpose |
+|-------|----------|---------|
+| `tool.invoke` | 60 | Reset per-tool last-used counter |
+| `agent.turn.end` | 60 | Increment internal turn counter |
+| `before:llm.request` | 14 | Filter `req.Tools` |
+
+### Emits
+
+| Event | When |
+|-------|------|
+| `memory.tool_def_pruned` | Per pruned tool (carries `tool_id`, `last_used_turn`, `definition_size`) |
+| `memory.curated` | Envelope event (`Layer: "tool_def_pruner"`, `CacheInvalidates: true` — tool defs are part of the cached prefix) |
+
+## Example Configuration
+
+```yaml
+plugins:
+  active:
+    - nexus.agent.react
+    - nexus.memory.tool_def_pruner
+
+  nexus.memory.tool_def_pruner:
+    unused_turns_threshold: 6
+    never_prune: ["discover", "ask_user", "memory_read"]
+```

--- a/docs/src/plugins/memory/tool_result_clear.md
+++ b/docs/src/plugins/memory/tool_result_clear.md
@@ -1,0 +1,90 @@
+# Tool-Result Clearing
+
+Live curator that drops the body of stale tool results from outgoing LLM
+requests while keeping the call/result envelope. The model still sees that
+the tool was invoked; the (often large) body is replaced inline with a
+`<tool_result … cleared="true" …/>` marker.
+
+This is the highest-leverage layer in Idea 30's curation stack — for
+tool-heavy sessions, 50–80% of context bytes are tool-result bodies,
+most of which are dead weight by the time the next request fires.
+
+## Details
+
+| | |
+|---|---|
+| **ID** | `nexus.memory.tool_result_clear` |
+| **Capabilities** | _none_ |
+| **Dependencies** | _none_ |
+
+Operates at priority 12 on `before:llm.request` — after
+`nexus.discovery.progressive` (priority 8) has shaped the tool list, then
+re-shapes the outgoing message slice without touching the upstream
+history buffer.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Toggle the curator. |
+| `age_turns` | int | `5` | Clear tool results older than this many turns when also exceeding `size_bytes_threshold`. |
+| `size_bytes_threshold` | int | `1000` | Skip clearing for result bodies smaller than this many bytes. |
+| `preserve_recent_kinds` | []string | `["error","user_question"]` | Result kinds never cleared regardless of age. |
+| `drop_strategy` | string | `replace_with_envelope` | `replace_with_envelope` keeps the call/result pair with a marker body (default). `full_drop` removes the message entirely; risks tool_use/tool_result pairing breakage. |
+
+## Heuristics
+
+A tool result is cleared when **any** of the following hold:
+
+- **Age + size** — `now_turn − call_turn ≥ age_turns` AND
+  `len(result) ≥ size_bytes_threshold`.
+- **Subsequent-call** — the same tool was invoked later with semantically
+  equivalent arguments (canonical-JSON hash). Earlier results are
+  redundant.
+- **Preserved kind exemption** — results classified as `error` (and any
+  kind listed in `preserve_recent_kinds`) are never cleared.
+
+Once an ID is cleared, it stays cleared for the remainder of the session
+— subsequent requests re-replace deterministically without re-running the
+heuristic.
+
+## Events
+
+### Subscribes To
+
+| Event | Priority | Purpose |
+|-------|----------|---------|
+| `tool.invoke` | 60 | Track call name, canonical args hash, and turn |
+| `tool.result` | 60 | Record result size and kind classification |
+| `agent.turn.end` | 60 | Increment internal turn counter |
+| `before:llm.request` | 12 | Mutate `req.Messages`, replace stale tool result bodies |
+
+### Emits
+
+| Event | When |
+|-------|------|
+| `memory.tool_result_cleared` | Once per cleared call (carries `tool_call_id`, `tool`, `original_size`, `cleared_at_turn`, `reason`) |
+| `memory.curated` | Envelope event with stability descriptor (`Layer: "tool_result_clear"`, `CacheInvalidates: false`) |
+
+## Replay Determinism
+
+The clearing decision is heuristic, but every cleared call is recorded as
+a `memory.tool_result_cleared` event. The durable journal (Idea 01)
+captures these events so replay reproduces the same envelope without
+re-running the heuristic.
+
+## Example Configuration
+
+```yaml
+plugins:
+  active:
+    - nexus.agent.react
+    - nexus.memory.tool_result_clear
+
+  nexus.memory.tool_result_clear:
+    enabled: true
+    age_turns: 4
+    size_bytes_threshold: 512
+    preserve_recent_kinds: ["error", "user_question"]
+    drop_strategy: replace_with_envelope
+```

--- a/docs/src/plugins/memory/topic_pruner.md
+++ b/docs/src/plugins/memory/topic_pruner.md
@@ -1,0 +1,87 @@
+# Topic-Aware Pruner
+
+Detects topic boundaries in user input and emits
+`memory.topic_shift_detected`. The pruner does not itself rewrite
+history; it surfaces the shift so other plugins (summary buffer,
+compaction) can react.
+
+## Details
+
+| | |
+|---|---|
+| **ID** | `nexus.memory.topic_pruner` |
+| **Capabilities** | _none_ |
+| **Dependencies** | _none_; uses `embeddings.provider` opportunistically when one is registered. |
+
+Two signals are combined:
+
+- **Explicit phrase** — substring match against a configurable list
+  (`"different question"`, `"new topic"`, `"let's move on"`, etc.).
+  Cheap, deterministic. Lead-anchored phrases (`"unrelated:"`,
+  `"separately,"`) are tagged `user_explicit`; substring matches are
+  tagged `phrase`.
+- **Embedding similarity** — cosine similarity between the latest user
+  input and the rolling centroid of the current topic's user inputs.
+  Below the configured threshold flags a shift. Runs only when an
+  `embeddings.provider` is active. Tagged `embedding`.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Toggle the pruner. |
+| `similarity_threshold` | float | `0.55` | Cosine similarity below which a new user input flags a topic shift. Used only when an `embeddings.provider` is active. |
+| `keep_last_topic_full` | bool | `true` | Reserved for downstream consumers. |
+| `explicit_phrases` | []string | _see code_ | Lowercase substrings that signal a topic shift. Replacing the list disables the defaults. |
+
+Defaults for `explicit_phrases`:
+
+```
+"different question", "different topic", "new topic", "new question",
+"let's move on", "moving on", "change of subject", "switching gears",
+"unrelated:", "separately,", "on a different note"
+```
+
+## Events
+
+### Subscribes To
+
+| Event | Priority | Purpose |
+|-------|----------|---------|
+| `io.input` | 60 | Run the classifier on every user input |
+| `agent.turn.end` | 60 | Track the current turn for debouncing |
+
+### Emits
+
+| Event | When |
+|-------|------|
+| `memory.topic_shift_detected` | Per detected shift (carries `from_turn`, `to_turn`, `similarity`, `signal`) |
+| `memory.curated` | Envelope event (`Layer: "topic_pruner"`, `CacheInvalidates: false`) |
+| `embeddings.request` | Pointer-payload request when an `embeddings.provider` is active |
+
+Same-turn duplicate signals are debounced — at most one shift event
+per turn boundary.
+
+## Replay Determinism
+
+Topic-shift decisions are non-deterministic (heuristic + embeddings).
+Each decision is journalled as a `memory.topic_shift_detected` event
+(Idea 01) so replay reproduces the same boundaries.
+
+## Example Configuration
+
+```yaml
+plugins:
+  active:
+    - nexus.agent.react
+    - nexus.memory.topic_pruner
+    - nexus.embeddings.openai   # optional; enables the embedding signal
+
+  nexus.memory.topic_pruner:
+    enabled: true
+    similarity_threshold: 0.55
+    explicit_phrases:
+      - "different question"
+      - "new topic"
+      - "moving on"
+```

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -32,6 +32,9 @@ import (
 	longtermplugin "github.com/frankbardon/nexus/plugins/memory/longterm"
 	"github.com/frankbardon/nexus/plugins/memory/simple"
 	"github.com/frankbardon/nexus/plugins/memory/summary_buffer"
+	tooldefpruner "github.com/frankbardon/nexus/plugins/memory/tool_def_pruner"
+	toolresultclear "github.com/frankbardon/nexus/plugins/memory/tool_result_clear"
+	topicpruner "github.com/frankbardon/nexus/plugins/memory/topic_pruner"
 	vectorplugin "github.com/frankbardon/nexus/plugins/memory/vector"
 
 	// Observer plugins.
@@ -146,6 +149,9 @@ func RegisterAll(r *engine.PluginRegistry) {
 	r.Register("nexus.memory.compaction", compactionplugin.New)
 	r.Register("nexus.memory.longterm", longtermplugin.New)
 	r.Register("nexus.memory.vector", vectorplugin.New)
+	r.Register("nexus.memory.tool_result_clear", toolresultclear.New)
+	r.Register("nexus.memory.tool_def_pruner", tooldefpruner.New)
+	r.Register("nexus.memory.topic_pruner", topicpruner.New)
 
 	// Observers
 	r.Register("nexus.observe.thinking", thinkingplugin.New)

--- a/pkg/events/memory.go
+++ b/pkg/events/memory.go
@@ -20,6 +20,13 @@ const (
 	LongTermMemoryListResultVersion    = 1
 	CompactionTriggeredVersion         = 1
 	CompactionCompleteVersion          = 1
+
+	// Idea 30 — live context curation events.
+	MemoryToolResultClearedVersion  = 1
+	MemoryToolDefPrunedVersion      = 1
+	MemoryTopicShiftDetectedVersion = 1
+	MemorySummaryReplacedVersion    = 1
+	MemoryCuratedVersion            = 1
 )
 
 // MemoryEntry represents a single memory record.
@@ -167,4 +174,91 @@ type CompactionComplete struct {
 	BackupPath   string    // session-relative path to the backup file
 	MessageCount int       // number of messages after compaction
 	PrevCount    int       // number of messages before compaction
+}
+
+// --- Idea 30: live context curation events ---
+
+// MemoryToolResultCleared signals that a tool result body has been replaced
+// with an envelope marker by the live curator. The call/result pairing stays
+// in history; only the body is gone.
+type MemoryToolResultCleared struct {
+	SchemaVersion int `json:"_schema_version"`
+
+	ToolCallID    string `json:"tool_call_id"`
+	Tool          string `json:"tool"`
+	OriginalSize  int    `json:"original_size"`
+	ClearedAtTurn int    `json:"cleared_at_turn"`
+	Reason        string `json:"reason"` // "age", "subsequent_call", "no_citation", "synthesis_detected"
+}
+
+// MemoryToolDefPruned signals that a tool definition has been demoted out
+// of the LLM-visible tool list because it has been idle too long. Restoration
+// happens implicitly via discovery on next mention.
+type MemoryToolDefPruned struct {
+	SchemaVersion int `json:"_schema_version"`
+
+	ToolID         string `json:"tool_id"`
+	LastUsedTurn   int    `json:"last_used_turn"`
+	DefinitionSize int    `json:"definition_size"`
+}
+
+// MemoryTopicShiftDetected signals the topic pruner observed a topic
+// boundary in the conversation.
+type MemoryTopicShiftDetected struct {
+	SchemaVersion int `json:"_schema_version"`
+
+	FromTurn   int     `json:"from_turn"`
+	ToTurn     int     `json:"to_turn"`
+	Similarity float64 `json:"similarity"`
+	Signal     string  `json:"signal"` // "embedding" | "phrase" | "user_explicit"
+}
+
+// MemorySummaryReplaced signals that a span of the conversation has been
+// replaced with a reasoning-preserving summary. Distinct from
+// CompactionComplete — that event reports a full-buffer rewrite; this one
+// reports a span-level replacement.
+type MemorySummaryReplaced struct {
+	SchemaVersion int `json:"_schema_version"`
+
+	FromTurns      [2]int   `json:"from_turns"` // [start, end] inclusive turn range
+	OriginalTokens int      `json:"original_tokens"`
+	SummaryTokens  int      `json:"summary_tokens"`
+	PreservedKinds []string `json:"preserved_kinds"` // e.g. ["decision","rationale","error","next_step"]
+}
+
+// CurationSection describes one section of context touched by a curation
+// pass. Used by MemoryCurated to convey stability impact.
+type CurationSection struct {
+	// SectionID is an opaque identifier for the section that was edited.
+	// Convention: "<plugin-id>/<scope>" e.g. "nexus.memory.tool_result_clear/turn-12"
+	// or "nexus.memory.summary_buffer/range-3-8".
+	SectionID string `json:"section_id"`
+	// Kind is the cache-stability category. "volatile" = recent turns
+	// (no cache impact); "session" = session-long content like compaction
+	// summaries (controlled re-cache); "static" = system prompt / tool defs
+	// (curator must not touch these).
+	Kind string `json:"kind"`
+	// TokensDelta is the post-edit minus pre-edit token estimate. Negative
+	// for shrinkage (the common case); positive for replacements that grew.
+	TokensDelta int `json:"tokens_delta"`
+}
+
+// MemoryCurated is the envelope event emitted by every curation layer.
+// It carries the stability-impact descriptor consumed by the cache-aware
+// prompt builder (Idea 05) so cache invalidation cost is scoped.
+type MemoryCurated struct {
+	SchemaVersion int `json:"_schema_version"`
+
+	// Layer names the curation layer that ran (e.g. "tool_result_clear",
+	// "tool_def_pruner", "topic_pruner", "summary_buffer").
+	Layer string `json:"layer"`
+	// SectionsTouched describes every section the layer edited.
+	SectionsTouched []CurationSection `json:"sections_touched"`
+	// CacheInvalidates is true when at least one touched section is in
+	// the cached prefix and the prompt builder must re-cache. False when
+	// every touched section is volatile (no impact).
+	CacheInvalidates bool `json:"cache_invalidates"`
+	// AtTurn is the turn boundary at which the curation ran. Curations
+	// batch at turn boundaries to keep cache invalidations predictable.
+	AtTurn int `json:"at_turn"`
 }

--- a/pkg/events/version_test.go
+++ b/pkg/events/version_test.go
@@ -79,6 +79,19 @@ func versionedPayloads() []versionedPayload {
 		{"LongTermMemoryListResult", func() any { return LongTermMemoryListResult{SchemaVersion: LongTermMemoryListResultVersion} }, LongTermMemoryListResultVersion},
 		{"CompactionTriggered", func() any { return CompactionTriggered{SchemaVersion: CompactionTriggeredVersion} }, CompactionTriggeredVersion},
 		{"CompactionComplete", func() any { return CompactionComplete{SchemaVersion: CompactionCompleteVersion} }, CompactionCompleteVersion},
+		{"MemoryToolResultCleared", func() any {
+			return MemoryToolResultCleared{SchemaVersion: MemoryToolResultClearedVersion}
+		}, MemoryToolResultClearedVersion},
+		{"MemoryToolDefPruned", func() any {
+			return MemoryToolDefPruned{SchemaVersion: MemoryToolDefPrunedVersion}
+		}, MemoryToolDefPrunedVersion},
+		{"MemoryTopicShiftDetected", func() any {
+			return MemoryTopicShiftDetected{SchemaVersion: MemoryTopicShiftDetectedVersion}
+		}, MemoryTopicShiftDetectedVersion},
+		{"MemorySummaryReplaced", func() any {
+			return MemorySummaryReplaced{SchemaVersion: MemorySummaryReplacedVersion}
+		}, MemorySummaryReplacedVersion},
+		{"MemoryCurated", func() any { return MemoryCurated{SchemaVersion: MemoryCuratedVersion} }, MemoryCuratedVersion},
 		// skill.go
 		{"SkillCatalog", func() any { return SkillCatalog{SchemaVersion: SkillCatalogVersion} }, SkillCatalogVersion},
 		{"SkillActivation", func() any { return SkillActivation{SchemaVersion: SkillActivationVersion} }, SkillActivationVersion},

--- a/plugins/agents/react/plugin.go
+++ b/plugins/agents/react/plugin.go
@@ -245,8 +245,12 @@ func (p *Plugin) handleLLMResponseEvent(event engine.Event[any]) {
 	if !ok {
 		return
 	}
-	// Skip responses tagged for other plugins (e.g., planner LLM calls).
-	if source, _ := resp.Metadata["_source"].(string); source != "" {
+	// Skip responses tagged for other plugins (planner, summary buffer,
+	// subagent, etc.). Since Idea 09 the agent tags its own request with
+	// `_source = pluginID` for cost attribution and providers propagate
+	// that onto the response, so an empty-source check would skip our
+	// own reply too.
+	if source, _ := resp.Metadata["_source"].(string); source != "" && source != pluginID {
 		return
 	}
 	p.handleLLMResponse(resp)

--- a/plugins/gates/tool_filter/plugin.go
+++ b/plugins/gates/tool_filter/plugin.go
@@ -106,8 +106,12 @@ func (p *Plugin) handleBeforeLLMRequest(event engine.Event[any]) {
 		return
 	}
 
-	// Skip gate-originated or planner LLM requests.
-	if src, _ := req.Metadata["_source"].(string); src != "" {
+	// Filter is meaningful only when the request actually carries tools.
+	// Requests without tools (planner, summariser, classifier router probes)
+	// fall through as no-ops — these once short-circuited via a non-empty
+	// `_source` check, but Idea 09 made every agent main request tag itself
+	// with its own pluginID, which broke that heuristic.
+	if len(req.Tools) == 0 {
 		return
 	}
 

--- a/plugins/memory/capped/plugin.go
+++ b/plugins/memory/capped/plugin.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/frankbardon/nexus/pkg/engine"
 	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/plugins/memory/internal/internalflow"
 )
 
 const pluginID = "nexus.memory.capped"
@@ -198,7 +199,7 @@ func (p *Plugin) handleLLMResponse(e engine.Event[any]) {
 	if !ok {
 		return
 	}
-	if source, _ := resp.Metadata["_source"].(string); source != "" {
+	if internalflow.SkipForHistory(resp.Metadata) {
 		return
 	}
 	p.appendMessage(events.Message{

--- a/plugins/memory/internal/internalflow/internalflow.go
+++ b/plugins/memory/internal/internalflow/internalflow.go
@@ -1,0 +1,39 @@
+// Package internalflow centralises the predicate every memory plugin
+// uses to skip recording assistant messages produced by internal sub-flows
+// (planner, classifier router, summariser, compaction, subagent).
+//
+// The earlier predicate — "skip when LLMResponse.Metadata[\"_source\"] is
+// non-empty" — was correct until Idea 09 (#83) made every agent main
+// request tag itself with `_source = pluginID` for cost attribution.
+// Provider plugins propagate request metadata onto the response, so under
+// the old predicate every agent main response was silently dropped from
+// history along with its tool_use blocks. Anthropic then rejected the
+// next request with "unexpected tool_use_id found in tool_result blocks".
+//
+// The fix targets task_kind instead: each internal sub-flow has a stable
+// task_kind value, and main agent loops do not appear in this set.
+package internalflow
+
+// internalTaskKinds enumerates the task_kind values produced by sub-flows
+// memory plugins should not record in the main conversation history.
+// Agent main loops (react_main, planexec_step, orchestrator_decompose,
+// orchestrator_synthesize) are deliberately excluded — they ARE the
+// conversation.
+var internalTaskKinds = map[string]bool{
+	"plan":      true, // dynamic / static planner
+	"classify":  true, // classifier router probe
+	"summarise": true, // summary_buffer / compaction summary call
+	"compact":   true, // explicit compaction
+	"subagent":  true, // subagent has its own scratch history
+}
+
+// SkipForHistory returns true when the response metadata indicates an
+// internal sub-flow whose output must not be recorded as part of the
+// user-facing conversation history.
+func SkipForHistory(meta map[string]any) bool {
+	if meta == nil {
+		return false
+	}
+	kind, _ := meta["task_kind"].(string)
+	return internalTaskKinds[kind]
+}

--- a/plugins/memory/internal/internalflow/internalflow.go
+++ b/plugins/memory/internal/internalflow/internalflow.go
@@ -37,3 +37,14 @@ func SkipForHistory(meta map[string]any) bool {
 	kind, _ := meta["task_kind"].(string)
 	return internalTaskKinds[kind]
 }
+
+// SkipForCuration returns true when the request metadata indicates an
+// internal sub-flow whose outgoing LLM request a curation layer should
+// leave alone. Mirrors SkipForHistory but is intended for the
+// before:llm.request side: tool_result_clear, tool_def_pruner, and any
+// other curator should bail when the request originates from a planner,
+// classifier, summariser, compaction, or subagent flow rather than the
+// main agent loop.
+func SkipForCuration(meta map[string]any) bool {
+	return SkipForHistory(meta)
+}

--- a/plugins/memory/internal/internalflow/internalflow_test.go
+++ b/plugins/memory/internal/internalflow/internalflow_test.go
@@ -1,0 +1,31 @@
+package internalflow
+
+import "testing"
+
+func TestSkipForHistory(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]any
+		want bool
+	}{
+		{"nil_meta", nil, false},
+		{"empty_meta", map[string]any{}, false},
+		{"react_main_records", map[string]any{"task_kind": "react_main", "_source": "nexus.agent.react"}, false},
+		{"planexec_step_records", map[string]any{"task_kind": "planexec_step", "_source": "nexus.agent.planexec"}, false},
+		{"orchestrator_decompose_records", map[string]any{"task_kind": "orchestrator_decompose"}, false},
+		{"plan_skipped", map[string]any{"task_kind": "plan"}, true},
+		{"summarise_skipped", map[string]any{"task_kind": "summarise"}, true},
+		{"classify_skipped", map[string]any{"task_kind": "classify"}, true},
+		{"compact_skipped", map[string]any{"task_kind": "compact"}, true},
+		{"subagent_skipped", map[string]any{"task_kind": "subagent"}, true},
+		{"unknown_kind_records", map[string]any{"task_kind": "future_agent"}, false},
+		{"source_alone_records", map[string]any{"_source": "nexus.agent.react"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SkipForHistory(tc.meta); got != tc.want {
+				t.Fatalf("SkipForHistory(%v) = %v, want %v", tc.meta, got, tc.want)
+			}
+		})
+	}
+}

--- a/plugins/memory/simple/plugin.go
+++ b/plugins/memory/simple/plugin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/frankbardon/nexus/pkg/engine"
 	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/plugins/memory/internal/internalflow"
 )
 
 const pluginID = "nexus.memory.simple"
@@ -116,7 +117,7 @@ func (p *Plugin) handleLLMResponse(e engine.Event[any]) {
 	if !ok {
 		return
 	}
-	if source, _ := resp.Metadata["_source"].(string); source != "" {
+	if internalflow.SkipForHistory(resp.Metadata) {
 		return
 	}
 	p.append(events.Message{

--- a/plugins/memory/simple/plugin_test.go
+++ b/plugins/memory/simple/plugin_test.go
@@ -92,18 +92,30 @@ func TestCompactedReplacesBuffer(t *testing.T) {
 	}
 }
 
-// TestLLMResponseWithSourceIgnored proves that llm.response events tagged
-// with Metadata["_source"] (e.g. planner or summariser replies) don't land
-// in the history buffer.
-func TestLLMResponseWithSourceIgnored(t *testing.T) {
+// TestLLMResponseInternalKindIgnored proves that llm.response events
+// produced by internal sub-flows (planner, summariser, classifier, …) —
+// identified by their task_kind — don't land in the history buffer. Main
+// agent responses are always recorded; the older non-empty `_source` check
+// would have skipped those too once Idea 09 made every agent main request
+// tag its own pluginID.
+func TestLLMResponseInternalKindIgnored(t *testing.T) {
 	p := New().(*Plugin)
 	p.logger = slog.Default()
 
+	// Internal — must be skipped.
 	p.handleLLMResponse(engine.Event[any]{Payload: events.LLMResponse{SchemaVersion: events.LLMResponseVersion, Content: "internal",
-		Metadata: map[string]any{"_source": "nexus.planner.dynamic"},
+		Metadata: map[string]any{"_source": "nexus.planner.dynamic", "task_kind": "plan"},
 	}})
-
 	if got := len(p.GetHistory()); got != 0 {
-		t.Fatalf("expected sourced response ignored, got %d messages", got)
+		t.Fatalf("expected sourced internal response ignored, got %d messages", got)
+	}
+
+	// Main agent loop — must be recorded even though `_source` is non-empty.
+	p.handleLLMResponse(engine.Event[any]{Payload: events.LLMResponse{SchemaVersion: events.LLMResponseVersion, Content: "main",
+		Metadata: map[string]any{"_source": "nexus.agent.react", "task_kind": "react_main"},
+	}})
+	hist := p.GetHistory()
+	if len(hist) != 1 || hist[0].Content != "main" {
+		t.Fatalf("expected main agent response recorded, got %+v", hist)
 	}
 }

--- a/plugins/memory/summary_buffer/plugin.go
+++ b/plugins/memory/summary_buffer/plugin.go
@@ -43,19 +43,39 @@ const (
 	triggerTurnCount     triggerStrategy = "turn_count"
 )
 
-const defaultSummaryPrompt = `You are a context compaction assistant. Your job is to distill a conversation history into a concise summary that preserves all information needed for the assistant to continue working effectively.
+// defaultSummaryPrompt instructs the summariser with the
+// reasoning-preservation rules from Idea 30. The output ends with a
+// "## Preserved Kinds:" trailer that the plugin parses to populate the
+// MemorySummaryReplaced event and to drive optional retry-on-missing-kind.
+const defaultSummaryPrompt = `You are a context compaction assistant. Compress an older slice of conversation history into a summary that the assistant can rely on to continue working without re-reading the original.
 
-Rules:
-- Preserve the user's original goals, preferences, and constraints.
-- Preserve all decisions made, actions taken, and their outcomes.
-- Preserve any file paths, code snippets, variable names, or technical details that were referenced.
-- Preserve the current state of any in-progress work.
-- Preserve any errors encountered and how they were resolved (or not).
-- Remove redundant back-and-forth, pleasantries, and repeated information.
-- Remove verbose tool outputs that have already been processed — keep only the conclusions.
-- Write in third person narrative form, not as a dialogue.
+PRESERVE — keep these explicitly, in priority order:
+- Decisions: choices made by the user or assistant, including alternatives that were rejected.
+- Rationale: the *why* behind each decision (constraints, preferences, observations).
+- Errors: any error encountered and the resolution (or that it remains unresolved).
+- Next steps: planned actions, open questions, anything blocking forward progress.
+- File paths, identifiers, code references, technical details that future turns will likely need.
 
-Output ONLY the compacted summary as a single block of text. Do not include any preamble, explanation, or metadata.`
+COMPRESS — drop or condense aggressively:
+- Verbatim transcript of pleasantries, acknowledgements, recapping.
+- Tool result bodies whose conclusions are already captured above.
+- Repeated context that the user has already restated.
+
+Wrap each compressed segment with an XML tag of the form
+<summary topic="<short topic>" compressed-from-turns="<lo>-<hi>"> ... </summary>
+so future turns can trace which range produced which paragraph. Pick a topic
+slug for each segment based on its dominant subject.
+
+Write in third-person narrative form, not as a dialogue. Output the
+compacted summary as one or more <summary>…</summary> blocks back-to-back.
+
+Finish with a single trailer line listing every category you preserved
+content for, exactly in this format:
+
+## Preserved Kinds: decision, rationale, error, next_step
+
+Use only categories that actually appear in the summary. Allowed values:
+decision, rationale, error, next_step, technical_detail.`
 
 // Plugin implements inline auto-compaction for the memory.history buffer.
 type Plugin struct {
@@ -72,27 +92,44 @@ type Plugin struct {
 	modelRole        string
 	model            string
 	summaryPrompt    string
+	// requirePreservedKinds enumerates Preserved-Kinds tags that must be
+	// reported by the summariser before adoption. When the trailer is
+	// missing any required kind and qualityRetry is true, we re-run the
+	// summary once with a stricter prompt.
+	requirePreservedKinds []string
+	qualityRetry          bool
 
 	mu              sync.RWMutex
 	messages        []events.Message
 	turnCount       int
+	turn            int // monotonic turn counter for span reporting
 	summarising     bool
 	unsubs          []func()
 	internalCallIDs map[string]struct{}
+	// summarisationStartTurn records the turn we kicked off the in-flight
+	// summary; combined with maxRecent it lets MemorySummaryReplaced
+	// describe the original span.
+	summarisationStartTurn int
+	summarisationEndTurn   int
+	// retryAttempts counts judge-driven retries for the in-flight summary
+	// so we cap at one retry (two attempts total).
+	retryAttempts int
 }
 
 // New creates a new summary_buffer memory plugin.
 func New() engine.Plugin {
 	return &Plugin{
-		strategy:         triggerMessageCount,
-		messageThreshold: 50,
-		tokenThreshold:   30000,
-		turnThreshold:    10,
-		charsPerToken:    4.0,
-		maxRecent:        8,
-		modelRole:        "quick",
-		summaryPrompt:    defaultSummaryPrompt,
-		internalCallIDs:  make(map[string]struct{}),
+		strategy:              triggerMessageCount,
+		messageThreshold:      50,
+		tokenThreshold:        30000,
+		turnThreshold:         10,
+		charsPerToken:         4.0,
+		maxRecent:             8,
+		modelRole:             "quick",
+		summaryPrompt:         defaultSummaryPrompt,
+		internalCallIDs:       make(map[string]struct{}),
+		requirePreservedKinds: []string{"decision", "rationale"},
+		qualityRetry:          false,
 	}
 }
 
@@ -137,6 +174,8 @@ func (p *Plugin) Emissions() []string {
 		"llm.request",
 		"memory.compaction.triggered",
 		"memory.compacted",
+		"memory.summary_replaced",
+		"memory.curated",
 		"io.status",
 	}
 }
@@ -179,6 +218,19 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.summaryPrompt = string(data)
 	} else if prompt, ok := ctx.Config["prompt"].(string); ok && prompt != "" {
 		p.summaryPrompt = prompt
+	}
+
+	if v, ok := ctx.Config["quality_retry"].(bool); ok {
+		p.qualityRetry = v
+	}
+	if list, ok := ctx.Config["require_preserved_kinds"].([]any); ok {
+		kinds := make([]string, 0, len(list))
+		for _, item := range list {
+			if s, ok := item.(string); ok && s != "" {
+				kinds = append(kinds, s)
+			}
+		}
+		p.requirePreservedKinds = kinds
 	}
 
 	p.unsubs = append(p.unsubs,
@@ -293,6 +345,7 @@ func (p *Plugin) handleTurnEnd(e engine.Event[any]) {
 	}
 	p.mu.Lock()
 	p.turnCount++
+	p.turn++
 	p.mu.Unlock()
 	p.checkTrigger()
 }
@@ -410,6 +463,13 @@ func (p *Plugin) triggerSummarisation(reason string) {
 	copy(snapshot, p.messages[:splitIdx])
 	msgCount := len(p.messages)
 	p.summarising = true
+	// Capture the turn span the summary will replace. Conservative: the
+	// older slice covers turns 0..p.turn at most. Without per-message turn
+	// indices we report (0, p.turn) and let downstream consumers treat
+	// this as the cumulative range.
+	p.summarisationStartTurn = 0
+	p.summarisationEndTurn = p.turn
+	p.retryAttempts = 0
 	p.mu.Unlock()
 
 	_ = p.bus.Emit("memory.compaction.triggered", events.CompactionTriggered{SchemaVersion: events.CompactionTriggeredVersion, Reason: reason,
@@ -468,7 +528,25 @@ func (p *Plugin) triggerSummarisation(reason string) {
 }
 
 func (p *Plugin) finishSummarisation(summary string) {
+	preservedKinds := parsePreservedKinds(summary)
+
+	// Quality-retry path: when the trailer is missing required kinds and
+	// the operator opted in, fire one stricter retry before adopting.
 	p.mu.Lock()
+	if p.qualityRetry && p.retryAttempts == 0 && missingRequiredKinds(preservedKinds, p.requirePreservedKinds) {
+		p.retryAttempts++
+		startTurn := p.summarisationStartTurn
+		endTurn := p.summarisationEndTurn
+		// Keep summarising == true so we don't re-trigger from the
+		// trigger path; release the lock and dispatch the retry.
+		p.mu.Unlock()
+		p.logger.Info("summary_buffer rejected: missing preserved kinds; retrying",
+			"reported_kinds", preservedKinds,
+			"required", p.requirePreservedKinds,
+		)
+		p.dispatchSummaryRetry(startTurn, endTurn)
+		return
+	}
 	prevCount := len(p.messages)
 
 	protectCount := p.maxRecent
@@ -485,6 +563,11 @@ func (p *Plugin) finishSummarisation(summary string) {
 		splitIdx = 0
 	}
 
+	originalChars := 0
+	for _, m := range p.messages[:splitIdx] {
+		originalChars += len(m.Content)
+	}
+
 	protected := make([]events.Message, len(p.messages)-splitIdx)
 	copy(protected, p.messages[splitIdx:])
 
@@ -498,18 +581,133 @@ func (p *Plugin) finishSummarisation(summary string) {
 	p.messages = compacted
 	p.turnCount = 0
 	p.summarising = false
+	startTurn := p.summarisationStartTurn
+	endTurn := p.summarisationEndTurn
+	now := p.turn
 	p.mu.Unlock()
 
 	p.logger.Info("summary_buffer compaction complete",
 		"prev_messages", prevCount,
 		"new_messages", len(compacted),
+		"preserved_kinds", preservedKinds,
 	)
 
 	_ = p.bus.Emit("memory.compacted", events.CompactionComplete{SchemaVersion: events.CompactionCompleteVersion, Messages: compacted,
 		MessageCount: len(compacted),
 		PrevCount:    prevCount,
 	})
+	_ = p.bus.Emit("memory.summary_replaced", events.MemorySummaryReplaced{
+		SchemaVersion:  events.MemorySummaryReplacedVersion,
+		FromTurns:      [2]int{startTurn, endTurn},
+		OriginalTokens: int(float64(originalChars) / p.charsPerToken),
+		SummaryTokens:  int(float64(len(summary)) / p.charsPerToken),
+		PreservedKinds: preservedKinds,
+	})
+	_ = p.bus.Emit("memory.curated", events.MemoryCurated{
+		SchemaVersion: events.MemoryCuratedVersion,
+		Layer:         "summary_buffer",
+		SectionsTouched: []events.CurationSection{{
+			SectionID:   pluginID + "/range",
+			Kind:        "session",
+			TokensDelta: -(originalChars - len(summary)) / 4,
+		}},
+		CacheInvalidates: true,
+		AtTurn:           now,
+	})
 	_ = p.bus.Emit("io.status", events.StatusUpdate{SchemaVersion: events.StatusUpdateVersion, State: "idle", Detail: ""})
+}
+
+// dispatchSummaryRetry fires a second summary request with a stricter
+// preamble. The stricter prompt explicitly names the missing kinds the
+// first attempt failed to surface so the second attempt can target them.
+func (p *Plugin) dispatchSummaryRetry(startTurn, endTurn int) {
+	p.mu.Lock()
+	snapshot := make([]events.Message, len(p.messages))
+	copy(snapshot, p.messages)
+	protectCount := p.maxRecent
+	if protectCount > len(snapshot) {
+		protectCount = len(snapshot)
+	}
+	splitIdx := len(snapshot) - protectCount
+	splitIdx = safeSplit(snapshot, splitIdx)
+	if splitIdx <= 0 {
+		// Nothing to summarise on retry — abort retry, release flag.
+		p.summarising = false
+		p.mu.Unlock()
+		return
+	}
+	older := snapshot[:splitIdx]
+	msgCount := len(snapshot)
+	p.mu.Unlock()
+
+	var transcript strings.Builder
+	for _, msg := range older {
+		fmt.Fprintf(&transcript, "[%s]: %s\n\n", msg.Role, msg.Content)
+	}
+
+	stricterPrompt := p.summaryPrompt + "\n\nIMPORTANT: the previous attempt did not preserve every required category. Re-read the source carefully and ensure the trailer lists at least: " + strings.Join(p.requirePreservedKinds, ", ") + ". Do NOT omit categories that are present in the source."
+
+	messages := []events.Message{
+		{Role: "system", Content: stricterPrompt},
+		{Role: "user", Content: "Here is the conversation to compact:\n\n" + transcript.String()},
+	}
+
+	_ = p.bus.Emit("llm.request", events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: p.modelRole,
+		Model:    p.model,
+		Messages: messages,
+		Stream:   false,
+		Metadata: map[string]any{
+			"_source":        llmSource,
+			"_prev_count":    msgCount,
+			"_protect":       protectCount,
+			"_summarising":   true,
+			"_summary_retry": true,
+			"task_kind":      "summarise",
+			"_span_start":    startTurn,
+			"_span_end":      endTurn,
+		},
+		Tags: map[string]string{"source_plugin": pluginID},
+	})
+}
+
+// parsePreservedKinds extracts the comma-separated kinds from the
+// "## Preserved Kinds:" trailer the summariser appends. Returns an empty
+// slice when the trailer is absent or malformed.
+func parsePreservedKinds(summary string) []string {
+	const tag = "## Preserved Kinds:"
+	idx := strings.LastIndex(summary, tag)
+	if idx < 0 {
+		return nil
+	}
+	tail := summary[idx+len(tag):]
+	// Trim through end of line.
+	if nl := strings.Index(tail, "\n"); nl >= 0 {
+		tail = tail[:nl]
+	}
+	parts := strings.Split(tail, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// missingRequiredKinds returns true when at least one required kind is
+// absent from the reported list.
+func missingRequiredKinds(reported, required []string) bool {
+	have := make(map[string]bool, len(reported))
+	for _, k := range reported {
+		have[k] = true
+	}
+	for _, k := range required {
+		if !have[k] {
+			return true
+		}
+	}
+	return false
 }
 
 // safeSplit walks a proposed split index leftward until splitting at that

--- a/plugins/memory/summary_buffer/plugin.go
+++ b/plugins/memory/summary_buffer/plugin.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/frankbardon/nexus/pkg/engine"
 	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/plugins/memory/internal/internalflow"
 )
 
 const (
@@ -292,8 +293,11 @@ func (p *Plugin) handleLLMResponse(e engine.Event[any]) {
 		p.finishSummarisation(resp.Content)
 		return
 	}
-	if source != "" {
-		// Owned by another plugin (planner etc.) — don't record.
+	// Skip outputs from other internal sub-flows (planner, classifier,
+	// compaction, subagent). Main agent loops are recorded — every agent
+	// main request now tags its own pluginID for cost attribution
+	// (Idea 09), and a non-empty `_source` no longer means "internal".
+	if internalflow.SkipForHistory(resp.Metadata) {
 		return
 	}
 	p.append(events.Message{

--- a/plugins/memory/summary_buffer/preserved_kinds_test.go
+++ b/plugins/memory/summary_buffer/preserved_kinds_test.go
@@ -1,0 +1,37 @@
+package summary_buffer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePreservedKinds_Trailer(t *testing.T) {
+	got := parsePreservedKinds("paragraph one\n\n## Preserved Kinds: decision, rationale, error\n")
+	want := []string{"decision", "rationale", "error"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestParsePreservedKinds_NoTrailer(t *testing.T) {
+	if got := parsePreservedKinds("just a summary"); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestParsePreservedKinds_TrailerNoNewline(t *testing.T) {
+	got := parsePreservedKinds("body\n## Preserved Kinds: decision")
+	want := []string{"decision"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestMissingRequiredKinds(t *testing.T) {
+	if !missingRequiredKinds([]string{"rationale"}, []string{"decision", "rationale"}) {
+		t.Fatal("expected missing decision")
+	}
+	if missingRequiredKinds([]string{"decision", "rationale", "error"}, []string{"decision", "rationale"}) {
+		t.Fatal("must not flag when all required present")
+	}
+}

--- a/plugins/memory/summary_buffer/schema.json
+++ b/plugins/memory/summary_buffer/schema.json
@@ -14,6 +14,12 @@
     "model_role":        {"type": "string"},
     "model":             {"type": "string"},
     "prompt":            {"type": "string"},
-    "prompt_file":       {"type": "string"}
+    "prompt_file":       {"type": "string"},
+    "quality_retry":     {"type": "boolean", "description": "When true, re-run the summariser once with a stricter prompt if the trailer omits any required preserved kind. Default false (backwards-compatible)."},
+    "require_preserved_kinds": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Preserved-kind tags that must appear in the summariser's trailer for adoption. Defaults to [\"decision\", \"rationale\"]."
+    }
   }
 }

--- a/plugins/memory/tool_def_pruner/plugin.go
+++ b/plugins/memory/tool_def_pruner/plugin.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/frankbardon/nexus/pkg/engine"
 	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/plugins/memory/internal/internalflow"
 )
 
 const (
@@ -175,7 +176,7 @@ func (p *Plugin) handleBeforeLLMRequest(e engine.Event[any]) {
 	if !ok {
 		return
 	}
-	if src, _ := req.Metadata["_source"].(string); src != "" {
+	if internalflow.SkipForCuration(req.Metadata) {
 		return
 	}
 	if len(req.Tools) == 0 {

--- a/plugins/memory/tool_def_pruner/plugin.go
+++ b/plugins/memory/tool_def_pruner/plugin.go
@@ -1,0 +1,245 @@
+// Package tool_def_pruner removes tool definitions from outgoing
+// LLMRequest.Tools when those tools have been idle past a turn threshold.
+// Pairs with nexus.discovery.progressive: progressive scopes by class;
+// this plugin scopes per individual tool.
+//
+// Runs at priority 14 on before:llm.request — after both
+// progressive (8) and tool_result_clear (12) have shaped the request.
+// Idle tools are surfaced as MemoryToolDefPruned events; they reappear
+// automatically next turn if the agent invokes them via discover or any
+// other path, since this plugin observes tool.invoke and resets the
+// last-used counter.
+package tool_def_pruner
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID   = "nexus.memory.tool_def_pruner"
+	pluginName = "Tool-Definition Pruner"
+	version    = "0.1.0"
+)
+
+// Plugin tracks per-tool last-used turn and prunes idle definitions.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+
+	enabled              bool
+	unusedTurnsThreshold int
+	// neverPrune lists tool names that should always remain visible. The
+	// agent's "discover" meta-tool is added by default so progressive
+	// discovery isn't accidentally severed when nothing has been invoked
+	// yet.
+	neverPrune map[string]bool
+
+	mu       sync.Mutex
+	turn     int
+	lastUsed map[string]int // tool_name -> turn
+	pruned   map[string]bool
+
+	unsubs []func()
+}
+
+// New creates a new tool_def_pruner plugin.
+func New() engine.Plugin {
+	return &Plugin{
+		enabled:              true,
+		unusedTurnsThreshold: 6,
+		neverPrune: map[string]bool{
+			"discover": true,
+			"ask_user": true,
+		},
+		lastUsed: make(map[string]int),
+		pruned:   make(map[string]bool),
+	}
+}
+
+func (p *Plugin) ID() string                        { return pluginID }
+func (p *Plugin) Name() string                      { return pluginName }
+func (p *Plugin) Version() string                   { return version }
+func (p *Plugin) Dependencies() []string            { return nil }
+func (p *Plugin) Requires() []engine.Requirement    { return nil }
+func (p *Plugin) Capabilities() []engine.Capability { return nil }
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "tool.invoke", Priority: 60},
+		{EventType: "agent.turn.end", Priority: 60},
+		{EventType: "before:llm.request", Priority: 14},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"memory.tool_def_pruned",
+		"memory.curated",
+	}
+}
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+
+	if v, ok := ctx.Config["enabled"].(bool); ok {
+		p.enabled = v
+	}
+	if v, ok := ctx.Config["unused_turns_threshold"].(int); ok {
+		p.unusedTurnsThreshold = v
+	} else if v, ok := ctx.Config["unused_turns_threshold"].(float64); ok {
+		p.unusedTurnsThreshold = int(v)
+	}
+	if list, ok := ctx.Config["never_prune"].([]any); ok {
+		// Replace defaults entirely when the operator supplies a list —
+		// matches the principle of letting users opt out of "discover"
+		// being kept if they have a different agent shape.
+		p.neverPrune = make(map[string]bool, len(list))
+		for _, item := range list {
+			if s, ok := item.(string); ok && s != "" {
+				p.neverPrune[s] = true
+			}
+		}
+	}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("tool.invoke", p.handleToolInvoke,
+			engine.WithPriority(60), engine.WithSource(pluginID)),
+		p.bus.Subscribe("agent.turn.end", p.handleTurnEnd,
+			engine.WithPriority(60), engine.WithSource(pluginID)),
+		p.bus.Subscribe("before:llm.request", p.handleBeforeLLMRequest,
+			engine.WithPriority(14), engine.WithSource(pluginID)),
+	)
+
+	p.logger.Info("tool_def_pruner initialized",
+		"enabled", p.enabled,
+		"unused_turns_threshold", p.unusedTurnsThreshold,
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, u := range p.unsubs {
+		u()
+	}
+	return nil
+}
+
+// handleToolInvoke marks a tool as "just used" — resets idle counter.
+func (p *Plugin) handleToolInvoke(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	tc, ok := e.Payload.(events.ToolCall)
+	if !ok || tc.Name == "" {
+		return
+	}
+	p.mu.Lock()
+	p.lastUsed[tc.Name] = p.turn
+	delete(p.pruned, tc.Name)
+	p.mu.Unlock()
+}
+
+func (p *Plugin) handleTurnEnd(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	if _, ok := e.Payload.(events.TurnInfo); !ok {
+		return
+	}
+	p.mu.Lock()
+	p.turn++
+	p.mu.Unlock()
+}
+
+// handleBeforeLLMRequest filters req.Tools, dropping definitions for tools
+// that have been idle past the threshold. Tools never seen are tracked
+// with first-seen turn so we don't prune freshly-loaded tools instantly.
+func (p *Plugin) handleBeforeLLMRequest(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	vp, ok := e.Payload.(*engine.VetoablePayload)
+	if !ok {
+		return
+	}
+	req, ok := vp.Original.(*events.LLMRequest)
+	if !ok {
+		return
+	}
+	if src, _ := req.Metadata["_source"].(string); src != "" {
+		return
+	}
+	if len(req.Tools) == 0 {
+		return
+	}
+
+	p.mu.Lock()
+	now := p.turn
+	keep := make([]events.ToolDef, 0, len(req.Tools))
+	pruned := make([]events.MemoryToolDefPruned, 0)
+	sections := make([]events.CurationSection, 0)
+
+	for _, td := range req.Tools {
+		if p.neverPrune[td.Name] {
+			keep = append(keep, td)
+			continue
+		}
+		last, seen := p.lastUsed[td.Name]
+		if !seen {
+			// First sight — register as just-loaded so the threshold
+			// counts from this turn, not from turn zero.
+			p.lastUsed[td.Name] = now
+			keep = append(keep, td)
+			continue
+		}
+		if now-last < p.unusedTurnsThreshold {
+			keep = append(keep, td)
+			continue
+		}
+
+		size := defSize(td)
+		pruned = append(pruned, events.MemoryToolDefPruned{
+			SchemaVersion:  events.MemoryToolDefPrunedVersion,
+			ToolID:         td.Name,
+			LastUsedTurn:   last,
+			DefinitionSize: size,
+		})
+		sections = append(sections, events.CurationSection{
+			SectionID:   pluginID + "/" + td.Name,
+			Kind:        "session",
+			TokensDelta: -size / 4,
+		})
+		p.pruned[td.Name] = true
+	}
+	p.mu.Unlock()
+
+	if len(pruned) == 0 {
+		return
+	}
+	req.Tools = keep
+	for _, ev := range pruned {
+		_ = p.bus.Emit("memory.tool_def_pruned", ev)
+	}
+	_ = p.bus.Emit("memory.curated", events.MemoryCurated{
+		SchemaVersion:    events.MemoryCuratedVersion,
+		Layer:            "tool_def_pruner",
+		SectionsTouched:  sections,
+		CacheInvalidates: true,
+		AtTurn:           now,
+	})
+}
+
+// defSize estimates the byte size of a tool definition for observability.
+func defSize(td events.ToolDef) int {
+	raw, _ := json.Marshal(td)
+	return len(raw)
+}

--- a/plugins/memory/tool_def_pruner/plugin_test.go
+++ b/plugins/memory/tool_def_pruner/plugin_test.go
@@ -1,0 +1,139 @@
+package tool_def_pruner
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func newPluginForTest(t *testing.T) (*Plugin, engine.EventBus) {
+	t.Helper()
+	bus := engine.NewEventBus()
+	p := &Plugin{
+		bus:                  bus,
+		logger:               slog.Default(),
+		enabled:              true,
+		unusedTurnsThreshold: 3,
+		neverPrune:           map[string]bool{"discover": true},
+		lastUsed:             make(map[string]int),
+		pruned:               make(map[string]bool),
+	}
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("tool.invoke", p.handleToolInvoke, engine.WithPriority(60)),
+		bus.Subscribe("agent.turn.end", p.handleTurnEnd, engine.WithPriority(60)),
+		bus.Subscribe("before:llm.request", p.handleBeforeLLMRequest, engine.WithPriority(14)),
+	)
+	return p, bus
+}
+
+func TestPrunesIdleTools(t *testing.T) {
+	_, bus := newPluginForTest(t)
+
+	// Establish baseline: tool seen at turn 0.
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Tools: []events.ToolDef{
+		{Name: "shell", Description: "..."},
+		{Name: "web_fetch", Description: "..."},
+	}}
+	bus.EmitVetoable("before:llm.request", req)
+	if len(req.Tools) != 2 {
+		t.Fatalf("first sight should not prune, got %d tools", len(req.Tools))
+	}
+
+	// Advance turns past idle threshold for web_fetch.
+	for i := 0; i < 4; i++ {
+		bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+	}
+	// Mark shell as used at the current turn so it survives the prune.
+	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, Name: "shell"})
+
+	pruned := 0
+	bus.Subscribe("memory.tool_def_pruned", func(_ engine.Event[any]) { pruned++ })
+
+	req2 := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Tools: []events.ToolDef{
+		{Name: "shell"},
+		{Name: "web_fetch"},
+	}}
+	bus.EmitVetoable("before:llm.request", req2)
+	if pruned != 1 {
+		t.Fatalf("expected exactly 1 pruning event, got %d", pruned)
+	}
+	if len(req2.Tools) != 1 || req2.Tools[0].Name != "shell" {
+		t.Fatalf("expected only shell to remain, got %v", req2.Tools)
+	}
+}
+
+func TestNeverPruneList(t *testing.T) {
+	_, bus := newPluginForTest(t)
+
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Tools: []events.ToolDef{
+		{Name: "discover"},
+		{Name: "anything_else"},
+	}}
+	bus.EmitVetoable("before:llm.request", req)
+
+	// Advance 10 turns; discover should still be there.
+	for i := 0; i < 10; i++ {
+		bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+	}
+
+	req2 := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Tools: []events.ToolDef{
+		{Name: "discover"},
+		{Name: "anything_else"},
+	}}
+	bus.EmitVetoable("before:llm.request", req2)
+
+	hasDiscover := false
+	for _, td := range req2.Tools {
+		if td.Name == "discover" {
+			hasDiscover = true
+		}
+	}
+	if !hasDiscover {
+		t.Fatalf("discover must be exempt from pruning")
+	}
+}
+
+func TestSkipsSourcedRequests(t *testing.T) {
+	_, bus := newPluginForTest(t)
+
+	bus.EmitVetoable("before:llm.request", &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Tools: []events.ToolDef{{Name: "shell"}}})
+	for i := 0; i < 10; i++ {
+		bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+	}
+
+	pruned := 0
+	bus.Subscribe("memory.tool_def_pruned", func(_ engine.Event[any]) { pruned++ })
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion,
+		Metadata: map[string]any{"_source": "internal.plugin"},
+		Tools:    []events.ToolDef{{Name: "shell"}},
+	}
+	bus.EmitVetoable("before:llm.request", req)
+	if pruned != 0 {
+		t.Fatalf("must not prune sourced requests, got %d", pruned)
+	}
+}
+
+func TestRecentInvocationResetsCounter(t *testing.T) {
+	_, bus := newPluginForTest(t)
+
+	// Establish + idle.
+	bus.EmitVetoable("before:llm.request", &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Tools: []events.ToolDef{{Name: "shell"}}})
+	for i := 0; i < 5; i++ {
+		bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+	}
+	// Use just before the next request — should reset and survive prune.
+	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, Name: "shell"})
+
+	pruned := 0
+	bus.Subscribe("memory.tool_def_pruned", func(_ engine.Event[any]) { pruned++ })
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Tools: []events.ToolDef{{Name: "shell"}}}
+	bus.EmitVetoable("before:llm.request", req)
+	if pruned != 0 {
+		t.Fatalf("recently-used tool must not be pruned, got %d", pruned)
+	}
+	if len(req.Tools) != 1 {
+		t.Fatalf("tool should remain, got %v", req.Tools)
+	}
+}

--- a/plugins/memory/tool_def_pruner/plugin_test.go
+++ b/plugins/memory/tool_def_pruner/plugin_test.go
@@ -95,7 +95,7 @@ func TestNeverPruneList(t *testing.T) {
 	}
 }
 
-func TestSkipsSourcedRequests(t *testing.T) {
+func TestSkipsInternalSubFlowRequests(t *testing.T) {
 	_, bus := newPluginForTest(t)
 
 	bus.EmitVetoable("before:llm.request", &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Tools: []events.ToolDef{{Name: "shell"}}})
@@ -105,13 +105,16 @@ func TestSkipsSourcedRequests(t *testing.T) {
 
 	pruned := 0
 	bus.Subscribe("memory.tool_def_pruned", func(_ engine.Event[any]) { pruned++ })
+	// task_kind=plan signals an internal sub-flow — pruner stays out of
+	// the way. Idea 09 made every agent main request tag its own
+	// pluginID, so a non-empty `_source` is no longer the skip signal.
 	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion,
-		Metadata: map[string]any{"_source": "internal.plugin"},
+		Metadata: map[string]any{"_source": "nexus.planner.dynamic", "task_kind": "plan"},
 		Tools:    []events.ToolDef{{Name: "shell"}},
 	}
 	bus.EmitVetoable("before:llm.request", req)
 	if pruned != 0 {
-		t.Fatalf("must not prune sourced requests, got %d", pruned)
+		t.Fatalf("must not prune internal sub-flow requests, got %d", pruned)
 	}
 }
 

--- a/plugins/memory/tool_def_pruner/schema.go
+++ b/plugins/memory/tool_def_pruner/schema.go
@@ -1,0 +1,9 @@
+package tool_def_pruner
+
+import _ "embed"
+
+//go:embed schema.json
+var configSchemaBytes []byte
+
+// ConfigSchema implements engine.ConfigSchemaProvider.
+func (p *Plugin) ConfigSchema() []byte { return configSchemaBytes }

--- a/plugins/memory/tool_def_pruner/schema.json
+++ b/plugins/memory/tool_def_pruner/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexus.local/schemas/plugins/nexus.memory.tool_def_pruner.json",
+  "title": "nexus.memory.tool_def_pruner",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "enabled":                {"type": "boolean", "description": "Enable per-tool definition pruning. Default true."},
+    "unused_turns_threshold": {"type": "integer", "minimum": 1, "description": "Drop a tool definition after this many consecutive turns without an invocation."},
+    "never_prune": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Tool names that are exempt from pruning. Defaults to [\"discover\", \"ask_user\"]."
+    }
+  }
+}

--- a/plugins/memory/tool_result_clear/plugin.go
+++ b/plugins/memory/tool_result_clear/plugin.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/frankbardon/nexus/pkg/engine"
 	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/plugins/memory/internal/internalflow"
 )
 
 const (
@@ -268,8 +269,11 @@ func (p *Plugin) handleBeforeLLMRequest(e engine.Event[any]) {
 	if !ok {
 		return
 	}
-	// Skip internal/synthetic requests (e.g. summaries, gates retrying).
-	if src, _ := req.Metadata["_source"].(string); src != "" {
+	// Skip internal sub-flow requests (planner / classifier / summariser
+	// / compaction / subagent). Main agent loops are processed even
+	// though every agent main request now tags `_source = pluginID` for
+	// cost attribution (Idea 09).
+	if internalflow.SkipForCuration(req.Metadata) {
 		return
 	}
 

--- a/plugins/memory/tool_result_clear/plugin.go
+++ b/plugins/memory/tool_result_clear/plugin.go
@@ -1,0 +1,465 @@
+// Package tool_result_clear implements live curation of tool result bodies
+// in the LLM-visible conversation. The call/result envelope stays in
+// history so the agent retains the fact that a tool was invoked; only the
+// (often-large) result body is replaced with a marker once heuristics
+// decide it is no longer load-bearing.
+//
+// Operates at priority 12 on before:llm.request so it runs after
+// nexus.discovery.progressive (priority 8) has shaped the tool list, then
+// re-shapes the outgoing message slice without touching the upstream
+// history buffer.
+package tool_result_clear
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID   = "nexus.memory.tool_result_clear"
+	pluginName = "Tool-Result Clearing"
+	version    = "0.1.0"
+)
+
+// Drop strategies.
+const (
+	dropReplaceEnvelope = "replace_with_envelope"
+	dropFullDrop        = "full_drop"
+)
+
+// Reason tags carried on MemoryToolResultCleared.
+const (
+	reasonAge            = "age"
+	reasonSubsequentCall = "subsequent_call"
+	reasonPreservedKind  = "preserved_kind"
+)
+
+// callRecord tracks a single tool invocation we've seen on the bus.
+type callRecord struct {
+	id        string
+	name      string
+	argHash   string
+	turn      int
+	resultLen int
+	cleared   bool
+	// kind classifies the result body so preserve_recent_kinds can keep
+	// errors and user_question results verbatim past the age cutoff.
+	kind string
+}
+
+// Plugin clears stale tool result bodies from outgoing LLM requests.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+
+	// Config.
+	enabled            bool
+	ageTurns           int
+	sizeBytesThreshold int
+	preserveKinds      map[string]bool
+	dropStrategy       string
+
+	mu    sync.Mutex
+	turn  int
+	calls map[string]*callRecord // tool_call_id -> record
+	// argIndex groups call ids by tool name + canonical args hash so we
+	// can detect "called again with the same args, drop earlier results".
+	argIndex map[string][]string // "name|argHash" -> []callID
+	// preCleared remembers which IDs we've already cleared so subsequent
+	// before:llm.request handlers re-clear deterministically without
+	// re-running the heuristic.
+	preCleared map[string]string // id -> reason
+
+	unsubs []func()
+}
+
+// New creates a new tool_result_clear plugin.
+func New() engine.Plugin {
+	return &Plugin{
+		enabled:            true,
+		ageTurns:           5,
+		sizeBytesThreshold: 1000,
+		preserveKinds: map[string]bool{
+			"error":         true,
+			"user_question": true,
+		},
+		dropStrategy: dropReplaceEnvelope,
+		calls:        make(map[string]*callRecord),
+		argIndex:     make(map[string][]string),
+		preCleared:   make(map[string]string),
+	}
+}
+
+func (p *Plugin) ID() string                        { return pluginID }
+func (p *Plugin) Name() string                      { return pluginName }
+func (p *Plugin) Version() string                   { return version }
+func (p *Plugin) Dependencies() []string            { return nil }
+func (p *Plugin) Requires() []engine.Requirement    { return nil }
+func (p *Plugin) Capabilities() []engine.Capability { return nil }
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "tool.invoke", Priority: 60},
+		{EventType: "tool.result", Priority: 60},
+		{EventType: "agent.turn.end", Priority: 60},
+		{EventType: "before:llm.request", Priority: 12},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"memory.tool_result_cleared",
+		"memory.curated",
+	}
+}
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+
+	if v, ok := ctx.Config["enabled"].(bool); ok {
+		p.enabled = v
+	}
+	if v, ok := intConfig(ctx.Config, "age_turns", p.ageTurns); ok {
+		p.ageTurns = v
+	}
+	if v, ok := intConfig(ctx.Config, "size_bytes_threshold", p.sizeBytesThreshold); ok {
+		p.sizeBytesThreshold = v
+	}
+	if list, ok := ctx.Config["preserve_recent_kinds"].([]any); ok {
+		preserve := make(map[string]bool, len(list))
+		for _, item := range list {
+			if s, ok := item.(string); ok && s != "" {
+				preserve[s] = true
+			}
+		}
+		p.preserveKinds = preserve
+	}
+	if v, ok := ctx.Config["drop_strategy"].(string); ok {
+		switch v {
+		case dropReplaceEnvelope, dropFullDrop:
+			p.dropStrategy = v
+		default:
+			return fmt.Errorf("tool_result_clear: invalid drop_strategy %q", v)
+		}
+	}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("tool.invoke", p.handleToolInvoke,
+			engine.WithPriority(60), engine.WithSource(pluginID)),
+		p.bus.Subscribe("tool.result", p.handleToolResult,
+			engine.WithPriority(60), engine.WithSource(pluginID)),
+		p.bus.Subscribe("agent.turn.end", p.handleTurnEnd,
+			engine.WithPriority(60), engine.WithSource(pluginID)),
+		p.bus.Subscribe("before:llm.request", p.handleBeforeLLMRequest,
+			engine.WithPriority(12), engine.WithSource(pluginID)),
+	)
+
+	p.logger.Info("tool_result_clear initialized",
+		"enabled", p.enabled,
+		"age_turns", p.ageTurns,
+		"size_bytes_threshold", p.sizeBytesThreshold,
+		"drop_strategy", p.dropStrategy)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, u := range p.unsubs {
+		u()
+	}
+	return nil
+}
+
+// --- bus handlers ---
+
+func (p *Plugin) handleToolInvoke(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	tc, ok := e.Payload.(events.ToolCall)
+	if !ok {
+		return
+	}
+	if tc.ID == "" {
+		return
+	}
+
+	hash := canonicalArgHash(tc.Arguments)
+	key := tc.Name + "|" + hash
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if rec, exists := p.calls[tc.ID]; exists {
+		// Re-invoke of same id (rare); just update turn pointer.
+		rec.turn = p.turn
+		rec.argHash = hash
+		rec.name = tc.Name
+		return
+	}
+
+	p.calls[tc.ID] = &callRecord{
+		id:      tc.ID,
+		name:    tc.Name,
+		argHash: hash,
+		turn:    p.turn,
+	}
+	p.argIndex[key] = append(p.argIndex[key], tc.ID)
+}
+
+func (p *Plugin) handleToolResult(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	res, ok := e.Payload.(events.ToolResult)
+	if !ok {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	rec, exists := p.calls[res.ID]
+	if !exists {
+		// Result without a recorded invoke (e.g. tool emitted result
+		// pre-init); make a minimal record so we can still age it.
+		rec = &callRecord{id: res.ID, name: res.Name, turn: p.turn}
+		p.calls[res.ID] = rec
+	}
+	rec.resultLen = len(res.Output)
+	rec.kind = classifyResult(res)
+}
+
+func (p *Plugin) handleTurnEnd(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	if _, ok := e.Payload.(events.TurnInfo); !ok {
+		return
+	}
+	p.mu.Lock()
+	p.turn++
+	p.mu.Unlock()
+}
+
+// handleBeforeLLMRequest mutates req.Messages, replacing tool result bodies
+// that meet the staleness criteria. The history buffer is left intact.
+func (p *Plugin) handleBeforeLLMRequest(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	vp, ok := e.Payload.(*engine.VetoablePayload)
+	if !ok {
+		return
+	}
+	req, ok := vp.Original.(*events.LLMRequest)
+	if !ok {
+		return
+	}
+	// Skip internal/synthetic requests (e.g. summaries, gates retrying).
+	if src, _ := req.Metadata["_source"].(string); src != "" {
+		return
+	}
+
+	p.mu.Lock()
+	now := p.turn
+	cleared := make([]events.MemoryToolResultCleared, 0)
+	sections := make([]events.CurationSection, 0)
+
+	// First pass: for each tool message in the request, decide.
+	keep := make([]events.Message, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		if m.Role != "tool" || m.ToolCallID == "" {
+			keep = append(keep, m)
+			continue
+		}
+
+		// Already-cleared shortcut.
+		if reason, isCleared := p.preCleared[m.ToolCallID]; isCleared {
+			if p.dropStrategy == dropFullDrop {
+				continue
+			}
+			rec := p.calls[m.ToolCallID]
+			toolName := m.ToolCallID
+			origSize := len(m.Content)
+			if rec != nil {
+				if rec.name != "" {
+					toolName = rec.name
+				}
+				if rec.resultLen > 0 {
+					origSize = rec.resultLen
+				}
+			}
+			m.Content = envelopeMarker(m.ToolCallID, toolName, origSize, now)
+			keep = append(keep, m)
+			_ = reason // already-cleared events emitted on first clearing only
+			continue
+		}
+
+		rec := p.calls[m.ToolCallID]
+		// Heuristic decision.
+		shouldClear, reason := p.decideClearLocked(rec, m, now)
+		if !shouldClear {
+			keep = append(keep, m)
+			continue
+		}
+
+		toolName := m.ToolCallID
+		origSize := len(m.Content)
+		if rec != nil {
+			if rec.name != "" {
+				toolName = rec.name
+			}
+			if rec.resultLen > 0 {
+				origSize = rec.resultLen
+			}
+			rec.cleared = true
+		}
+		p.preCleared[m.ToolCallID] = reason
+
+		cleared = append(cleared, events.MemoryToolResultCleared{
+			SchemaVersion: events.MemoryToolResultClearedVersion,
+			ToolCallID:    m.ToolCallID,
+			Tool:          toolName,
+			OriginalSize:  origSize,
+			ClearedAtTurn: now,
+			Reason:        reason,
+		})
+		sections = append(sections, events.CurationSection{
+			SectionID:   pluginID + "/" + m.ToolCallID,
+			Kind:        "volatile",
+			TokensDelta: -origSize / 4, // crude chars-per-token estimate
+		})
+
+		if p.dropStrategy == dropFullDrop {
+			continue
+		}
+		m.Content = envelopeMarker(m.ToolCallID, toolName, origSize, now)
+		keep = append(keep, m)
+	}
+	p.mu.Unlock()
+
+	if len(cleared) == 0 {
+		return
+	}
+	req.Messages = keep
+
+	for _, ev := range cleared {
+		_ = p.bus.Emit("memory.tool_result_cleared", ev)
+	}
+	_ = p.bus.Emit("memory.curated", events.MemoryCurated{
+		SchemaVersion:    events.MemoryCuratedVersion,
+		Layer:            "tool_result_clear",
+		SectionsTouched:  sections,
+		CacheInvalidates: false,
+		AtTurn:           now,
+	})
+}
+
+// decideClearLocked applies the staleness heuristics to a single tool
+// result message. Caller holds p.mu.
+func (p *Plugin) decideClearLocked(rec *callRecord, m events.Message, now int) (bool, string) {
+	// Preserve hot kinds regardless of age.
+	if rec != nil && rec.kind != "" && p.preserveKinds[rec.kind] {
+		return false, reasonPreservedKind
+	}
+
+	// Subsequent-call: same name+args invoked again later — earlier result
+	// is redundant. Drop regardless of size, but only when age is positive
+	// (don't clear the very call we just observed).
+	if rec != nil {
+		key := rec.name + "|" + rec.argHash
+		ids := p.argIndex[key]
+		if len(ids) > 1 {
+			latest := ids[len(ids)-1]
+			if latest != rec.id && rec.turn < p.calls[latest].turn {
+				return true, reasonSubsequentCall
+			}
+		}
+	}
+
+	// Age + size.
+	resultLen := len(m.Content)
+	if resultLen >= p.sizeBytesThreshold {
+		callTurn := now
+		if rec != nil {
+			callTurn = rec.turn
+		}
+		if now-callTurn >= p.ageTurns {
+			return true, reasonAge
+		}
+	}
+
+	return false, ""
+}
+
+// --- helpers ---
+
+// envelopeMarker returns the inline replacement body for a cleared tool
+// result. Mirrors the form documented in idea.md so traces and journals
+// surface a stable marker shape.
+func envelopeMarker(id, tool string, originalSize, clearedAtTurn int) string {
+	return fmt.Sprintf(
+		`<tool_result id=%q tool=%q cleared="true" original_size=%q cleared_at=%q />`,
+		id, tool, fmt.Sprintf("%d", originalSize), fmt.Sprintf("turn-%d", clearedAtTurn),
+	)
+}
+
+// canonicalArgHash produces a deterministic short hash of a tool call's
+// arguments so subsequent-call detection survives JSON key reordering.
+func canonicalArgHash(args map[string]any) string {
+	if len(args) == 0 {
+		return "empty"
+	}
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		raw, _ := json.Marshal(args[k])
+		b.Write(raw)
+		b.WriteByte(';')
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:8])
+}
+
+// classifyResult tags a tool result so preserve_recent_kinds can opt
+// specific kinds out of clearing. v1 only distinguishes errors; future
+// kinds (user_question, etc.) plug in here.
+func classifyResult(res events.ToolResult) string {
+	if res.Error != "" {
+		return "error"
+	}
+	return "ok"
+}
+
+// intConfig parses an integer from a YAML map allowing both int and
+// float64 representations. Returns (value, true) when the key is present
+// with a usable type.
+func intConfig(cfg map[string]any, key string, def int) (int, bool) {
+	if v, ok := cfg[key].(int); ok {
+		return v, true
+	}
+	if v, ok := cfg[key].(float64); ok {
+		return int(v), true
+	}
+	_ = def
+	return 0, false
+}

--- a/plugins/memory/tool_result_clear/plugin_test.go
+++ b/plugins/memory/tool_result_clear/plugin_test.go
@@ -1,0 +1,190 @@
+package tool_result_clear
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// newPluginForTest wires an empty bus + default config so each test can
+// drive the plugin via raw Emit calls without going through full Init.
+func newPluginForTest(t *testing.T) (*Plugin, engine.EventBus) {
+	t.Helper()
+	bus := engine.NewEventBus()
+	p := &Plugin{
+		bus:                bus,
+		logger:             slog.Default(),
+		enabled:            true,
+		ageTurns:           5,
+		sizeBytesThreshold: 1000,
+		preserveKinds:      map[string]bool{"error": true, "user_question": true},
+		dropStrategy:       dropReplaceEnvelope,
+		calls:              make(map[string]*callRecord),
+		argIndex:           make(map[string][]string),
+		preCleared:         make(map[string]string),
+	}
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("tool.invoke", p.handleToolInvoke, engine.WithPriority(60)),
+		bus.Subscribe("tool.result", p.handleToolResult, engine.WithPriority(60)),
+		bus.Subscribe("agent.turn.end", p.handleTurnEnd, engine.WithPriority(60)),
+		bus.Subscribe("before:llm.request", p.handleBeforeLLMRequest, engine.WithPriority(12)),
+	)
+	return p, bus
+}
+
+func TestClearsLargeAgedResults(t *testing.T) {
+	p, bus := newPluginForTest(t)
+
+	// turn 0: invoke + result (1500 bytes, big enough to qualify).
+	big := strings.Repeat("a", 1500)
+	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, ID: "t1", Name: "web_fetch", Arguments: map[string]any{"url": "https://x"}})
+	bus.Emit("tool.result", events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: "t1", Name: "web_fetch", Output: big})
+
+	// Advance 6 turns past age threshold.
+	for i := 0; i < 6; i++ {
+		bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+	}
+
+	cleared := 0
+	bus.Subscribe("memory.tool_result_cleared", func(_ engine.Event[any]) { cleared++ })
+
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Messages: []events.Message{
+		{Role: "tool", ToolCallID: "t1", Content: big},
+	}}
+	if _, err := bus.EmitVetoable("before:llm.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if cleared != 1 {
+		t.Fatalf("expected 1 cleared event, got %d", cleared)
+	}
+	if !strings.Contains(req.Messages[0].Content, `cleared="true"`) {
+		t.Fatalf("expected envelope marker, got %q", req.Messages[0].Content)
+	}
+
+	// Plugin must keep the call/result envelope so the agent retains
+	// the fact-of-the-call.
+	if req.Messages[0].ToolCallID != "t1" {
+		t.Fatalf("ToolCallID lost on clear")
+	}
+	_ = p
+}
+
+func TestPreservesRecentResultsUnderAge(t *testing.T) {
+	p, bus := newPluginForTest(t)
+
+	big := strings.Repeat("b", 2000)
+	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, ID: "t2", Name: "web_fetch", Arguments: map[string]any{"url": "https://y"}})
+	bus.Emit("tool.result", events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: "t2", Name: "web_fetch", Output: big})
+	// Only one turn passes — under age cutoff of 5.
+	bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+
+	cleared := 0
+	bus.Subscribe("memory.tool_result_cleared", func(_ engine.Event[any]) { cleared++ })
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Messages: []events.Message{
+		{Role: "tool", ToolCallID: "t2", Content: big},
+	}}
+	if _, err := bus.EmitVetoable("before:llm.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if cleared != 0 {
+		t.Fatalf("did not expect any clear, got %d", cleared)
+	}
+	if req.Messages[0].Content != big {
+		t.Fatalf("body should be intact when under age")
+	}
+	_ = p
+}
+
+func TestPreservesErrorsRegardlessOfAge(t *testing.T) {
+	_, bus := newPluginForTest(t)
+
+	big := strings.Repeat("e", 1500)
+	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, ID: "t3", Name: "shell"})
+	bus.Emit("tool.result", events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: "t3", Name: "shell", Error: big})
+	for i := 0; i < 8; i++ {
+		bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+	}
+
+	cleared := 0
+	bus.Subscribe("memory.tool_result_cleared", func(_ engine.Event[any]) { cleared++ })
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Messages: []events.Message{
+		{Role: "tool", ToolCallID: "t3", Content: "Error: " + big},
+	}}
+	if _, err := bus.EmitVetoable("before:llm.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if cleared != 0 {
+		t.Fatalf("error result must not be cleared, got %d", cleared)
+	}
+}
+
+func TestSubsequentCallDropsEarlier(t *testing.T) {
+	_, bus := newPluginForTest(t)
+
+	body := strings.Repeat("c", 500) // size below threshold, but subsequent-call should still drop.
+	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, ID: "t4", Name: "search", Arguments: map[string]any{"q": "go"}})
+	bus.Emit("tool.result", events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: "t4", Name: "search", Output: body})
+	bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, ID: "t5", Name: "search", Arguments: map[string]any{"q": "go"}})
+	bus.Emit("tool.result", events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: "t5", Name: "search", Output: body})
+	bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+
+	cleared := 0
+	bus.Subscribe("memory.tool_result_cleared", func(_ engine.Event[any]) { cleared++ })
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Messages: []events.Message{
+		{Role: "tool", ToolCallID: "t4", Content: body},
+		{Role: "tool", ToolCallID: "t5", Content: body},
+	}}
+	if _, err := bus.EmitVetoable("before:llm.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if cleared != 1 {
+		t.Fatalf("expected first of two duplicate calls to be cleared, got %d", cleared)
+	}
+	if !strings.Contains(req.Messages[0].Content, `cleared="true"`) {
+		t.Fatalf("first message should be cleared, got %q", req.Messages[0].Content)
+	}
+	if req.Messages[1].Content != body {
+		t.Fatalf("latest call body must be preserved, got %q", req.Messages[1].Content)
+	}
+}
+
+func TestSkipsSourcedRequests(t *testing.T) {
+	_, bus := newPluginForTest(t)
+	big := strings.Repeat("a", 2000)
+	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, ID: "t6", Name: "web_fetch"})
+	bus.Emit("tool.result", events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: "t6", Name: "web_fetch", Output: big})
+	for i := 0; i < 8; i++ {
+		bus.Emit("agent.turn.end", events.TurnInfo{SchemaVersion: events.TurnInfoVersion})
+	}
+
+	cleared := 0
+	bus.Subscribe("memory.tool_result_cleared", func(_ engine.Event[any]) { cleared++ })
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Metadata: map[string]any{"_source": "another.plugin"},
+		Messages: []events.Message{{Role: "tool", ToolCallID: "t6", Content: big}}}
+	if _, err := bus.EmitVetoable("before:llm.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if cleared != 0 {
+		t.Fatalf("must not touch sourced requests, got %d", cleared)
+	}
+}
+
+func TestEnvelopeMarkerStable(t *testing.T) {
+	got := envelopeMarker("abc", "web_fetch", 1000, 5)
+	want := `<tool_result id="abc" tool="web_fetch" cleared="true" original_size="1000" cleared_at="turn-5" />`
+	if got != want {
+		t.Fatalf("envelope mismatch:\n got:  %s\n want: %s", got, want)
+	}
+}
+
+func TestCanonicalArgHashOrderInvariant(t *testing.T) {
+	a := canonicalArgHash(map[string]any{"x": 1, "y": "two"})
+	b := canonicalArgHash(map[string]any{"y": "two", "x": 1})
+	if a != b {
+		t.Fatalf("hash should be order-invariant; got %s vs %s", a, b)
+	}
+}

--- a/plugins/memory/tool_result_clear/plugin_test.go
+++ b/plugins/memory/tool_result_clear/plugin_test.go
@@ -152,7 +152,7 @@ func TestSubsequentCallDropsEarlier(t *testing.T) {
 	}
 }
 
-func TestSkipsSourcedRequests(t *testing.T) {
+func TestSkipsInternalSubFlowRequests(t *testing.T) {
 	_, bus := newPluginForTest(t)
 	big := strings.Repeat("a", 2000)
 	bus.Emit("tool.invoke", events.ToolCall{SchemaVersion: events.ToolCallVersion, ID: "t6", Name: "web_fetch"})
@@ -163,13 +163,19 @@ func TestSkipsSourcedRequests(t *testing.T) {
 
 	cleared := 0
 	bus.Subscribe("memory.tool_result_cleared", func(_ engine.Event[any]) { cleared++ })
-	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Metadata: map[string]any{"_source": "another.plugin"},
-		Messages: []events.Message{{Role: "tool", ToolCallID: "t6", Content: big}}}
+	// task_kind = "plan" (or any internal kind) signals an internal sub-flow
+	// — curators must leave it alone. A non-empty `_source` alone is no
+	// longer a skip signal: every agent main request now tags its own
+	// pluginID for cost attribution (Idea 09).
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion,
+		Metadata: map[string]any{"_source": "nexus.planner.dynamic", "task_kind": "plan"},
+		Messages: []events.Message{{Role: "tool", ToolCallID: "t6", Content: big}},
+	}
 	if _, err := bus.EmitVetoable("before:llm.request", req); err != nil {
 		t.Fatalf("emit: %v", err)
 	}
 	if cleared != 0 {
-		t.Fatalf("must not touch sourced requests, got %d", cleared)
+		t.Fatalf("must not touch internal sub-flow requests, got %d", cleared)
 	}
 }
 

--- a/plugins/memory/tool_result_clear/schema.go
+++ b/plugins/memory/tool_result_clear/schema.go
@@ -1,0 +1,9 @@
+package tool_result_clear
+
+import _ "embed"
+
+//go:embed schema.json
+var configSchemaBytes []byte
+
+// ConfigSchema implements engine.ConfigSchemaProvider.
+func (p *Plugin) ConfigSchema() []byte { return configSchemaBytes }

--- a/plugins/memory/tool_result_clear/schema.json
+++ b/plugins/memory/tool_result_clear/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexus.local/schemas/plugins/nexus.memory.tool_result_clear.json",
+  "title": "nexus.memory.tool_result_clear",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "enabled":              {"type": "boolean", "description": "Enable the curator. Default true."},
+    "age_turns":            {"type": "integer", "minimum": 0, "description": "Clear tool results older than this many turns when also exceeding size threshold."},
+    "size_bytes_threshold": {"type": "integer", "minimum": 0, "description": "Skip clearing for result bodies smaller than this many bytes."},
+    "preserve_recent_kinds": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Result kinds (e.g. \"error\", \"user_question\") that are never cleared regardless of age."
+    },
+    "drop_strategy": {
+      "type": "string",
+      "enum": ["replace_with_envelope", "full_drop"],
+      "description": "How to drop a stale tool result. replace_with_envelope keeps the call/result pair with a marker body (default). full_drop removes the message entirely (risks tool_use/tool_result pairing breakage)."
+    }
+  }
+}

--- a/plugins/memory/topic_pruner/plugin.go
+++ b/plugins/memory/topic_pruner/plugin.go
@@ -1,0 +1,332 @@
+// Package topic_pruner detects topic shifts in the conversation and emits
+// MemoryTopicShiftDetected when the user appears to have changed subjects.
+//
+// Two signals are combined:
+//
+//   - Explicit phrase matching ("different question", "new topic",
+//     "let's move on", "moving on", etc.) — cheap, deterministic.
+//   - Embedding similarity drop — runs only when the embeddings.provider
+//     capability is active. Compares the latest user input against a
+//     rolling centroid of the current topic's user inputs; a similarity
+//     below the configured threshold flags a shift.
+//
+// Both signals are journalled via the bus event so replay is deterministic
+// even though the classifier itself is heuristic. The pruner does not
+// itself rewrite history — it surfaces the shift so other plugins
+// (summary buffer, compaction) can react. This separation keeps the
+// pruner cheap and avoids stepping on the existing summary_buffer
+// machinery.
+package topic_pruner
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"strings"
+	"sync"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID   = "nexus.memory.topic_pruner"
+	pluginName = "Topic-Aware Pruner"
+	version    = "0.1.0"
+
+	signalPhrase   = "phrase"
+	signalEmbed    = "embedding"
+	signalExplicit = "user_explicit"
+)
+
+// defaultPhrases captures common topic-shift cues. Lowercased; matched via
+// case-insensitive substring contains. Operators can replace via config.
+var defaultPhrases = []string{
+	"different question",
+	"different topic",
+	"new topic",
+	"new question",
+	"let's move on",
+	"moving on",
+	"change of subject",
+	"switching gears",
+	"unrelated:",
+	"separately,",
+	"on a different note",
+}
+
+// Plugin implements the topic-aware pruner.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+
+	enabled              bool
+	similarityThreshold  float64
+	keepLastTopicFull    bool
+	phrases              []string
+	embeddingsCapability bool
+
+	mu               sync.Mutex
+	turn             int
+	currentTopicTurn int
+	// centroid is the rolling mean embedding of the current topic's user
+	// turns. Reset whenever a shift is detected.
+	centroid     []float32
+	centroidSize int
+	// lastShiftTurn debounces consecutive shift signals — back-to-back
+	// shifts within the same turn batch are noise.
+	lastShiftTurn int
+
+	unsubs []func()
+}
+
+// New creates a new topic_pruner plugin.
+func New() engine.Plugin {
+	return &Plugin{
+		enabled:             true,
+		similarityThreshold: 0.55,
+		keepLastTopicFull:   true,
+		phrases:             append([]string{}, defaultPhrases...),
+		lastShiftTurn:       -1,
+	}
+}
+
+func (p *Plugin) ID() string                     { return pluginID }
+func (p *Plugin) Name() string                   { return pluginName }
+func (p *Plugin) Version() string                { return version }
+func (p *Plugin) Dependencies() []string         { return nil }
+func (p *Plugin) Requires() []engine.Requirement { return nil }
+func (p *Plugin) Capabilities() []engine.Capability {
+	return nil
+}
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "io.input", Priority: 60},
+		{EventType: "agent.turn.end", Priority: 60},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"memory.topic_shift_detected",
+		"memory.curated",
+		"embeddings.request",
+	}
+}
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+
+	if v, ok := ctx.Config["enabled"].(bool); ok {
+		p.enabled = v
+	}
+	if v, ok := ctx.Config["similarity_threshold"].(float64); ok {
+		p.similarityThreshold = v
+	}
+	if v, ok := ctx.Config["keep_last_topic_full"].(bool); ok {
+		p.keepLastTopicFull = v
+	}
+	if list, ok := ctx.Config["explicit_phrases"].([]any); ok {
+		phrases := make([]string, 0, len(list))
+		for _, item := range list {
+			if s, ok := item.(string); ok && s != "" {
+				phrases = append(phrases, strings.ToLower(s))
+			}
+		}
+		p.phrases = phrases
+	} else {
+		// Normalise defaults to lowercase up front.
+		for i, ph := range p.phrases {
+			p.phrases[i] = strings.ToLower(ph)
+		}
+	}
+
+	// Detect whether an embeddings.provider is registered. The capability
+	// snapshot is point-in-time at boot; if no provider is active the
+	// pruner falls back to phrase-only signal.
+	if providers := ctx.Capabilities["embeddings.provider"]; len(providers) > 0 {
+		p.embeddingsCapability = true
+	}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("io.input", p.handleInput,
+			engine.WithPriority(60), engine.WithSource(pluginID)),
+		p.bus.Subscribe("agent.turn.end", p.handleTurnEnd,
+			engine.WithPriority(60), engine.WithSource(pluginID)),
+	)
+
+	p.logger.Info("topic_pruner initialized",
+		"enabled", p.enabled,
+		"similarity_threshold", p.similarityThreshold,
+		"embeddings_capability", p.embeddingsCapability,
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, u := range p.unsubs {
+		u()
+	}
+	return nil
+}
+
+// handleInput runs the classifier on every user input.
+func (p *Plugin) handleInput(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	in, ok := e.Payload.(events.UserInput)
+	if !ok {
+		return
+	}
+	text := strings.TrimSpace(in.Content)
+	if text == "" {
+		return
+	}
+
+	// Phrase signal — cheapest first.
+	if signal := p.matchPhrase(text); signal != "" {
+		p.recordShift(signal, 0)
+		return
+	}
+
+	// Embedding signal — only when a provider is registered.
+	if !p.embeddingsCapability {
+		// Still track the input so when an embeddings provider does
+		// arrive (hot reload), we have something to compare against.
+		return
+	}
+
+	vec, ok := p.embed(text)
+	if !ok {
+		return
+	}
+
+	p.mu.Lock()
+	if p.centroid == nil {
+		p.centroid = append([]float32{}, vec...)
+		p.centroidSize = 1
+		p.mu.Unlock()
+		return
+	}
+	sim := cosine(vec, p.centroid)
+	if sim < p.similarityThreshold {
+		// Reset centroid for the new topic.
+		p.centroid = append([]float32{}, vec...)
+		p.centroidSize = 1
+		p.mu.Unlock()
+		p.recordShift(signalEmbed, sim)
+		return
+	}
+	// Update rolling mean.
+	for i := range p.centroid {
+		p.centroid[i] = (p.centroid[i]*float32(p.centroidSize) + vec[i]) / float32(p.centroidSize+1)
+	}
+	p.centroidSize++
+	p.mu.Unlock()
+}
+
+func (p *Plugin) handleTurnEnd(e engine.Event[any]) {
+	if !p.enabled {
+		return
+	}
+	if _, ok := e.Payload.(events.TurnInfo); !ok {
+		return
+	}
+	p.mu.Lock()
+	p.turn++
+	p.mu.Unlock()
+}
+
+// matchPhrase returns the signal kind ("phrase" or "user_explicit") when
+// the text contains any configured cue. We treat the leading-anchor
+// variants ("unrelated:", "separately,") as user_explicit since they're
+// stronger signals; the rest are "phrase".
+func (p *Plugin) matchPhrase(text string) string {
+	low := strings.ToLower(text)
+	for _, ph := range p.phrases {
+		if strings.HasPrefix(low, ph) {
+			return signalExplicit
+		}
+		if strings.Contains(low, ph) {
+			return signalPhrase
+		}
+	}
+	return ""
+}
+
+// recordShift emits the bus events for an observed topic boundary,
+// debouncing same-turn duplicate signals.
+func (p *Plugin) recordShift(signal string, similarity float64) {
+	p.mu.Lock()
+	if p.turn == p.lastShiftTurn {
+		p.mu.Unlock()
+		return
+	}
+	from := p.currentTopicTurn
+	p.lastShiftTurn = p.turn
+	p.currentTopicTurn = p.turn
+	now := p.turn
+	p.mu.Unlock()
+
+	_ = p.bus.Emit("memory.topic_shift_detected", events.MemoryTopicShiftDetected{
+		SchemaVersion: events.MemoryTopicShiftDetectedVersion,
+		FromTurn:      from,
+		ToTurn:        now,
+		Similarity:    similarity,
+		Signal:        signal,
+	})
+	_ = p.bus.Emit("memory.curated", events.MemoryCurated{
+		SchemaVersion: events.MemoryCuratedVersion,
+		Layer:         "topic_pruner",
+		SectionsTouched: []events.CurationSection{{
+			SectionID:   pluginID + "/shift",
+			Kind:        "session",
+			TokensDelta: 0,
+		}},
+		CacheInvalidates: false,
+		AtTurn:           now,
+	})
+}
+
+// embed asks the resolved embeddings provider to encode a single text.
+// Returns false when the provider failed or refused so the caller can
+// fall back to phrase-only behaviour.
+func (p *Plugin) embed(text string) ([]float32, bool) {
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Texts:         []string{text},
+	}
+	if err := p.bus.Emit("embeddings.request", req); err != nil {
+		return nil, false
+	}
+	if req.Error != "" || len(req.Vectors) == 0 || len(req.Vectors[0]) == 0 {
+		return nil, false
+	}
+	return req.Vectors[0], true
+}
+
+// cosine returns the cosine similarity of two equal-length vectors.
+// Returns 0 when a vector is zero-length or all-zero (caller should treat
+// as "below threshold" — same as far apart).
+func cosine(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		x := float64(a[i])
+		y := float64(b[i])
+		dot += x * y
+		na += x * x
+		nb += y * y
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/plugins/memory/topic_pruner/plugin_test.go
+++ b/plugins/memory/topic_pruner/plugin_test.go
@@ -1,0 +1,121 @@
+package topic_pruner
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+func newPluginForTest(t *testing.T, embedAvailable bool) (*Plugin, engine.EventBus) {
+	t.Helper()
+	bus := engine.NewEventBus()
+	p := &Plugin{
+		bus:                  bus,
+		logger:               slog.Default(),
+		enabled:              true,
+		similarityThreshold:  0.55,
+		keepLastTopicFull:    true,
+		phrases:              append([]string{}, defaultPhrases...),
+		embeddingsCapability: embedAvailable,
+		lastShiftTurn:        -1,
+	}
+	for i, ph := range p.phrases {
+		p.phrases[i] = lower(ph)
+	}
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("io.input", p.handleInput, engine.WithPriority(60)),
+		bus.Subscribe("agent.turn.end", p.handleTurnEnd, engine.WithPriority(60)),
+	)
+	return p, bus
+}
+
+// lower is a tiny helper so we don't pull strings into the test header.
+func lower(s string) string {
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 32
+		}
+		out[i] = c
+	}
+	return string(out)
+}
+
+func TestExplicitPhraseShift(t *testing.T) {
+	_, bus := newPluginForTest(t, false)
+
+	shifts := 0
+	bus.Subscribe("memory.topic_shift_detected", func(_ engine.Event[any]) { shifts++ })
+
+	bus.Emit("io.input", events.UserInput{SchemaVersion: events.UserInputVersion, Content: "Different question: how does Go GC work?"})
+
+	if shifts != 1 {
+		t.Fatalf("expected 1 shift event, got %d", shifts)
+	}
+}
+
+func TestPhraseInMiddleStillCounts(t *testing.T) {
+	_, bus := newPluginForTest(t, false)
+
+	shifts := 0
+	bus.Subscribe("memory.topic_shift_detected", func(_ engine.Event[any]) { shifts++ })
+
+	bus.Emit("io.input", events.UserInput{SchemaVersion: events.UserInputVersion, Content: "OK got it. On a different note can you check the build?"})
+
+	if shifts != 1 {
+		t.Fatalf("expected shift via 'on a different note', got %d", shifts)
+	}
+}
+
+func TestNoShiftOnTopicalContinuation(t *testing.T) {
+	_, bus := newPluginForTest(t, false)
+
+	shifts := 0
+	bus.Subscribe("memory.topic_shift_detected", func(_ engine.Event[any]) { shifts++ })
+
+	bus.Emit("io.input", events.UserInput{SchemaVersion: events.UserInputVersion, Content: "Continue with the previous task please."})
+
+	if shifts != 0 {
+		t.Fatalf("expected no shift, got %d", shifts)
+	}
+}
+
+func TestSameTurnDebounce(t *testing.T) {
+	_, bus := newPluginForTest(t, false)
+
+	shifts := 0
+	bus.Subscribe("memory.topic_shift_detected", func(_ engine.Event[any]) { shifts++ })
+
+	// Two phrase-triggering inputs in the same turn — second should debounce.
+	bus.Emit("io.input", events.UserInput{SchemaVersion: events.UserInputVersion, Content: "different question: x"})
+	bus.Emit("io.input", events.UserInput{SchemaVersion: events.UserInputVersion, Content: "new topic: y"})
+
+	if shifts != 1 {
+		t.Fatalf("expected debounce to suppress duplicate shift, got %d", shifts)
+	}
+}
+
+func TestSchemaVersionPropagated(t *testing.T) {
+	_, bus := newPluginForTest(t, false)
+
+	var captured events.MemoryTopicShiftDetected
+	got := false
+	bus.Subscribe("memory.topic_shift_detected", func(e engine.Event[any]) {
+		if v, ok := e.Payload.(events.MemoryTopicShiftDetected); ok {
+			captured = v
+			got = true
+		}
+	})
+
+	bus.Emit("io.input", events.UserInput{SchemaVersion: events.UserInputVersion, Content: "different topic: z"})
+
+	if !got {
+		t.Fatalf("did not capture shift event")
+	}
+	if captured.SchemaVersion != events.MemoryTopicShiftDetectedVersion {
+		t.Fatalf("schema version mismatch: %d", captured.SchemaVersion)
+	}
+}

--- a/plugins/memory/topic_pruner/schema.go
+++ b/plugins/memory/topic_pruner/schema.go
@@ -1,0 +1,9 @@
+package topic_pruner
+
+import _ "embed"
+
+//go:embed schema.json
+var configSchemaBytes []byte
+
+// ConfigSchema implements engine.ConfigSchemaProvider.
+func (p *Plugin) ConfigSchema() []byte { return configSchemaBytes }

--- a/plugins/memory/topic_pruner/schema.json
+++ b/plugins/memory/topic_pruner/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexus.local/schemas/plugins/nexus.memory.topic_pruner.json",
+  "title": "nexus.memory.topic_pruner",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "enabled":               {"type": "boolean", "description": "Enable topic-shift detection. Default true."},
+    "similarity_threshold":  {"type": "number", "minimum": 0, "maximum": 1, "description": "Cosine similarity below which a new user input is flagged as a topic shift. Only used when an embeddings.provider is active."},
+    "keep_last_topic_full":  {"type": "boolean", "description": "When true (default), the most recent topic remains verbatim while older topics may be summarised by downstream plugins. Reserved for future use."},
+    "explicit_phrases": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Lowercase substrings whose presence in a user input is treated as a topic shift signal."
+    }
+  }
+}

--- a/tests/integration/tool_choice_test.go
+++ b/tests/integration/tool_choice_test.go
@@ -47,9 +47,12 @@ func TestToolChoice_SequenceCyclesAcrossIterations(t *testing.T) {
 		if !ok {
 			return
 		}
-		// Skip non-agent requests (planner / compaction) — react agent requests
-		// are the only ones carrying the configured tool_choice sequence.
-		if src, _ := req.Metadata["_source"].(string); src != "" {
+		// Only inspect ReAct main-loop requests — those carry the configured
+		// tool_choice sequence. Filter by task_kind because every agent main
+		// request now also tags itself with `_source = pluginID` for cost
+		// attribution (Idea 09), so a non-empty source check would let
+		// planner / classifier probes through too.
+		if kind, _ := req.Metadata["task_kind"].(string); kind != "react_main" {
 			return
 		}
 		mu.Lock()

--- a/tests/integration/tool_choice_test.go
+++ b/tests/integration/tool_choice_test.go
@@ -47,12 +47,15 @@ func TestToolChoice_SequenceCyclesAcrossIterations(t *testing.T) {
 		if !ok {
 			return
 		}
-		// Only inspect ReAct main-loop requests — those carry the configured
-		// tool_choice sequence. Filter by task_kind because every agent main
-		// request now also tags itself with `_source = pluginID` for cost
-		// attribution (Idea 09), so a non-empty source check would let
-		// planner / classifier probes through too.
-		if kind, _ := req.Metadata["task_kind"].(string); kind != "react_main" {
+		// Skip internal sub-requests (planner, summariser, classifier
+		// router, etc.). The agent main loop carries the configured
+		// tool_choice sequence regardless of which agent type the config
+		// activates; non-empty `_source` no longer distinguishes "internal"
+		// since Idea 09 made every agent main request tag its own pluginID
+		// for cost attribution.
+		kind, _ := req.Metadata["task_kind"].(string)
+		switch kind {
+		case "plan", "summarise", "compact", "classify":
 			return
 		}
 		mu.Lock()

--- a/tests/integration/tool_result_clear_test.go
+++ b/tests/integration/tool_result_clear_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/pkg/testharness"
+)
+
+// TestToolResultClear_FiresAfterTwoTurns drives the agent through two user
+// messages: the first triggers a tool call whose result is recorded; the
+// second pushes the prior tool result past the age threshold so
+// nexus.memory.tool_result_clear replaces its body with the envelope marker
+// before the second turn's LLM request goes out.
+//
+// Asserts that:
+//   - memory.tool_result_cleared event fires exactly once
+//   - memory.curated envelope event fires for the same layer
+//   - the cleared message in the second turn's request carries the
+//     <tool_result … cleared="true" …/> marker rather than the raw body
+func TestToolResultClear_FiresAfterTwoTurns(t *testing.T) {
+	h := testharness.New(t, "configs/test-tool-result-clear.yaml", testharness.WithTimeout(30*time.Second))
+
+	var (
+		mu              sync.Mutex
+		clearedEvents   []events.MemoryToolResultCleared
+		curatedEvents   []events.MemoryCurated
+		toolMessageBody []string // tool-role message contents per before:llm.request
+	)
+
+	h.Bus().Subscribe("memory.tool_result_cleared", func(e engine.Event[any]) {
+		if v, ok := e.Payload.(events.MemoryToolResultCleared); ok {
+			mu.Lock()
+			clearedEvents = append(clearedEvents, v)
+			mu.Unlock()
+		}
+	})
+
+	h.Bus().Subscribe("memory.curated", func(e engine.Event[any]) {
+		if v, ok := e.Payload.(events.MemoryCurated); ok {
+			mu.Lock()
+			curatedEvents = append(curatedEvents, v)
+			mu.Unlock()
+		}
+	})
+
+	// Capture every tool-role message body across requests so we can verify
+	// the envelope marker replaces the original payload on the second turn.
+	h.Bus().Subscribe("before:llm.request", func(e engine.Event[any]) {
+		vp, ok := e.Payload.(*engine.VetoablePayload)
+		if !ok {
+			return
+		}
+		req, ok := vp.Original.(*events.LLMRequest)
+		if !ok {
+			return
+		}
+		// Only the agent's main loop carries tool messages; planner /
+		// summariser / classifier sub-flows don't.
+		if kind, _ := req.Metadata["task_kind"].(string); kind != "react_main" {
+			return
+		}
+		mu.Lock()
+		for _, m := range req.Messages {
+			if m.Role == "tool" {
+				toolMessageBody = append(toolMessageBody, m.Content)
+			}
+		}
+		mu.Unlock()
+	}, engine.WithPriority(15)) // after tool_result_clear (priority 12)
+
+	h.Run()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(clearedEvents) != 1 {
+		t.Fatalf("expected 1 memory.tool_result_cleared, got %d", len(clearedEvents))
+	}
+	if got := clearedEvents[0].Tool; got != "shell" {
+		t.Errorf("expected cleared tool=shell, got %q", got)
+	}
+
+	// memory.curated should fire for the tool_result_clear layer.
+	foundCuratedLayer := false
+	for _, ev := range curatedEvents {
+		if ev.Layer == "tool_result_clear" {
+			foundCuratedLayer = true
+			break
+		}
+	}
+	if !foundCuratedLayer {
+		t.Errorf("expected memory.curated event with Layer=\"tool_result_clear\"; got events: %+v", curatedEvents)
+	}
+
+	// One of the captured tool-message bodies must contain the envelope.
+	envelopeSeen := false
+	for _, body := range toolMessageBody {
+		if strings.Contains(body, `cleared="true"`) {
+			envelopeSeen = true
+			break
+		}
+	}
+	if !envelopeSeen {
+		t.Errorf("expected envelope marker in tool-role message body; bodies seen:\n%s",
+			strings.Join(toolMessageBody, "\n---\n"))
+	}
+}


### PR DESCRIPTION
Closes #89.

Adds the four cheap deterministic curation layers from Idea 30 plus a
reasoning-preservation upgrade to the existing summary buffer. Every
layer emits a `memory.curated` envelope with a stability descriptor
that the future cache-aware prompt builder (Idea 05) will consume.

## Summary

- **`nexus.memory.tool_result_clear`** (priority 12 on `before:llm.request`) — replaces stale tool-result bodies inline with `<tool_result … cleared="true" …/>` while preserving the call/result envelope. Heuristics: age + size, subsequent-call equivalence, preserved kinds (errors/user_question never cleared).
- **`nexus.memory.tool_def_pruner`** (priority 14) — drops idle tool definitions per tool. Complements progressive discovery's class-level scoping. `discover` and `ask_user` are exempt by default; never-prune list is configurable.
- **`nexus.memory.topic_pruner`** — detects topic boundaries on every `io.input` via explicit-phrase match (deterministic) plus optional embedding cosine drop when an `embeddings.provider` is registered. Same-turn duplicate signals are debounced.
- **`nexus.memory.summary_buffer`** — default summariser prompt rewritten for reasoning preservation: tags compressed segments with `<summary topic="…" compressed-from-turns="…">…</summary>` and ends with a `## Preserved Kinds:` trailer that the plugin parses to populate `MemorySummaryReplaced`. Opt-in `quality_retry` re-runs once with a stricter prompt when required kinds are missing.

## Stability descriptor (Idea 05 hand-off)

Every layer emits `memory.curated` with `SectionsTouched[].Kind ∈ {volatile, session, static}` and a `CacheInvalidates` flag. Curators are forbidden from touching `static` sections (system prompt, tool defs at the engine level). Curations batch at turn boundaries to keep cache invalidations predictable until the cache-aware prompt builder lands.

## Replay determinism

Every curation decision (cleared call, pruned tool, topic boundary, summary span) is a journal-able event. The durable journal (Idea 01, #66/#67) records each envelope so replay reproduces curation by replaying decisions, not by re-running heuristics.

## Events (`pkg/events/memory.go`)

| Type | Version |
|---|---|
| `MemoryToolResultCleared` | 1 |
| `MemoryToolDefPruned` | 1 |
| `MemoryTopicShiftDetected` | 1 |
| `MemorySummaryReplaced` | 1 |
| `MemoryCurated` | 1 |

`TestVersionedPayloadsRoundtrip` covers all five.

## Tests

Unit tests per plugin cover the heuristic decisions, debounce, source-skip, and the envelope marker shape. `make test` green; `make vet` and `make lint` clean. (Three integration tests fail the same way on `main` — pre-existing infrastructure.)

## Docs

- New `docs/src/architecture/context-engineering.md` describes the layered stack and the stability descriptor.
- New plugin pages for the three new memory plugins.
- `docs/src/plugins/memory/summary_buffer.md` and the configuration reference both updated for the new keys (`quality_retry`, `require_preserved_kinds`) and emissions.
- SUMMARY.md sidebar exposes everything.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/events/ ./plugins/memory/...`
- [x] `make test` (full module)
- [x] `make vet` / `make lint`
- [ ] Wire into a live config and confirm `memory.tool_result_cleared` fires on a tool-heavy session
- [ ] Eval-harness curation-on/off pivot once Idea 07 wiring lands the new event types

🤖 Generated with [Claude Code](https://claude.com/claude-code)