### PR TITLE
Idea 18 — Multimodal-First Events + Voice IO Transport (Phase 1 cost gap + Phase 2 foundations)

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -89,6 +89,7 @@
 - [Event Types](./events/reference.md)
 - [Configuration Reference](./configuration/reference.md)
 - [Sandboxing](./security/sandboxing.md)
+- [Native Realtime API — deferred](./multimodal/native-realtime-deferred.md)
 
 # Eval Harness
 

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -1062,6 +1062,30 @@ Deterministic hash-based vectors; opt-in via `plugins.active`.
 | `dimensions` | int    | `128`            | Vector dimensionality. |
 | `model`      | string | `mock-embedding` | Model ID string returned to callers. |
 
+### `nexus.embeddings.cohere_multimodal`
+
+Source: `plugins/embeddings/cohere_multimodal/plugin.go`. Provides
+`embeddings.provider` via Cohere Embed v3 (`POST /v2/embed`). Multimodal:
+accepts text and image inputs in a single batch through
+`EmbeddingsRequest.Inputs`. Opt-in: registered but **not** in the default
+`plugins.active` list — wire it explicitly when image embeddings are
+required (e.g. `nexus.memory.vector` with `store_images: true`).
+
+For an `EmbeddingsInput` carrying `ImageURI` with the `nexus-blob:`
+scheme, the plugin resolves bytes via the per-session blob store. When
+the engine boots without a session (rare, mostly tests), the plugin
+errors clearly — callers must inline bytes via `EmbeddingsInput.Image`
+instead.
+
+| Key            | Type     | Default                       | Description |
+|----------------|----------|-------------------------------|-------------|
+| `api_key`      | string   | *(required, or via env)*      | Cohere API key. |
+| `api_key_env`  | string   | `COHERE_API_KEY`              | Override env var name. |
+| `base_url`     | string   | `https://api.cohere.com`      | Cohere API base URL. The plugin appends `/v2/embed` itself. |
+| `model`        | string   | `embed-english-v3.0`          | Cohere embedding model. |
+| `input_type`   | string   | `search_document`             | Cohere `input_type` (e.g. `search_document`, `search_query`, `classification`, `clustering`, `image`). |
+| `timeout`      | duration | `30s`                         | HTTP timeout. |
+
 ---
 
 ## Vector store

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -1374,6 +1374,16 @@ transcript output.
 Prompt resolution precedence: `NEXUS_ONESHOT_PROMPT` env > `input` > `input_file`
 > stdin.
 
+### Native Realtime API integration — deferred
+
+OpenAI Realtime and Gemini Multimodal Live are entire new wire protocols
+separate from the standard chat/generate endpoints. They are **not**
+part of the multimodal-foundation PR (#93) and are tracked as a
+follow-up under issue #91. Until they land, voice-mode use the
+ASR → LLM → TTS pipeline implemented in `plugins/io/voice/`. See
+[Native Realtime API integration — deferred](../multimodal/native-realtime-deferred.md)
+for the full rationale and follow-up scope.
+
 ---
 
 ## Observers

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -967,6 +967,8 @@ Source: `plugins/memory/vector/plugin.go`. Provides `memory.vector`. Requires
 | `auto_store_user_input` | bool   | `false`                | Store user messages on every input (opt-in). |
 | `section_priority`      | int    | `45`                   | Priority of the recalled-memory section in the system prompt. |
 | `recall_via_hybrid`     | bool   | `false`                | When `search.hybrid` is active, route recall queries through it instead of direct vector lookup. Off by default — adds the lexical leg's latency to every user input. |
+| `store_images`          | bool   | `false`                | Embed image attachments on `UserInput.Files` (any `MimeType` starting with `image/`) via the multimodal `embeddings.provider` and store the resulting vector under `image_namespace`. Requires a multimodal adapter (e.g. `nexus.embeddings.cohere_multimodal`); text-only adapters will reject and the path no-ops. Off by default — opt-in. |
+| `image_namespace`       | string | `<namespace>-images`   | Vector store namespace for image embeddings. Kept separate from the text namespace so similarity queries can target one or the other. |
 | `require_approval.enabled`                    | bool     | `false`   | Emit `hitl.requested` before each `vector.upsert`. Off = unchanged behavior. |
 | `require_approval.default_choice`             | string   | *(none)*  | Choice ID picked when the deadline expires (e.g. `reject`). Empty = treat timeout as cancelled. |
 | `require_approval.timeout`                    | duration | *(none)*  | Optional deadline (`5m`, `30s`, …). |

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -829,6 +829,13 @@ Two compilers selected via `compiler`:
   forfeits `tools.*`, `parallel.*`, and skill helpers — the bridge SDK
   does not surface them.
 
+Multimodal helper (host compiler only): scripts may
+`import "nexus"` and call `nexus.ReturnImage(data []byte, mimeType string)`
+to attach images to the resulting `tool.result` (alongside `main.Run`'s
+JSON return). Multiple calls stack in script order; the routing follows
+the same inline / blob-store threshold pattern used by other multimodal
+tools.
+
 | Key                 | Type   | Default                    | Description |
 |---------------------|--------|----------------------------|-------------|
 | `compiler`          | string | `yaegi-host`               | `yaegi-host` or `yaegi-wasm`. The latter requires `sandbox.backend: wasm`. |
@@ -838,6 +845,8 @@ Two compilers selected via `compiler`:
 | `persist_scripts`   | bool   | `true`                     | Write executed scripts to session files. |
 | `reject_goroutines` | bool   | `true`                     | Reject scripts that spawn goroutines. |
 | `allowed_packages`  | list   | *(stdlib whitelist)*       | Importable stdlib packages. |
+| `blob_store.byte_budget`     | int | `2147483648` (2 GiB) | Soft cap on total stored blob bytes per session for `nexus.ReturnImage` payloads. `0` = unbounded. |
+| `blob_store.inline_threshold`| int | `262144` (256 KiB)   | Payloads at or below this size are inlined on the `MessagePart` instead of being stored as a blob. |
 | `sandbox.backend`   | string | `host`                     | Required `wasm` for `compiler: yaegi-wasm`. Other backends (`host`) reject `KindGoWasm` requests. |
 | `sandbox.cache_dir` | string | *(none)*                   | Persistent wazero compilation cache. Recommended for fast cold-start across processes. |
 | `sandbox.timeout`   | duration | `30s`                    | Default per-call wasm timeout. |

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -739,8 +739,18 @@ Source: `plugins/tools/knowledge_search/plugin.go`. Requires
 
 ### `nexus.tool.pdf`
 
-Source: `plugins/tools/pdf/plugin.go`. Registers `read_pdf`. Requires
-`pdftotext` (poppler-utils) on `PATH`.
+Source: `plugins/tools/pdf/plugin.go`. Registers `read_pdf`. Two modes
+selectable per call via `mode` argument or `default_mode` config:
+
+- `text` (default) — extract text via `pdftotext` (poppler-utils).
+  Requires `pdftotext` on `PATH` (or `pdftotext_bin` config).
+- `document` — return the raw PDF bytes as a `file` `MessagePart` on
+  `ToolResult.OutputParts` for native multimodal providers (Anthropic,
+  Gemini). No poppler call. `first_page`, `last_page`, and `layout`
+  arguments are ignored in this mode.
+
+If `default_mode` is `document` and `pdftotext` is missing, the plugin
+boots; text mode then surfaces an actionable error per call.
 
 | Key               | Type     | Default                | Description |
 |-------------------|----------|------------------------|-------------|
@@ -749,6 +759,7 @@ Source: `plugins/tools/pdf/plugin.go`. Registers `read_pdf`. Requires
 | `timeout`         | duration | `30s`                  | Per-extraction timeout. |
 | `save_to_session` | bool     | `false`                | Persist extracted text to session files. |
 | `save_file_name`  | string   | *(derived from PDF)*   | Custom filename for the saved text. |
+| `default_mode`    | string   | `text`                 | `text` or `document`. Default `read_pdf` mode when the LLM doesn't supply one. |
 
 ### `nexus.tool.screenshot`
 

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -670,13 +670,23 @@ deprecated; removal targeted for the milestone after gVisor lands.
 ### `nexus.tool.file`
 
 Source: `plugins/tools/fileio/plugin.go`. Registers `read_file`, `write_file`,
-`check_file_size`, `list_files`.
+`check_file_size`, `list_files`, `read_image`, `read_document`.
 
-| Key                     | Type | Default                 | Description |
-|-------------------------|------|-------------------------|-------------|
-| `base_dir`              | string | *(session files dir)* | Base directory for file operations. |
-| `allow_external_writes` | bool   | `false`               | Permit reads/writes outside `base_dir`. |
-| `tools.<tool_name>`     | bool   | `true` for each       | Per-tool enable/disable: `read_file`, `write_file`, `check_file_size`, `list_files`. |
+`read_image` and `read_document` return a `MessagePart` on
+`ToolResult.OutputParts`; the memory plugin copies parts onto the resulting
+tool-role `Message.Parts` so the next LLM request sees the multimodal
+content. Provider plugins resolve `MessagePart.URI = "nexus-blob:<sha>"`
+references from the per-session blob store at `~/.nexus/sessions/<id>/blobs/`
+when the payload was stored, or use the inline `MessagePart.Data` when it
+was inlined.
+
+| Key                          | Type   | Default                 | Description |
+|------------------------------|--------|-------------------------|-------------|
+| `base_dir`                   | string | *(session files dir)* | Base directory for file operations. |
+| `allow_external_writes`      | bool   | `false`               | Permit reads/writes outside `base_dir`. |
+| `blob_store.byte_budget`     | int    | `2147483648` (2 GiB)  | Soft cap on total stored blob bytes per session. `0` = unbounded. Applied via LRU sweep after each blob put. |
+| `blob_store.inline_threshold`| int    | `262144` (256 KiB)    | Payloads at or below this size are inlined on the `MessagePart` instead of being stored as a blob. |
+| `tools.<tool_name>`          | bool   | `true` for each       | Per-tool enable/disable: `read_file`, `write_file`, `check_file_size`, `list_files`, `read_image`, `read_document`. |
 
 ### `nexus.tool.catalog`
 

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -696,22 +696,32 @@ Source: `plugins/tools/catalog/plugin.go`. **No configuration.** Provides the
 
 ### `nexus.tool.web`
 
-Source: `plugins/tools/web/plugin.go`. Registers `web_search` and `web_fetch`.
-Requires the `search.provider` capability for `web_search`.
+Source: `plugins/tools/web/plugin.go`. Registers `web_search`, `web_fetch`,
+and `fetch_page_image`. Requires the `search.provider` capability for
+`web_search`. `fetch_page_image` requires `screenshot_provider` config —
+without it, the tool surfaces a clear error at invoke time.
 
-| Key                          | Type     | Default                                | Description |
-|------------------------------|----------|----------------------------------------|-------------|
-| `search.default_count`       | int      | `10`                                   | Default result count for `web_search`. |
-| `search.default_safe_search` | string   | `moderate`                             | `off`, `moderate`, `strict`. |
-| `search.default_language`    | string   | *(none)*                               | BCP-47 language tag (e.g. `en`, `es-MX`). |
-| `fetch.user_agent`           | string   | `Nexus/0.1 (+https://...)`             | User-Agent header for `web_fetch`. |
-| `fetch.timeout`              | duration | `20s`                                  | HTTP timeout. |
-| `fetch.max_size`             | int      | `5242880` (5 MB)                       | Maximum response body size. |
-| `fetch.default_extract`      | string   | `readability`                          | `readability` or `raw`. |
-| `fetch.allowed_domains`      | list     | *(none — allow all)*                   | Allowlist of domains. |
-| `fetch.blocked_domains`      | list     | *(none)*                               | Blocklist of domains. |
-| `fetch.follow_redirects`     | bool     | `true`                                 | Follow HTTP redirects. |
-| `fetch.max_redirects`        | int      | `5`                                    | Maximum redirect chain length. |
+| Key                              | Type     | Default                                | Description |
+|----------------------------------|----------|----------------------------------------|-------------|
+| `search.default_count`           | int      | `10`                                   | Default result count for `web_search`. |
+| `search.default_safe_search`     | string   | `moderate`                             | `off`, `moderate`, `strict`. |
+| `search.default_language`        | string   | *(none)*                               | BCP-47 language tag (e.g. `en`, `es-MX`). |
+| `fetch.user_agent`               | string   | `Nexus/0.1 (+https://...)`             | User-Agent header for `web_fetch`. |
+| `fetch.timeout`                  | duration | `20s`                                  | HTTP timeout. |
+| `fetch.max_size`                 | int      | `5242880` (5 MB)                       | Maximum response body size. |
+| `fetch.default_extract`          | string   | `readability`                          | `readability` or `raw`. |
+| `fetch.allowed_domains`          | list     | *(none — allow all)*                   | Allowlist of domains. |
+| `fetch.blocked_domains`          | list     | *(none)*                               | Blocklist of domains. |
+| `fetch.follow_redirects`         | bool     | `true`                                 | Follow HTTP redirects. |
+| `fetch.max_redirects`            | int      | `5`                                    | Maximum redirect chain length. |
+| `screenshot_provider.url`        | string   | *(required for `fetch_page_image`)*    | Endpoint of the external screenshot service (urlbox, screenshotapi.net, browserless, …). |
+| `screenshot_provider.method`     | string   | `POST`                                 | `GET` or `POST`. |
+| `screenshot_provider.api_key_env`| string   | *(none)*                               | Env var holding the bearer token / API key. POST sends `Authorization: Bearer <key>`; GET appends `api_key=<key>` to the query. |
+| `screenshot_provider.url_param_name` | string | `url`                              | Field name carrying the target URL. |
+| `screenshot_provider.request_template` | map | *(empty)*                          | Extra fields merged into the JSON body (POST) or query string (GET). |
+| `screenshot_provider.headers`    | map      | *(empty)*                              | Fixed headers sent with every provider request. |
+| `blob_store.byte_budget`         | int      | `2147483648` (2 GiB)                   | Soft cap on total stored blob bytes per session for `fetch_page_image`. `0` = unbounded. |
+| `blob_store.inline_threshold`    | int      | `262144` (256 KiB)                     | Payloads at or below this size are inlined on the `MessagePart` instead of stored as a blob. |
 
 ### `nexus.tool.knowledge_search`
 
@@ -1208,6 +1218,73 @@ Source: `plugins/io/browser/plugin.go`.
 | `host`         | string | `localhost` | HTTP listen address. |
 | `port`         | int    | `8080`      | HTTP listen port. |
 | `open_browser` | bool   | `true`      | Auto-open the browser tab on startup (no-op when the OS lacks an opener). |
+
+### `nexus.io.realtime`
+
+Source: `plugins/io/realtime/plugin.go`. WebSocket bidirectional transport
+for low-latency clients (browser front-ends, native voice clients) that
+want raw `stream.delta` deltas, tool previews, voice audio chunks, and
+cancel envelopes without going through the `nexus.io.browser` UI hub.
+
+| Key            | Type   | Default  | Description |
+|----------------|--------|----------|-------------|
+| `listen_addr`  | string | `:7676`  | TCP address the WebSocket server binds to. |
+| `path`         | string | `/ws`    | URL path the WebSocket handler is mounted at. |
+| `max_clients`  | int    | `16`     | Concurrent connection cap. New dials past the cap receive HTTP 503. |
+
+**Outbound envelopes** (server → client, JSON): `stream.delta`, `stream.end`,
+`tool.preview`, `audio.chunk`, `cancel.complete`, `hitl.request`.
+
+**Inbound envelopes** (client → server, JSON): `input`, `audio.chunk`,
+`cancel`, `approval`.
+
+**No auth in v1.** Origin checks and bearer-token validation are tracked
+follow-ups; operators running this on a public network must front it
+with a reverse proxy that does its own authentication.
+
+### `nexus.io.voice`
+
+Source: `plugins/io/voice/plugin.go`. Bus-driven voice IO bridge:
+consumes `voice.audio.input.chunk` events (typically from
+`nexus.io.realtime`), runs simple energy-based VAD plus ASR via the
+OpenAI Whisper API, and emits `io.input`. Consumes `llm.response`,
+runs TTS via the OpenAI `/audio/speech` endpoint, and emits
+`voice.audio.output.chunk` frames back. Implements barge-in: a
+speech-energy input chunk arriving while a TTS turn is in flight emits
+`cancel.request{Source: "voice"}`.
+
+Local-model providers (`local_whisper`, `faster_whisper`,
+`distil_whisper` for ASR; `kokoro`, `local_*`, `*_local` for TTS) are
+recognized by the schema but rejected at `Init` with a clear error
+pointing at issue #92, where the local-model bootstrapping work is
+tracked separately.
+
+| Key                  | Type    | Default            | Description |
+|----------------------|---------|--------------------|-------------|
+| `asr.provider`       | string  | `openai_whisper`   | Only `openai_whisper` is wired in this PR. Local-model values rejected pending #92. |
+| `asr.api_key_env`    | string  | `OPENAI_API_KEY`   | Env var that holds the API key. |
+| `asr.api_key`        | string  | *(none)*           | Inline API key. Overrides `api_key_env`. |
+| `asr.model`          | string  | `whisper-1`        | Whisper model id. |
+| `asr.endpoint`       | string  | OpenAI default     | Override URL for the transcription endpoint (test injection). |
+| `tts.provider`       | string  | `openai`           | Only `openai` is wired in this PR. Local-model values rejected pending #92. |
+| `tts.api_key_env`    | string  | `OPENAI_API_KEY`   | Env var that holds the API key. |
+| `tts.api_key`        | string  | *(none)*           | Inline API key. Overrides `api_key_env`. |
+| `tts.model`          | string  | `tts-1`            | TTS model id. |
+| `tts.voice`          | string  | `alloy`            | Voice preset id. |
+| `tts.streaming`      | bool    | `true`             | Always true in v1; reserved for future non-streaming mode. |
+| `tts.endpoint`       | string  | OpenAI default     | Override URL for the speech endpoint (test injection). |
+| `tts.chunk_bytes`    | int     | `8192`             | Frame size in bytes for emitted output chunks. |
+| `vad.threshold`      | number  | `0.02`             | RMS energy threshold (normalized 0..1) above which the buffer is considered speech. |
+| `vad.silence_ms`     | integer | `600`              | Milliseconds of below-threshold audio that triggers an utterance flush. |
+| `barge_in.enabled`   | bool    | `true`             | Cancel an in-flight TTS turn when new speech is detected. |
+| `barge_in.threshold` | number  | `vad.threshold`    | RMS threshold above which an incoming chunk is treated as barge-in. |
+| `text_fallback`      | bool    | `true`             | Allow `io.input` from non-voice transports to flow through unchanged. |
+
+VAD energy is computed as RMS over little-endian PCM int16 samples for
+`audio/wav` / `audio/pcm` / `audio/l16`. For compressed containers
+(webm/opus, mpeg/mp3) the bytes are not PCM and we fall back to a
+byte-level energy heuristic until a proper decode is added — flagged
+with a `TODO(#91)` in `plugins/io/voice/vad.go`.
 
 ### `nexus.io.test`
 

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -740,6 +740,23 @@ Source: `plugins/tools/pdf/plugin.go`. Registers `read_pdf`. Requires
 | `save_to_session` | bool     | `false`                | Persist extracted text to session files. |
 | `save_file_name`  | string   | *(derived from PDF)*   | Custom filename for the saved text. |
 
+### `nexus.tool.screenshot`
+
+Source: `plugins/tools/screenshot/plugin.go`. Registers `take_screenshot`.
+Captures the full screen as PNG and emits an `image` `MessagePart` on
+`ToolResult.OutputParts`. Capture path is platform-specific:
+
+- `darwin`: `screencapture -t png -x <tmpfile>`
+- `linux`: `gnome-screenshot -f <tmpfile>`, then `grim <tmpfile>`, then
+  ImageMagick's `import -window root <tmpfile>` as fallbacks
+- other platforms: emits `ToolResult.Error: "screenshot not supported on this platform"`
+
+| Key                          | Type     | Default               | Description |
+|------------------------------|----------|-----------------------|-------------|
+| `timeout`                    | duration | `15s`                 | Per-capture subprocess timeout. |
+| `blob_store.byte_budget`     | int      | `2147483648` (2 GiB)  | Soft cap on total stored blob bytes per session. `0` = unbounded. |
+| `blob_store.inline_threshold`| int      | `262144` (256 KiB)    | Payloads at or below this size are inlined on the `MessagePart` instead of stored as a blob. |
+
 ### `nexus.tool.opener`
 
 Source: `plugins/tools/opener/plugin.go`. Registers `open_path`.

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -286,6 +286,10 @@ Certain metadata keys carry special meaning:
 | `PromptTokens` | int | Input tokens consumed |
 | `CompletionTokens` | int | Output tokens generated |
 | `TotalTokens` | int | Total tokens |
+| `ReasoningTokens` | int | Thinking / reasoning tokens (Gemini 2.5 thoughtTokenCount, etc.) |
+| `CachedTokens` | int | Tokens served from a prompt cache |
+| `CacheWriteTokens` | int | Tokens written into a prompt cache |
+| `ModalityBreakdown` | map[string]int | Per-modality token counts when the provider reports them. Lowercase keys: `text`, `image`, `audio`, `video`, `document`. Empty when the provider does not split modalities (Anthropic) or the request was text-only. Cost-attribution consumers read this to bill image / audio turns separately. |
 
 **StreamChunk**
 | Field | Type | Description |

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -707,13 +707,27 @@ Chunks are flushed on every newline and on a ~512-byte threshold so long lines w
 **EmbeddingsRequest**
 | Field | Type | Description |
 |-------|------|-------------|
-| `Texts` | []string | Batch of strings to embed (input). |
+| `Texts` | []string | Batch of strings to embed (input). Used when `Inputs` is empty — back-compat with text-only adapters. |
+| `Inputs` | []EmbeddingsInput | Polymorphic batch (text + image inputs) for multimodal-aware providers. When non-empty, providers consume `Inputs` and ignore `Texts`. |
 | `Model` | string | Requested model; provider may echo back actual model used. |
 | `Dimensions` | int | Optional truncation hint. Zero = provider default. |
 | `Vectors` | [][]float32 | Result vectors, in input order (output). |
 | `Provider` | string | Plugin ID of the adapter that answered (output). |
 | `Usage` | EmbeddingsUsage | Token usage when reported by the provider (output). |
 | `Error` | string | Non-empty on failure (output). |
+
+**EmbeddingsInput**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Text` | string | Text snippet. Mutually exclusive with `Image` and `ImageURI`. |
+| `Image` | []byte | Inline image bytes. Mutually exclusive with `Text` and `ImageURI`. Requires `MimeType`. |
+| `ImageURI` | string | Image reference: `nexus-blob:<sha>` (engine blob store) or external URL. Mutually exclusive with `Text` and `Image`. |
+| `MimeType` | string | IANA media type (e.g. `image/png`). Required when `Image` is set; recommended for `ImageURI`. |
+
+Adapters that don't support image inputs must return a clear error when
+they encounter an image-bearing input rather than silently downgrading.
+See `nexus.embeddings.cohere_multimodal` for a multimodal-aware reference
+adapter.
 
 **EmbeddingsUsage**
 | Field | Type | Description |

--- a/docs/src/events/reference.md
+++ b/docs/src/events/reference.md
@@ -291,6 +291,19 @@ Certain metadata keys carry special meaning:
 | `CacheWriteTokens` | int | Tokens written into a prompt cache |
 | `ModalityBreakdown` | map[string]int | Per-modality token counts when the provider reports them. Lowercase keys: `text`, `image`, `audio`, `video`, `document`. Empty when the provider does not split modalities (Anthropic) or the request was text-only. Cost-attribution consumers read this to bill image / audio turns separately. |
 
+#### Multimodal tool results
+
+`ToolResult` carries an `OutputParts []MessagePart` field for tools that
+emit multimodal content (image, audio, document, video). When non-empty,
+memory plugins copy the parts onto the resulting tool-role
+`Message.Parts` so the next LLM request includes the multimodal content
+alongside (or in place of) `Output`.
+
+Large payloads should be stored via `pkg/engine/blobs` and referenced via
+`MessagePart.URI = "nexus-blob:<sha256>"` so the journal stays compact;
+small payloads can ride inline as `MessagePart.Data`. Provider plugins
+resolve `nexus-blob:` URIs at request-assembly time.
+
 **StreamChunk**
 | Field | Type | Description |
 |-------|------|-------------|

--- a/docs/src/multimodal/native-realtime-deferred.md
+++ b/docs/src/multimodal/native-realtime-deferred.md
@@ -1,0 +1,46 @@
+# Native Realtime API Integration — Deferred
+
+Both **OpenAI Realtime API** and **Gemini Multimodal Live** are entire new
+wire protocols separate from the standard chat/generate endpoints already
+used by `plugins/providers/openai/` and `plugins/providers/gemini/`. They
+require per-provider WebSocket clients with their own session lifecycle,
+tool-use envelopes, audio-streaming framing, and turn-taking semantics —
+each on the order of a full provider plugin's implementation surface.
+
+That is too large to ship in the multimodal-foundation PR ([#93][pr]),
+which limits scope to the building blocks: blob store, multimodal
+`MessagePart` plumbing, the `EmbeddingsRequest.Inputs` shape, the Cohere
+multimodal embeddings adapter, and the `nexus.memory.vector`
+`store_images` opt-in. Native realtime adapters are tracked under issue
+[#91][issue] as a follow-up.
+
+Until they land, voice-mode users go through the standard pipeline:
+
+```
+ASR (e.g. Whisper) → llm.request → TTS
+```
+
+implemented as the `plugins/io/voice/` transport (Phase 4 of #91). The
+voice IO plugin is a portable design — when realtime providers are
+wired, the same agent configs keep working; only the inner LLM call is
+replaced with a streaming session.
+
+## What's needed when these land
+
+For each provider:
+
+- WebSocket client (`gorilla/websocket` or stdlib upgrader on the server
+  side; both providers run server-sent WebSockets) honoring the
+  documented session-init handshake.
+- A new `nexus.io.realtime.<provider>` transport plugin OR a new LLM
+  provider variant that consumes `voice.audio.input.chunk` events and
+  emits `voice.audio.output.chunk` events. Decision deferred to the
+  follow-up issue; both shapes work, but the IO-plugin shape keeps the
+  rest of the engine unaware of the streaming wire details.
+- Tool-use bridging: realtime APIs surface tool calls inline in the
+  audio stream — those need to translate into the existing `tool.call`
+  / `tool.result` events with no behavior change for tool plugins.
+- Cancel + barge-in plumbing onto `nexus.control.cancel`.
+
+[pr]: https://github.com/frankbardon/nexus/pull/93
+[issue]: https://github.com/frankbardon/nexus/issues/91

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -20,6 +20,7 @@ import (
 	// IO plugins.
 	browserplugin "github.com/frankbardon/nexus/plugins/io/browser"
 	oneshotplugin "github.com/frankbardon/nexus/plugins/io/oneshot"
+	realtimeplugin "github.com/frankbardon/nexus/plugins/io/realtime"
 	testioplugin "github.com/frankbardon/nexus/plugins/io/test"
 	tuiplugin "github.com/frankbardon/nexus/plugins/io/tui"
 	voiceplugin "github.com/frankbardon/nexus/plugins/io/voice"
@@ -138,6 +139,7 @@ func RegisterAll(r *engine.PluginRegistry) {
 	// IO
 	r.Register("nexus.io.tui", tuiplugin.New)
 	r.Register("nexus.io.browser", browserplugin.New)
+	r.Register("nexus.io.realtime", realtimeplugin.New)
 	r.Register("nexus.io.voice", voiceplugin.New)
 	r.Register("nexus.io.oneshot", oneshotplugin.New)
 	r.Register("nexus.io.test", testioplugin.New)

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -97,6 +97,7 @@ import (
 	knowledgesearchplugin "github.com/frankbardon/nexus/plugins/tools/knowledge_search"
 	openerplugin "github.com/frankbardon/nexus/plugins/tools/opener"
 	pdfplugin "github.com/frankbardon/nexus/plugins/tools/pdf"
+	screenshotplugin "github.com/frankbardon/nexus/plugins/tools/screenshot"
 	"github.com/frankbardon/nexus/plugins/tools/shell"
 	webplugin "github.com/frankbardon/nexus/plugins/tools/web"
 
@@ -213,6 +214,7 @@ func RegisterAll(r *engine.PluginRegistry) {
 	r.Register("nexus.tool.file", fileio.New)
 	r.Register("nexus.tool.catalog", catalogplugin.New)
 	r.Register("nexus.tool.pdf", pdfplugin.New)
+	r.Register("nexus.tool.screenshot", screenshotplugin.New)
 	r.Register("nexus.tool.opener", openerplugin.New)
 	r.Register("nexus.control.hitl", hitlplugin.New)
 	r.Register("nexus.tool.code_exec", codeexecplugin.New)

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -22,6 +22,7 @@ import (
 	oneshotplugin "github.com/frankbardon/nexus/plugins/io/oneshot"
 	testioplugin "github.com/frankbardon/nexus/plugins/io/test"
 	tuiplugin "github.com/frankbardon/nexus/plugins/io/tui"
+	voiceplugin "github.com/frankbardon/nexus/plugins/io/voice"
 
 	// LLM coordination plugins.
 	batchplugin "github.com/frankbardon/nexus/plugins/llm/batch"
@@ -137,6 +138,7 @@ func RegisterAll(r *engine.PluginRegistry) {
 	// IO
 	r.Register("nexus.io.tui", tuiplugin.New)
 	r.Register("nexus.io.browser", browserplugin.New)
+	r.Register("nexus.io.voice", voiceplugin.New)
 	r.Register("nexus.io.oneshot", oneshotplugin.New)
 	r.Register("nexus.io.test", testioplugin.New)
 

--- a/pkg/engine/allplugins/register.go
+++ b/pkg/engine/allplugins/register.go
@@ -62,6 +62,7 @@ import (
 	openainativesearch "github.com/frankbardon/nexus/plugins/search/openai_native"
 
 	// Embeddings provider plugins (advertise the "embeddings.provider" capability).
+	coheremultimodalembeddings "github.com/frankbardon/nexus/plugins/embeddings/cohere_multimodal"
 	mockembeddings "github.com/frankbardon/nexus/plugins/embeddings/mock"
 	openaiembeddings "github.com/frankbardon/nexus/plugins/embeddings/openai"
 
@@ -185,6 +186,10 @@ func RegisterAll(r *engine.PluginRegistry) {
 	// Embeddings providers (capability: embeddings.provider)
 	r.Register("nexus.embeddings.openai", openaiembeddings.New)
 	r.Register("nexus.embeddings.mock", mockembeddings.New)
+	// Multimodal (text + image) Cohere Embed v3 adapter. Opt-in: not in
+	// the default plugins.active list; users wire it explicitly when they
+	// want image embedding support.
+	r.Register("nexus.embeddings.cohere_multimodal", coheremultimodalembeddings.New)
 
 	// Vector stores (capability: vector.store)
 	r.Register("nexus.vectorstore.chromem", chromemvector.New)

--- a/pkg/engine/blobs/blobs.go
+++ b/pkg/engine/blobs/blobs.go
@@ -1,0 +1,334 @@
+// Package blobs implements a content-addressed blob store for multimodal
+// payloads (images, audio, documents, video) referenced from event-payload
+// MessageParts.
+//
+// The store keys blobs by sha256 of their bytes. Same content + media type
+// always returns the same handle, so callers can re-emit MessageParts that
+// reference a blob by URI without re-uploading.
+//
+// Layout:
+//
+//	{root}/
+//	  ab/
+//	    abcdef...01.bin   raw bytes (immutable once written)
+//	    abcdef...01.meta  "media/type\nsize\n"
+//
+// LRU is recorded by file mtime on the .bin file. Get() touches mtime so
+// recently-read blobs survive eviction. Sweep() walks the tree, sorts by
+// mtime ascending, deletes oldest until total bytes <= byteBudget.
+//
+// The store is process-local and synchronized via an internal mutex. It is
+// safe for concurrent Put/Get/Sweep across goroutines in one process.
+// Cross-process access is not supported (blob writes are atomic via
+// temp+rename, but Sweep is not coordinated across processes).
+package blobs
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Handle is a content-addressed reference to a stored blob.
+type Handle struct {
+	// SHA256 is the lowercase hex sha256 of the blob bytes. 64 chars.
+	SHA256 string
+
+	// MediaType is the IANA media type the caller supplied at Put time
+	// (e.g. "image/png", "application/pdf"). Empty when the caller didn't
+	// pass one.
+	MediaType string
+
+	// Size is the number of bytes stored.
+	Size int64
+
+	// Path is the absolute path to the .bin file. Useful for tools that
+	// want to stream the file rather than load into memory.
+	Path string
+}
+
+// URI returns a stable reference scheme that consumers (provider plugins,
+// MessagePart.URI) can resolve back to a blob. Form: "nexus-blob:<sha256>".
+func (h Handle) URI() string {
+	return "nexus-blob:" + h.SHA256
+}
+
+// SHAFromURI extracts the sha256 from a "nexus-blob:<sha>" URI. Returns the
+// empty string if the URI is not in that scheme.
+func SHAFromURI(uri string) string {
+	const prefix = "nexus-blob:"
+	if !strings.HasPrefix(uri, prefix) {
+		return ""
+	}
+	return uri[len(prefix):]
+}
+
+// Store is a content-addressed blob store rooted at a directory.
+type Store struct {
+	root       string
+	byteBudget int64
+
+	mu sync.Mutex
+}
+
+// New opens or creates a blob store rooted at dir. dir is created if missing.
+//
+// byteBudget is the soft cap for total stored bytes. When zero, the store
+// is unbounded and Sweep is a no-op. When positive, callers should call
+// Sweep periodically (or after Put) to enforce the cap.
+func New(dir string, byteBudget int64) (*Store, error) {
+	if dir == "" {
+		return nil, errors.New("blobs: empty root directory")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("blobs: create root: %w", err)
+	}
+	return &Store{root: dir, byteBudget: byteBudget}, nil
+}
+
+// Root returns the absolute root directory the store writes into.
+func (s *Store) Root() string { return s.root }
+
+// ByteBudget returns the configured soft cap (0 = unbounded).
+func (s *Store) ByteBudget() int64 { return s.byteBudget }
+
+// SetByteBudget updates the soft cap. Doesn't trigger an immediate sweep —
+// call Sweep separately if needed.
+func (s *Store) SetByteBudget(n int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.byteBudget = n
+}
+
+// Put writes data under its sha256 and returns a Handle. Idempotent — if a
+// blob with the same sha already exists, Put updates the mtime (touching
+// LRU) and returns its handle without rewriting.
+//
+// MediaType is recorded in a sidecar .meta file. When a Put hits an
+// existing blob, the recorded MediaType is the original — callers that
+// pass a different MediaType for the same content will read back the
+// original. (Same bytes + different media type would imply a content-type
+// confusion bug at the caller.)
+func (s *Store) Put(data []byte, mediaType string) (Handle, error) {
+	sum := sha256.Sum256(data)
+	sha := hex.EncodeToString(sum[:])
+	binPath, metaPath := s.paths(sha)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if info, err := os.Stat(binPath); err == nil {
+		// Already present — touch mtime for LRU and read back the existing
+		// media type so callers don't accidentally rewrite metadata.
+		now := time.Now()
+		_ = os.Chtimes(binPath, now, now)
+		mt, _ := readMeta(metaPath)
+		return Handle{SHA256: sha, MediaType: mt, Size: info.Size(), Path: binPath}, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
+		return Handle{}, fmt.Errorf("blobs: mkdir: %w", err)
+	}
+	if err := writeAtomic(binPath, data); err != nil {
+		return Handle{}, err
+	}
+	if err := writeAtomic(metaPath, []byte(formatMeta(mediaType, int64(len(data))))); err != nil {
+		return Handle{}, err
+	}
+	return Handle{SHA256: sha, MediaType: mediaType, Size: int64(len(data)), Path: binPath}, nil
+}
+
+// Get returns the bytes and media type for a blob, or os.ErrNotExist if
+// missing. Touches mtime so subsequent Sweep treats this as recently used.
+func (s *Store) Get(sha string) ([]byte, string, error) {
+	binPath, metaPath := s.paths(sha)
+	data, err := os.ReadFile(binPath)
+	if err != nil {
+		return nil, "", err
+	}
+	now := time.Now()
+	_ = os.Chtimes(binPath, now, now)
+	mt, _ := readMeta(metaPath)
+	return data, mt, nil
+}
+
+// Stat returns the handle for a blob without loading its bytes. Updates
+// mtime like Get so Stat-based hot paths don't get evicted.
+func (s *Store) Stat(sha string) (Handle, error) {
+	binPath, metaPath := s.paths(sha)
+	info, err := os.Stat(binPath)
+	if err != nil {
+		return Handle{}, err
+	}
+	now := time.Now()
+	_ = os.Chtimes(binPath, now, now)
+	mt, _ := readMeta(metaPath)
+	return Handle{SHA256: sha, MediaType: mt, Size: info.Size(), Path: binPath}, nil
+}
+
+// Delete removes a blob. Missing blobs are not an error.
+func (s *Store) Delete(sha string) error {
+	binPath, metaPath := s.paths(sha)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.Remove(binPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("blobs: delete bin: %w", err)
+	}
+	if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("blobs: delete meta: %w", err)
+	}
+	return nil
+}
+
+// Sweep evicts blobs in LRU order until total stored bytes <= byteBudget.
+// Returns the count of evicted blobs and the total bytes freed.
+//
+// No-op when byteBudget is zero (unbounded store).
+func (s *Store) Sweep() (evicted int, freed int64, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byteBudget <= 0 {
+		return 0, 0, nil
+	}
+
+	type entry struct {
+		path  string
+		sha   string
+		size  int64
+		mtime time.Time
+	}
+	var entries []entry
+	var total int64
+
+	walkErr := filepath.Walk(s.root, func(path string, info os.FileInfo, ferr error) error {
+		if ferr != nil {
+			return ferr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".bin") {
+			return nil
+		}
+		sha := strings.TrimSuffix(filepath.Base(path), ".bin")
+		entries = append(entries, entry{path: path, sha: sha, size: info.Size(), mtime: info.ModTime()})
+		total += info.Size()
+		return nil
+	})
+	if walkErr != nil {
+		return 0, 0, fmt.Errorf("blobs: walk: %w", walkErr)
+	}
+
+	if total <= s.byteBudget {
+		return 0, 0, nil
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].mtime.Before(entries[j].mtime)
+	})
+
+	for _, e := range entries {
+		if total <= s.byteBudget {
+			break
+		}
+		_, metaPath := s.paths(e.sha)
+		if rerr := os.Remove(e.path); rerr != nil && !os.IsNotExist(rerr) {
+			return evicted, freed, fmt.Errorf("blobs: evict bin: %w", rerr)
+		}
+		if rerr := os.Remove(metaPath); rerr != nil && !os.IsNotExist(rerr) {
+			return evicted, freed, fmt.Errorf("blobs: evict meta: %w", rerr)
+		}
+		total -= e.size
+		freed += e.size
+		evicted++
+	}
+	return evicted, freed, nil
+}
+
+// TotalBytes walks the store and returns the current total of stored blob
+// bytes. Useful for tests and for callers that want to decide whether to
+// trigger Sweep.
+func (s *Store) TotalBytes() (int64, error) {
+	var total int64
+	err := filepath.Walk(s.root, func(path string, info os.FileInfo, ferr error) error {
+		if ferr != nil {
+			return ferr
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".bin") {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total, err
+}
+
+// paths returns the (.bin, .meta) absolute paths for a sha. The blob is
+// nested into a two-char prefix directory to avoid one giant flat dir.
+func (s *Store) paths(sha string) (binPath, metaPath string) {
+	prefix := "00"
+	if len(sha) >= 2 {
+		prefix = sha[:2]
+	}
+	bin := filepath.Join(s.root, prefix, sha+".bin")
+	meta := filepath.Join(s.root, prefix, sha+".meta")
+	return bin, meta
+}
+
+// writeAtomic writes data to path via a same-directory temp file + rename
+// so concurrent readers never see a partial blob.
+func writeAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("blobs: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("blobs: write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("blobs: close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("blobs: rename: %w", err)
+	}
+	return nil
+}
+
+// formatMeta serializes the sidecar contents: "<media-type>\n<size>\n".
+func formatMeta(mediaType string, size int64) string {
+	return mediaType + "\n" + strconv.FormatInt(size, 10) + "\n"
+}
+
+// readMeta loads "<media-type>\n<size>\n" from a sidecar. Errors and
+// missing files yield ("", err) so the caller can decide whether to surface
+// or treat as empty (Get/Stat treat as empty).
+func readMeta(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.SplitN(string(buf), "\n", 2)
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return parts[0], nil
+}

--- a/pkg/engine/blobs/blobs_test.go
+++ b/pkg/engine/blobs/blobs_test.go
@@ -1,0 +1,287 @@
+package blobs
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T, budget int64) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := New(dir, budget)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+func TestPutGet_RoundTrip(t *testing.T) {
+	s := newTestStore(t, 0)
+	data := []byte("hello world")
+
+	h, err := s.Put(data, "text/plain")
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	want := sha256.Sum256(data)
+	if h.SHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("SHA256: got %s want %s", h.SHA256, hex.EncodeToString(want[:]))
+	}
+	if h.MediaType != "text/plain" {
+		t.Errorf("MediaType: got %q want %q", h.MediaType, "text/plain")
+	}
+	if h.Size != int64(len(data)) {
+		t.Errorf("Size: got %d want %d", h.Size, len(data))
+	}
+
+	got, mt, err := s.Get(h.SHA256)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("Get bytes: got %q want %q", got, data)
+	}
+	if mt != "text/plain" {
+		t.Errorf("Get media: got %q want %q", mt, "text/plain")
+	}
+}
+
+func TestPut_Idempotent(t *testing.T) {
+	s := newTestStore(t, 0)
+	data := []byte("idempotent payload")
+
+	h1, err := s.Put(data, "image/png")
+	if err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+
+	h2, err := s.Put(data, "image/png")
+	if err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+
+	if h1.SHA256 != h2.SHA256 {
+		t.Errorf("idempotent Put yielded different hashes: %s vs %s", h1.SHA256, h2.SHA256)
+	}
+	if h1.Path != h2.Path {
+		t.Errorf("idempotent Put yielded different paths: %s vs %s", h1.Path, h2.Path)
+	}
+}
+
+func TestPut_DifferentContentDifferentSHA(t *testing.T) {
+	s := newTestStore(t, 0)
+	h1, _ := s.Put([]byte("a"), "text/plain")
+	h2, _ := s.Put([]byte("b"), "text/plain")
+	if h1.SHA256 == h2.SHA256 {
+		t.Errorf("different content collided: %s", h1.SHA256)
+	}
+}
+
+func TestGet_Missing(t *testing.T) {
+	s := newTestStore(t, 0)
+	if _, _, err := s.Get("0000000000000000000000000000000000000000000000000000000000000000"); !os.IsNotExist(err) {
+		t.Errorf("expected ErrNotExist; got %v", err)
+	}
+}
+
+func TestStat_NoLoad(t *testing.T) {
+	s := newTestStore(t, 0)
+	data := []byte("stat me")
+	h, _ := s.Put(data, "application/octet-stream")
+
+	st, err := s.Stat(h.SHA256)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if st.Size != int64(len(data)) {
+		t.Errorf("Stat.Size: got %d want %d", st.Size, len(data))
+	}
+	if st.MediaType != "application/octet-stream" {
+		t.Errorf("Stat.MediaType: got %q want octet-stream", st.MediaType)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	s := newTestStore(t, 0)
+	h, _ := s.Put([]byte("delete me"), "text/plain")
+
+	if err := s.Delete(h.SHA256); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, _, err := s.Get(h.SHA256); !os.IsNotExist(err) {
+		t.Errorf("expected ErrNotExist after Delete; got %v", err)
+	}
+}
+
+func TestDelete_Missing_NoError(t *testing.T) {
+	s := newTestStore(t, 0)
+	if err := s.Delete("0000000000000000000000000000000000000000000000000000000000000000"); err != nil {
+		t.Errorf("Delete on missing should not error; got %v", err)
+	}
+}
+
+func TestSweep_NoBudget_NoOp(t *testing.T) {
+	s := newTestStore(t, 0)
+	for i := range 10 {
+		_, _ = s.Put([]byte{byte(i)}, "application/octet-stream")
+	}
+	evicted, freed, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if evicted != 0 || freed != 0 {
+		t.Errorf("zero-budget Sweep should be no-op; got evicted=%d freed=%d", evicted, freed)
+	}
+}
+
+func TestSweep_EvictsLRU(t *testing.T) {
+	dir := t.TempDir()
+	// Budget = 30 bytes; we'll put three 20-byte blobs so the oldest two get evicted.
+	s, err := New(dir, 30)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	bigA := bytes.Repeat([]byte("A"), 20)
+	bigB := bytes.Repeat([]byte("B"), 20)
+	bigC := bytes.Repeat([]byte("C"), 20)
+
+	// Put A, advance time so mtime ordering is deterministic across filesystems.
+	hA, _ := s.Put(bigA, "")
+	mustChtime(t, hA.Path, time.Now().Add(-3*time.Second))
+
+	hB, _ := s.Put(bigB, "")
+	mustChtime(t, hB.Path, time.Now().Add(-2*time.Second))
+
+	hC, _ := s.Put(bigC, "")
+	mustChtime(t, hC.Path, time.Now().Add(-1*time.Second))
+
+	evicted, freed, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if evicted != 2 {
+		t.Errorf("evicted count: got %d want 2", evicted)
+	}
+	if freed != 40 {
+		t.Errorf("freed bytes: got %d want 40", freed)
+	}
+
+	// Oldest two (A, B) should be gone; C survives.
+	if _, _, err := s.Get(hA.SHA256); !os.IsNotExist(err) {
+		t.Errorf("A should be evicted; got err=%v", err)
+	}
+	if _, _, err := s.Get(hB.SHA256); !os.IsNotExist(err) {
+		t.Errorf("B should be evicted; got err=%v", err)
+	}
+	if _, _, err := s.Get(hC.SHA256); err != nil {
+		t.Errorf("C should survive; got err=%v", err)
+	}
+}
+
+func TestSweep_GetTouchesMtime(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := New(dir, 30)
+
+	bigA := bytes.Repeat([]byte("A"), 20)
+	bigB := bytes.Repeat([]byte("B"), 20)
+	bigC := bytes.Repeat([]byte("C"), 20)
+
+	hA, _ := s.Put(bigA, "")
+	mustChtime(t, hA.Path, time.Now().Add(-3*time.Second))
+
+	hB, _ := s.Put(bigB, "")
+	mustChtime(t, hB.Path, time.Now().Add(-2*time.Second))
+
+	// Read A — should bump A's mtime to now, pushing B to the oldest slot.
+	if _, _, err := s.Get(hA.SHA256); err != nil {
+		t.Fatalf("Get A: %v", err)
+	}
+
+	hC, _ := s.Put(bigC, "")
+	mustChtime(t, hC.Path, time.Now().Add(-1*time.Second))
+
+	// Now bump A again so it's clearly newer than C.
+	mustChtime(t, hA.Path, time.Now())
+
+	if _, _, err := s.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	// B is the oldest, should be evicted; A survived because Get touched it.
+	if _, _, err := s.Get(hA.SHA256); err != nil {
+		t.Errorf("A should survive due to recent Get; got err=%v", err)
+	}
+	if _, _, err := s.Get(hB.SHA256); !os.IsNotExist(err) {
+		t.Errorf("B should be evicted; got err=%v", err)
+	}
+}
+
+func TestTotalBytes(t *testing.T) {
+	s := newTestStore(t, 0)
+	_, _ = s.Put([]byte("aaaaa"), "")
+	_, _ = s.Put([]byte("bbbbbbbb"), "")
+	got, err := s.TotalBytes()
+	if err != nil {
+		t.Fatalf("TotalBytes: %v", err)
+	}
+	if got != 13 {
+		t.Errorf("TotalBytes: got %d want 13", got)
+	}
+}
+
+func TestURI_RoundTrip(t *testing.T) {
+	h := Handle{SHA256: "abc123"}
+	uri := h.URI()
+	if got := SHAFromURI(uri); got != "abc123" {
+		t.Errorf("SHAFromURI: got %q want %q", got, "abc123")
+	}
+	if SHAFromURI("https://example.com/foo") != "" {
+		t.Errorf("non-blob URI should yield empty sha")
+	}
+}
+
+func TestPut_ConcurrentSameContent(t *testing.T) {
+	s := newTestStore(t, 0)
+	data := []byte("concurrent content")
+
+	var wg sync.WaitGroup
+	results := make([]Handle, 10)
+	for i := range 10 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			h, err := s.Put(data, "application/octet-stream")
+			if err != nil {
+				t.Errorf("concurrent Put %d: %v", i, err)
+				return
+			}
+			results[i] = h
+		}(i)
+	}
+	wg.Wait()
+
+	first := results[0]
+	for i, h := range results {
+		if h.SHA256 != first.SHA256 {
+			t.Errorf("concurrent Put %d returned different sha: %s vs %s", i, h.SHA256, first.SHA256)
+		}
+	}
+}
+
+// mustChtime sets both atime and mtime on path. Used to synthesize
+// deterministic LRU ordering in tests since Put on a fast filesystem can
+// land multiple blobs within the mtime resolution window.
+func mustChtime(t *testing.T, path string, when time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatalf("Chtimes %s: %v", filepath.Base(path), err)
+	}
+}

--- a/pkg/engine/session.go
+++ b/pkg/engine/session.go
@@ -145,6 +145,13 @@ func (s *SessionWorkspace) FilesDir() string {
 	return filepath.Join(s.RootDir, "files")
 }
 
+// BlobsDir returns the path to the per-session blobs subdirectory used by
+// pkg/engine/blobs. Lazily created by the blob store on first Put — no
+// directory is forced at session boot.
+func (s *SessionWorkspace) BlobsDir() string {
+	return filepath.Join(s.RootDir, "blobs")
+}
+
 // MetadataDir returns the path to the metadata subdirectory.
 func (s *SessionWorkspace) MetadataDir() string {
 	return filepath.Join(s.RootDir, "metadata")

--- a/pkg/events/embeddings.go
+++ b/pkg/events/embeddings.go
@@ -14,7 +14,17 @@ type EmbeddingsRequest struct {
 	SchemaVersion int `json:"_schema_version"`
 
 	// Texts is the batch of strings to embed. Order is preserved in Vectors.
+	// Used when Inputs is empty — keeps existing text-only callers and
+	// adapters working unchanged.
 	Texts []string
+	// Inputs is the polymorphic batch (text and/or image inputs) for
+	// multimodal-aware providers. Additive over Texts: when empty, providers
+	// continue to read Texts. When non-empty, providers must consume Inputs
+	// in order (one vector per Input) and either honor every Input kind or
+	// return a clear error (e.g. an OpenAI text-only embedding model
+	// receiving an image input). Adapters must not silently downgrade an
+	// image input to a text fallback.
+	Inputs []EmbeddingsInput
 	// Model is the embeddings model to use. Zero value means provider default.
 	Model string
 	// Dimensions optionally requests a specific vector dimensionality when
@@ -29,6 +39,31 @@ type EmbeddingsRequest struct {
 	Provider string // plugin ID of the adapter that answered
 	Usage    EmbeddingsUsage
 	Error    string // non-empty when the call failed
+}
+
+// EmbeddingsInput is one polymorphic embedding input. Exactly one of Text,
+// Image, or ImageURI is populated. Adapters that don't support image inputs
+// must return a clear error when they encounter an image-bearing input
+// rather than silently downgrading.
+//
+// The ImageURI form supports the engine's content-addressed blob scheme
+// ("nexus-blob:<sha>") and plain external URLs. A provider that can't
+// resolve a particular scheme must error rather than skip the input.
+type EmbeddingsInput struct {
+	// Text is set when this input is a text snippet. Mutually exclusive
+	// with Image and ImageURI.
+	Text string
+	// Image is the inline image bytes. Mutually exclusive with Text and
+	// ImageURI. Requires MimeType.
+	Image []byte
+	// ImageURI references an image by URI: "nexus-blob:<sha>" for the
+	// engine blob store, or a plain HTTPS URL the provider can fetch.
+	// Mutually exclusive with Text and Image.
+	ImageURI string
+	// MimeType is the IANA media type (e.g. "image/png", "image/jpeg")
+	// describing Image / ImageURI bytes. Required when Image is set;
+	// recommended for ImageURI.
+	MimeType string
 }
 
 // EmbeddingsUsage reports token accounting for an embeddings call when the

--- a/pkg/events/llm.go
+++ b/pkg/events/llm.go
@@ -180,6 +180,21 @@ type Usage struct {
 	ReasoningTokens  int // thinking/reasoning tokens (Gemini 2.5 thoughtTokenCount, etc.)
 	CachedTokens     int // tokens served from a prompt cache (billed at a discount)
 	CacheWriteTokens int // tokens written into a prompt cache (billed at a premium over plain input)
+
+	// ModalityBreakdown carries per-modality token counts when the provider
+	// exposes them. Keys are stable lowercase modality identifiers
+	// ("text", "image", "audio", "video", "document"); each key value is the
+	// number of tokens the provider attributed to that modality across the
+	// turn (input + output combined when a provider does not split them).
+	//
+	// Empty when the provider does not report modality breakdowns
+	// (Anthropic rolls image / document tokens into input_tokens) or when the
+	// request was text-only.
+	//
+	// Cost-attribution consumers (cost CLI, multi-dim budget gate) read this
+	// to bill image / audio turns separately from text. Additive map; new
+	// modality keys can be introduced without an LLMResponse schema bump.
+	ModalityBreakdown map[string]int
 }
 
 // StreamChunk is a single chunk from a streaming LLM response.

--- a/pkg/events/tool.go
+++ b/pkg/events/tool.go
@@ -72,5 +72,18 @@ type ToolResult struct {
 	// run_code's typed bindings) prefer this over parsing Output.
 	// Content should validate against the tool's declared OutputSchema.
 	OutputStructured map[string]any
-	TurnID           string
+
+	// OutputParts carries multimodal content the tool produced (image,
+	// audio, document, video). When non-empty, the memory plugin copies
+	// these into the resulting tool-role Message.Parts so the next LLM
+	// request includes the multimodal content alongside (or in place of)
+	// Output. Empty for text-only tools.
+	//
+	// Large payloads should be stored via pkg/engine/blobs and referenced
+	// here as `MessagePart{URI: "nexus-blob:<sha>", MimeType: "..."}` so
+	// the journal stays compact; small payloads can ride inline as Data.
+	// Provider plugins resolve nexus-blob URIs at request-assembly time.
+	OutputParts []MessagePart
+
+	TurnID string
 }

--- a/pkg/events/version_test.go
+++ b/pkg/events/version_test.go
@@ -155,6 +155,13 @@ func versionedPayloads() []versionedPayload {
 		{"VectorQuery", func() any { return VectorQuery{SchemaVersion: VectorQueryVersion} }, VectorQueryVersion},
 		{"VectorDelete", func() any { return VectorDelete{SchemaVersion: VectorDeleteVersion} }, VectorDeleteVersion},
 		{"VectorNamespaceDrop", func() any { return VectorNamespaceDrop{SchemaVersion: VectorNamespaceDropVersion} }, VectorNamespaceDropVersion},
+		// voice.go
+		{"VoiceAudioInputChunk", func() any {
+			return VoiceAudioInputChunk{SchemaVersion: VoiceAudioInputChunkVersion}
+		}, VoiceAudioInputChunkVersion},
+		{"VoiceAudioOutputChunk", func() any {
+			return VoiceAudioOutputChunk{SchemaVersion: VoiceAudioOutputChunkVersion}
+		}, VoiceAudioOutputChunkVersion},
 	}
 }
 

--- a/pkg/events/voice.go
+++ b/pkg/events/voice.go
@@ -1,0 +1,59 @@
+package events
+
+// Schema-version constants for voice.* payloads. See doc.go.
+//
+// Voice events are forward-looking placeholders for Phase 4 of the
+// multimodal/voice IO work tracked under Idea 18. The realtime IO transport
+// (nexus.io.realtime) carries them between connected clients and the bus
+// today; nexus.io.voice will consume input chunks (run VAD + ASR) and
+// produce output chunks (TTS) once that plugin lands.
+const (
+	VoiceAudioInputChunkVersion  = 1
+	VoiceAudioOutputChunkVersion = 1
+)
+
+// VoiceAudioInputChunk carries a chunk of microphone-captured audio from a
+// realtime client. Phase 4 (nexus.io.voice) consumes these, runs voice-
+// activity detection, and hands a final segment to ASR. The audio frame is
+// base64-encoded so the chunk can ride a JSON envelope without any binary
+// framing concerns; MIME type is supplied by the producer (typically
+// "audio/webm;codecs=opus" from a browser MediaRecorder, or "audio/wav"
+// from a native client).
+//
+// Bus event type: "voice.audio.input.chunk".
+type VoiceAudioInputChunk struct {
+	SchemaVersion int `json:"_schema_version"`
+
+	// TurnID groups consecutive chunks belonging to the same utterance.
+	TurnID string
+	// Sequence is the 0-based ordinal of this chunk within the turn.
+	Sequence int
+	// AudioBase64 is the base64-encoded raw audio frame. Decoders should
+	// trust MimeType for the container/codec; this field is opaque.
+	AudioBase64 string
+	// MimeType identifies the container/codec, e.g. "audio/webm;codecs=opus".
+	MimeType string
+	// Final marks the last chunk of a turn. Consumers should treat any
+	// chunks emitted after Final=true as the start of a new turn.
+	Final bool
+}
+
+// VoiceAudioOutputChunk is emitted by Phase 4 (nexus.io.voice) when a TTS
+// stream produces audio for a given assistant response. The realtime IO
+// plugin forwards these to connected clients for playback.
+//
+// Bus event type: "voice.audio.output.chunk".
+type VoiceAudioOutputChunk struct {
+	SchemaVersion int `json:"_schema_version"`
+
+	// TurnID correlates the output with the assistant turn it speaks.
+	TurnID string
+	// Sequence is the 0-based ordinal of this chunk within the turn.
+	Sequence int
+	// AudioBase64 is the base64-encoded raw audio frame.
+	AudioBase64 string
+	// MimeType identifies the container/codec the producer chose.
+	MimeType string
+	// Final marks the last chunk of a turn.
+	Final bool
+}

--- a/plugins/embeddings/cohere_multimodal/plugin.go
+++ b/plugins/embeddings/cohere_multimodal/plugin.go
@@ -1,0 +1,359 @@
+// Package coheremultimodal implements an embeddings.provider capability
+// backed by Cohere Embed v3 (multimodal): POST /v2/embed with either
+// `text` or `image_url` content per input. Direct HTTP, no SDK — keeps
+// deps minimal.
+//
+// Inputs are read from EmbeddingsRequest.Inputs first; when that field is
+// empty the plugin falls back to EmbeddingsRequest.Texts so Cohere can
+// also serve plain text-only callers if a deployer wires it as their
+// embeddings.provider. Images are sent as data: URLs (base64-encoded) per
+// Cohere's documented contract.
+//
+// Blob-scheme URIs ("nexus-blob:<sha>") are resolved via the per-session
+// blob store when the plugin's PluginContext.Session is non-nil. When the
+// session is unavailable (rare; mostly tests outside the harness) the
+// plugin reports a clear error and asks the calling plugin to inline the
+// bytes in EmbeddingsInput.Image instead. No silent fallback.
+package coheremultimodal
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID         = "nexus.embeddings.cohere_multimodal"
+	pluginName       = "Cohere Multimodal Embeddings Provider"
+	version          = "0.1.0"
+	defaultBaseURL   = "https://api.cohere.com"
+	embedPath        = "/v2/embed"
+	defaultModel     = "embed-english-v3.0"
+	defaultInputType = "search_document"
+)
+
+// Plugin advertises the embeddings.provider capability and answers
+// embeddings.request events by calling Cohere's multimodal embeddings
+// endpoint.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+
+	apiKey       string
+	baseURL      string
+	defaultModel string
+	inputType    string
+	client       *http.Client
+	timeout      time.Duration
+	session      *engine.SessionWorkspace
+	// blobStore is opened lazily on first need so plugins activated outside
+	// a session (rare) still boot without error.
+	blobStore *blobs.Store
+
+	unsubs []func()
+}
+
+// New creates a new Cohere multimodal embeddings plugin.
+func New() engine.Plugin {
+	return &Plugin{timeout: 30 * time.Second}
+}
+
+func (p *Plugin) ID() string                     { return pluginID }
+func (p *Plugin) Name() string                   { return pluginName }
+func (p *Plugin) Version() string                { return version }
+func (p *Plugin) Dependencies() []string         { return nil }
+func (p *Plugin) Requires() []engine.Requirement { return nil }
+
+func (p *Plugin) Capabilities() []engine.Capability {
+	return []engine.Capability{{
+		Name:        "embeddings.provider",
+		Description: "Multimodal text + image embeddings via Cohere Embed v3 (POST /v2/embed).",
+	}}
+}
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+	p.session = ctx.Session
+
+	p.baseURL = defaultBaseURL
+	if base, ok := ctx.Config["base_url"].(string); ok && base != "" {
+		p.baseURL = strings.TrimRight(base, "/")
+	}
+
+	if key, ok := ctx.Config["api_key"].(string); ok && key != "" {
+		p.apiKey = key
+	} else {
+		envVar, _ := ctx.Config["api_key_env"].(string)
+		if envVar == "" {
+			envVar = "COHERE_API_KEY"
+		}
+		p.apiKey = os.Getenv(envVar)
+	}
+	if p.apiKey == "" {
+		return fmt.Errorf("embeddings/cohere_multimodal: no API key configured (set api_key in config or COHERE_API_KEY env var)")
+	}
+
+	p.defaultModel = defaultModel
+	if m, ok := ctx.Config["model"].(string); ok && m != "" {
+		p.defaultModel = m
+	}
+
+	p.inputType = defaultInputType
+	if t, ok := ctx.Config["input_type"].(string); ok && t != "" {
+		p.inputType = t
+	}
+
+	if ts, ok := ctx.Config["timeout"].(string); ok && ts != "" {
+		d, err := time.ParseDuration(ts)
+		if err != nil {
+			return fmt.Errorf("embeddings/cohere_multimodal: invalid timeout %q: %w", ts, err)
+		}
+		p.timeout = d
+	}
+
+	p.client = &http.Client{Timeout: p.timeout}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("embeddings.request", p.handleEmbeddings,
+			engine.WithPriority(50), engine.WithSource(pluginID)),
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	if p.client != nil {
+		p.client.CloseIdleConnections()
+	}
+	return nil
+}
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "embeddings.request", Priority: 50},
+	}
+}
+
+func (p *Plugin) Emissions() []string { return nil }
+
+func (p *Plugin) handleEmbeddings(event engine.Event[any]) {
+	req, ok := event.Payload.(*events.EmbeddingsRequest)
+	if !ok {
+		return
+	}
+	if req.Provider != "" {
+		// Another adapter already answered.
+		return
+	}
+
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+	req.Provider = pluginID
+	req.Model = model
+
+	// Build the polymorphic input list. EmbeddingsInput is preferred; fall
+	// back to legacy Texts when Inputs is empty.
+	cohereInputs := make([]cohereInput, 0)
+	if len(req.Inputs) > 0 {
+		for i, in := range req.Inputs {
+			ci, err := p.buildInput(in)
+			if err != nil {
+				req.Error = fmt.Sprintf("input %d: %v", i, err)
+				return
+			}
+			cohereInputs = append(cohereInputs, ci)
+		}
+	} else {
+		for _, t := range req.Texts {
+			cohereInputs = append(cohereInputs, cohereInput{Content: []cohereContent{{Type: "text", Text: t}}})
+		}
+	}
+	if len(cohereInputs) == 0 {
+		// Empty request — provider claim already set, nothing more to do.
+		return
+	}
+
+	vectors, usage, err := p.embed(cohereInputs, model)
+	if err != nil {
+		req.Error = err.Error()
+		return
+	}
+	if len(vectors) != len(cohereInputs) {
+		req.Error = fmt.Sprintf("expected %d vectors, got %d", len(cohereInputs), len(vectors))
+		return
+	}
+	req.Vectors = vectors
+	req.Usage = usage
+}
+
+// buildInput maps one EmbeddingsInput onto Cohere's polymorphic
+// `inputs[].content[]` shape. Mutually-exclusive fields are validated;
+// blob-scheme URIs are resolved via the engine blob store.
+func (p *Plugin) buildInput(in events.EmbeddingsInput) (cohereInput, error) {
+	switch {
+	case in.Text != "" && (in.Image != nil || in.ImageURI != ""):
+		return cohereInput{}, fmt.Errorf("EmbeddingsInput must populate exactly one of Text / Image / ImageURI")
+	case in.Image != nil && in.ImageURI != "":
+		return cohereInput{}, fmt.Errorf("EmbeddingsInput cannot set both Image and ImageURI")
+	case in.Text != "":
+		return cohereInput{Content: []cohereContent{{Type: "text", Text: in.Text}}}, nil
+	case in.Image != nil:
+		if in.MimeType == "" {
+			return cohereInput{}, fmt.Errorf("EmbeddingsInput.Image requires MimeType")
+		}
+		dataURL := buildDataURL(in.MimeType, in.Image)
+		return cohereInput{Content: []cohereContent{{Type: "image_url", ImageURL: &cohereImageURL{URL: dataURL}}}}, nil
+	case in.ImageURI != "":
+		// nexus-blob: scheme — resolve via per-session blob store.
+		if sha := blobs.SHAFromURI(in.ImageURI); sha != "" {
+			data, mime, err := p.resolveBlob(sha)
+			if err != nil {
+				return cohereInput{}, fmt.Errorf("resolve blob %q: %w", in.ImageURI, err)
+			}
+			if mime == "" {
+				mime = in.MimeType
+			}
+			if mime == "" {
+				return cohereInput{}, fmt.Errorf("blob %q has no recorded MimeType and EmbeddingsInput.MimeType is empty", in.ImageURI)
+			}
+			return cohereInput{Content: []cohereContent{{Type: "image_url", ImageURL: &cohereImageURL{URL: buildDataURL(mime, data)}}}}, nil
+		}
+		// External URL — Cohere can fetch it directly.
+		return cohereInput{Content: []cohereContent{{Type: "image_url", ImageURL: &cohereImageURL{URL: in.ImageURI}}}}, nil
+	default:
+		return cohereInput{}, fmt.Errorf("EmbeddingsInput is empty (no Text / Image / ImageURI)")
+	}
+}
+
+// resolveBlob looks up a "nexus-blob:<sha>" URI through the per-session
+// blob store. Returns a clear error when the engine has no session
+// (callers must inline bytes via EmbeddingsInput.Image instead).
+func (p *Plugin) resolveBlob(sha string) ([]byte, string, error) {
+	if p.session == nil {
+		return nil, "", fmt.Errorf("blob URI cannot be resolved: plugin has no session workspace; inline bytes via EmbeddingsInput.Image instead")
+	}
+	if p.blobStore == nil {
+		store, err := blobs.New(p.session.BlobsDir(), 0)
+		if err != nil {
+			return nil, "", fmt.Errorf("open blob store: %w", err)
+		}
+		p.blobStore = store
+	}
+	data, mime, err := p.blobStore.Get(sha)
+	if err != nil {
+		return nil, "", fmt.Errorf("blob get: %w", err)
+	}
+	return data, mime, nil
+}
+
+func buildDataURL(mime string, data []byte) string {
+	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(data)
+}
+
+// --- Cohere wire types ---
+
+type cohereInput struct {
+	Content []cohereContent `json:"content"`
+}
+
+type cohereContent struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	ImageURL *cohereImageURL `json:"image_url,omitempty"`
+}
+
+type cohereImageURL struct {
+	URL string `json:"url"`
+}
+
+type cohereEmbedRequest struct {
+	Model          string        `json:"model"`
+	InputType      string        `json:"input_type"`
+	EmbeddingTypes []string      `json:"embedding_types"`
+	Inputs         []cohereInput `json:"inputs"`
+}
+
+type cohereEmbedResponse struct {
+	Embeddings struct {
+		Float [][]float32 `json:"float"`
+	} `json:"embeddings"`
+	Meta struct {
+		BilledUnits struct {
+			InputTokens int `json:"input_tokens"`
+			Images      int `json:"images"`
+		} `json:"billed_units"`
+	} `json:"meta"`
+}
+
+func (p *Plugin) embed(inputs []cohereInput, model string) ([][]float32, events.EmbeddingsUsage, error) {
+	body := cohereEmbedRequest{
+		Model:          model,
+		InputType:      p.inputType,
+		EmbeddingTypes: []string{"float"},
+		Inputs:         inputs,
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, events.EmbeddingsUsage{}, fmt.Errorf("marshal: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+
+	endpoint := p.baseURL + embedPath
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(buf))
+	if err != nil {
+		return nil, events.EmbeddingsUsage{}, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, events.EmbeddingsUsage{}, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, events.EmbeddingsUsage{}, fmt.Errorf("cohere returned HTTP %d: %s", resp.StatusCode, truncate(string(respBody), 300))
+	}
+
+	var parsed cohereEmbedResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, events.EmbeddingsUsage{}, fmt.Errorf("decode: %w", err)
+	}
+
+	usage := events.EmbeddingsUsage{
+		PromptTokens: parsed.Meta.BilledUnits.InputTokens,
+		TotalTokens:  parsed.Meta.BilledUnits.InputTokens,
+	}
+	return parsed.Embeddings.Float, usage, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/plugins/embeddings/cohere_multimodal/plugin_test.go
+++ b/plugins/embeddings/cohere_multimodal/plugin_test.go
@@ -1,0 +1,362 @@
+package coheremultimodal
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// stubEmbedServer returns a minimal Cohere-compatible /v2/embed handler
+// that records the last received request body for assertions.
+type stubEmbedServer struct {
+	*httptest.Server
+	lastRequest cohereEmbedRequest
+	requests    int
+	// vectorsPerInput controls how many vectors of length 4 the server
+	// returns. Defaults to "match the request inputs" via len(req.Inputs).
+	overrideVectors [][]float32
+}
+
+func newStubServer(t *testing.T) *stubEmbedServer {
+	t.Helper()
+	s := &stubEmbedServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/embed" {
+			http.Error(w, "wrong path: "+r.URL.Path, http.StatusBadRequest)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var parsed cohereEmbedRequest
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			http.Error(w, "decode: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		s.lastRequest = parsed
+		s.requests++
+
+		// Default vector set: one 4-dim vector per input.
+		vectors := s.overrideVectors
+		if vectors == nil {
+			vectors = make([][]float32, len(parsed.Inputs))
+			for i := range vectors {
+				vectors[i] = []float32{0.1, 0.2, 0.3, 0.4}
+			}
+		}
+		resp := cohereEmbedResponse{}
+		resp.Embeddings.Float = vectors
+		resp.Meta.BilledUnits.InputTokens = 7
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	return s
+}
+
+func newTestPlugin(t *testing.T, baseURL string, sess *engine.SessionWorkspace) (*Plugin, engine.EventBus) {
+	t.Helper()
+	bus := engine.NewEventBus()
+	p := New().(*Plugin)
+	p.bus = bus
+	p.logger = slog.Default()
+	p.apiKey = "test-key"
+	p.baseURL = baseURL
+	p.defaultModel = defaultModel
+	p.inputType = defaultInputType
+	p.client = &http.Client{Timeout: p.timeout}
+	p.session = sess
+	bus.Subscribe("embeddings.request", p.handleEmbeddings,
+		engine.WithPriority(50))
+	return p, bus
+}
+
+func TestEmbed_TextOnly_ViaTexts(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL, nil)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Texts:         []string{"hello", "world"},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+	if len(req.Vectors) != 2 {
+		t.Fatalf("expected 2 vectors, got %d", len(req.Vectors))
+	}
+	if req.Provider != pluginID {
+		t.Fatalf("provider mismatch: %s", req.Provider)
+	}
+	if req.Model != defaultModel {
+		t.Fatalf("model mismatch: %s", req.Model)
+	}
+	// Verify wire shape.
+	if srv.lastRequest.Model != defaultModel {
+		t.Errorf("wire: model = %q", srv.lastRequest.Model)
+	}
+	if srv.lastRequest.InputType != defaultInputType {
+		t.Errorf("wire: input_type = %q", srv.lastRequest.InputType)
+	}
+	if got := srv.lastRequest.EmbeddingTypes; len(got) != 1 || got[0] != "float" {
+		t.Errorf("wire: embedding_types = %v", got)
+	}
+	if len(srv.lastRequest.Inputs) != 2 {
+		t.Errorf("wire: expected 2 inputs, got %d", len(srv.lastRequest.Inputs))
+	}
+	for i, in := range srv.lastRequest.Inputs {
+		if len(in.Content) != 1 || in.Content[0].Type != "text" {
+			t.Errorf("wire: input %d not text-shaped: %+v", i, in)
+		}
+	}
+}
+
+func TestEmbed_TextOnly_ViaInputs(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL, nil)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs:        []events.EmbeddingsInput{{Text: "alpha"}, {Text: "beta"}},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+	if len(req.Vectors) != 2 {
+		t.Fatalf("expected 2 vectors, got %d", len(req.Vectors))
+	}
+}
+
+func TestEmbed_InlineImage(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL, nil)
+
+	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs: []events.EmbeddingsInput{
+			{Image: pngBytes, MimeType: "image/png"},
+		},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+	if len(req.Vectors) != 1 {
+		t.Fatalf("expected 1 vector, got %d", len(req.Vectors))
+	}
+	if len(srv.lastRequest.Inputs) != 1 {
+		t.Fatalf("wire: expected 1 input, got %d", len(srv.lastRequest.Inputs))
+	}
+	c := srv.lastRequest.Inputs[0].Content
+	if len(c) != 1 || c[0].Type != "image_url" || c[0].ImageURL == nil {
+		t.Fatalf("wire: input not image-shaped: %+v", c)
+	}
+	want := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngBytes)
+	if c[0].ImageURL.URL != want {
+		t.Fatalf("wire: image_url mismatch:\n got %q\nwant %q", c[0].ImageURL.URL, want)
+	}
+}
+
+func TestEmbed_MixedTextAndImage(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL, nil)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs: []events.EmbeddingsInput{
+			{Text: "caption"},
+			{Image: []byte{0x01, 0x02}, MimeType: "image/jpeg"},
+			{Text: "more text"},
+		},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+	if len(req.Vectors) != 3 {
+		t.Fatalf("expected 3 vectors, got %d", len(req.Vectors))
+	}
+	if len(srv.lastRequest.Inputs) != 3 {
+		t.Fatalf("wire: expected 3 inputs, got %d", len(srv.lastRequest.Inputs))
+	}
+	types := []string{
+		srv.lastRequest.Inputs[0].Content[0].Type,
+		srv.lastRequest.Inputs[1].Content[0].Type,
+		srv.lastRequest.Inputs[2].Content[0].Type,
+	}
+	want := []string{"text", "image_url", "text"}
+	for i := range want {
+		if types[i] != want[i] {
+			t.Errorf("wire: input[%d].type = %q, want %q", i, types[i], want[i])
+		}
+	}
+}
+
+func TestEmbed_ImageURI_Blob(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	store, err := blobs.New(filepath.Join(tmp, "blobs"), 0)
+	if err != nil {
+		t.Fatalf("blobs.New: %v", err)
+	}
+	imgBytes := []byte("\x89PNG-fake")
+	h, err := store.Put(imgBytes, "image/png")
+	if err != nil {
+		t.Fatalf("blob put: %v", err)
+	}
+
+	// Inject a session workspace pointing at the same root.
+	// SessionWorkspace.BlobsDir() returns RootDir/blobs — set RootDir = tmp.
+	sess := &engine.SessionWorkspace{RootDir: tmp}
+	_, bus := newTestPlugin(t, srv.URL, sess)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs: []events.EmbeddingsInput{
+			{ImageURI: h.URI()},
+		},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+	if len(req.Vectors) != 1 {
+		t.Fatalf("expected 1 vector, got %d", len(req.Vectors))
+	}
+	c := srv.lastRequest.Inputs[0].Content
+	if c[0].Type != "image_url" || c[0].ImageURL == nil {
+		t.Fatalf("wire: input not image-shaped: %+v", c)
+	}
+	wantURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(imgBytes)
+	if c[0].ImageURL.URL != wantURL {
+		t.Fatalf("wire: image_url mismatch:\n got %q\nwant %q", c[0].ImageURL.URL, wantURL)
+	}
+}
+
+func TestEmbed_ImageURI_External(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL, nil)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs: []events.EmbeddingsInput{
+			{ImageURI: "https://example.com/img.png", MimeType: "image/png"},
+		},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+	c := srv.lastRequest.Inputs[0].Content
+	if c[0].Type != "image_url" || c[0].ImageURL == nil {
+		t.Fatalf("wire: input not image-shaped: %+v", c)
+	}
+	if c[0].ImageURL.URL != "https://example.com/img.png" {
+		t.Fatalf("wire: external URL not passed through: %q", c[0].ImageURL.URL)
+	}
+}
+
+func TestEmbed_BlobURI_NoSession(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+	// session==nil → blob URIs cannot be resolved.
+	_, bus := newTestPlugin(t, srv.URL, nil)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs: []events.EmbeddingsInput{
+			{ImageURI: "nexus-blob:deadbeef"},
+		},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(req.Error, "blob URI cannot be resolved") {
+		t.Fatalf("expected clear blob-resolution error, got: %q", req.Error)
+	}
+}
+
+func TestEmbed_ImageWithoutMimeType(t *testing.T) {
+	_, bus := newTestPlugin(t, "http://127.0.0.1:1", nil)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs: []events.EmbeddingsInput{
+			{Image: []byte{0x01}},
+		},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if !strings.Contains(req.Error, "MimeType") {
+		t.Fatalf("expected MimeType validation error, got: %q", req.Error)
+	}
+}
+
+func TestEmbed_RequestShape_FloatEmbeddings(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL, nil)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Texts:         []string{"hello"},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+
+	// embedding_types must be exactly ["float"] per the documented contract.
+	if got := srv.lastRequest.EmbeddingTypes; len(got) != 1 || got[0] != "float" {
+		t.Errorf("embedding_types = %v, want [\"float\"]", got)
+	}
+}
+
+func TestEmbed_UsageReported(t *testing.T) {
+	srv := newStubServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL, nil)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Texts:         []string{"hello"},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Usage.PromptTokens != 7 || req.Usage.TotalTokens != 7 {
+		t.Errorf("usage not surfaced: got %+v, want PromptTokens/TotalTokens=7", req.Usage)
+	}
+}

--- a/plugins/embeddings/cohere_multimodal/schema.go
+++ b/plugins/embeddings/cohere_multimodal/schema.go
@@ -1,0 +1,9 @@
+package coheremultimodal
+
+import _ "embed"
+
+//go:embed schema.json
+var configSchemaBytes []byte
+
+// ConfigSchema implements engine.ConfigSchemaProvider.
+func (p *Plugin) ConfigSchema() []byte { return configSchemaBytes }

--- a/plugins/embeddings/cohere_multimodal/schema.json
+++ b/plugins/embeddings/cohere_multimodal/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexus.local/schemas/plugins/nexus.embeddings.cohere_multimodal.json",
+  "title": "nexus.embeddings.cohere_multimodal",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "base_url":    {"type": "string", "description": "Override Cohere API base URL (default https://api.cohere.com)."},
+    "api_key":     {"type": "string", "description": "Direct API key."},
+    "api_key_env": {"type": "string", "description": "Environment variable to read the API key from (default COHERE_API_KEY)."},
+    "model":       {"type": "string", "description": "Cohere embedding model (e.g. embed-english-v3.0)."},
+    "input_type":  {"type": "string", "description": "Cohere input_type (search_document, search_query, classification, clustering, image)."},
+    "timeout":     {"type": "string", "description": "HTTP timeout (Go duration string)."}
+  }
+}

--- a/plugins/embeddings/openai/plugin.go
+++ b/plugins/embeddings/openai/plugin.go
@@ -132,7 +132,28 @@ func (p *Plugin) handleEmbeddings(event engine.Event[any]) {
 	if req.Provider != "" {
 		return
 	}
-	if len(req.Texts) == 0 {
+
+	// Multimodal-aware producers populate Inputs. OpenAI's
+	// text-embedding-3-* family is text-only — an image-bearing input is
+	// a hard error rather than a silent text fallback. Reject before any
+	// HTTP call so the caller sees a clear, deterministic message.
+	var texts []string
+	if len(req.Inputs) > 0 {
+		texts = make([]string, 0, len(req.Inputs))
+		for i, in := range req.Inputs {
+			if in.Image != nil || in.ImageURI != "" {
+				req.Provider = pluginID
+				req.Error = fmt.Sprintf(
+					"openai text-embedding-* models accept text only; use a multimodal embeddings provider for image inputs (e.g. nexus.embeddings.cohere_multimodal) [input %d]", i)
+				return
+			}
+			texts = append(texts, in.Text)
+		}
+	} else {
+		texts = req.Texts
+	}
+
+	if len(texts) == 0 {
 		req.Provider = pluginID
 		return
 	}
@@ -142,7 +163,7 @@ func (p *Plugin) handleEmbeddings(event engine.Event[any]) {
 		model = p.defaultModel
 	}
 
-	vectors, usage, err := p.embed(req.Texts, model, req.Dimensions)
+	vectors, usage, err := p.embed(texts, model, req.Dimensions)
 	req.Provider = pluginID
 	req.Model = model
 	if err != nil {

--- a/plugins/embeddings/openai/plugin_test.go
+++ b/plugins/embeddings/openai/plugin_test.go
@@ -1,0 +1,139 @@
+package openai
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// newTestPlugin wires a Plugin against an httptest server endpoint so
+// embedding calls don't hit api.openai.com.
+func newTestPlugin(t *testing.T, baseURL string) (*Plugin, engine.EventBus) {
+	t.Helper()
+	bus := engine.NewEventBus()
+	p := New().(*Plugin)
+	p.bus = bus
+	p.logger = slog.Default()
+	p.apiKey = "test-key"
+	p.baseURL = baseURL
+	p.defaultModel = defaultModel
+	p.client = &http.Client{Timeout: p.timeout}
+	bus.Subscribe("embeddings.request", p.handleEmbeddings,
+		engine.WithPriority(50))
+	return p, bus
+}
+
+// fakeEmbedServer returns a tiny embeddings response so the text-only path
+// can complete end-to-end.
+func fakeEmbedServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+            "data": [
+                {"index": 0, "embedding": [0.1, 0.2, 0.3]}
+            ],
+            "model": "text-embedding-3-small",
+            "usage": {"prompt_tokens": 1, "total_tokens": 1}
+        }`))
+	}))
+}
+
+func TestHandleEmbeddings_TextOnly_Texts(t *testing.T) {
+	srv := fakeEmbedServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Texts:         []string{"hello"},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+	if len(req.Vectors) != 1 || len(req.Vectors[0]) != 3 {
+		t.Fatalf("expected 1 vector of length 3; got %v", req.Vectors)
+	}
+	if req.Provider != pluginID {
+		t.Fatalf("expected provider=%s, got %s", pluginID, req.Provider)
+	}
+}
+
+func TestHandleEmbeddings_TextOnly_Inputs(t *testing.T) {
+	srv := fakeEmbedServer(t)
+	defer srv.Close()
+	_, bus := newTestPlugin(t, srv.URL)
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs:        []events.EmbeddingsInput{{Text: "hello"}},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error != "" {
+		t.Fatalf("unexpected error: %s", req.Error)
+	}
+	if len(req.Vectors) != 1 {
+		t.Fatalf("expected 1 vector; got %d", len(req.Vectors))
+	}
+}
+
+func TestHandleEmbeddings_RejectsInlineImage(t *testing.T) {
+	// No HTTP server: rejection must happen before any HTTP call.
+	_, bus := newTestPlugin(t, "http://127.0.0.1:1") // unreachable
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs: []events.EmbeddingsInput{
+			{Image: []byte{0x89, 0x50, 0x4e, 0x47}, MimeType: "image/png"},
+		},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error == "" {
+		t.Fatal("expected error rejecting image input")
+	}
+	if !strings.Contains(req.Error, "openai text-embedding-* models accept text only") {
+		t.Fatalf("error message missing the expected guidance: %q", req.Error)
+	}
+	if !strings.Contains(req.Error, "nexus.embeddings.cohere_multimodal") {
+		t.Fatalf("error message should point at the multimodal adapter: %q", req.Error)
+	}
+	if req.Provider != pluginID {
+		t.Fatalf("expected provider=%s on rejection, got %s", pluginID, req.Provider)
+	}
+	if len(req.Vectors) != 0 {
+		t.Fatalf("rejection must not produce vectors")
+	}
+}
+
+func TestHandleEmbeddings_RejectsImageURI(t *testing.T) {
+	_, bus := newTestPlugin(t, "http://127.0.0.1:1")
+
+	req := &events.EmbeddingsRequest{
+		SchemaVersion: events.EmbeddingsRequestVersion,
+		Inputs: []events.EmbeddingsInput{
+			{Text: "hello"},
+			{ImageURI: "nexus-blob:deadbeef", MimeType: "image/png"},
+		},
+	}
+	if err := bus.Emit("embeddings.request", req); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if req.Error == "" {
+		t.Fatal("expected error rejecting ImageURI input")
+	}
+	if !strings.Contains(req.Error, "[input 1]") {
+		t.Fatalf("error should identify the offending input index: %q", req.Error)
+	}
+}

--- a/plugins/io/realtime/plugin.go
+++ b/plugins/io/realtime/plugin.go
@@ -1,0 +1,278 @@
+// Package realtime implements the nexus.io.realtime plugin: a WebSocket
+// transport that streams LLM token deltas, tool previews, voice audio, and
+// cancellation envelopes to connected clients, and accepts text input,
+// audio chunks, cancel, and HITL responses going the other way.
+//
+// This is Phase 3 of Idea 18 (multimodal & voice IO). Phase 4 will land
+// nexus.io.voice (VAD + ASR + TTS); Phase 5 may eventually fold the
+// envelope shape into io/browser and io/wails. Until then the realtime
+// transport stands alongside those plugins as a third, lower-latency
+// option for clients that want raw stream.delta deltas without the
+// browser UI's hub state machine.
+//
+// Security: there is **no auth in v1**. Origin checks and bearer-token
+// validation are tracked as follow-ups; operators running this on a
+// public network must front it with a reverse proxy that does its own
+// authentication. See docs/src/configuration/reference.md for the
+// nexus.io.realtime entry.
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const pluginID = "nexus.io.realtime"
+
+// Plugin is the realtime IO plugin. It hosts a WebSocket server and
+// bridges a small set of bus events into JSON envelopes for clients.
+type Plugin struct {
+	bus    engine.EventBus
+	logger *slog.Logger
+	server *Server
+
+	listenAddr string
+	path       string
+	maxClients int
+
+	unsubs []func()
+}
+
+// New creates a new realtime IO plugin. Used by the plugin registry.
+func New() engine.Plugin {
+	return &Plugin{}
+}
+
+func (p *Plugin) ID() string                        { return pluginID }
+func (p *Plugin) Name() string                      { return "Realtime IO" }
+func (p *Plugin) Version() string                   { return "0.1.0" }
+func (p *Plugin) Dependencies() []string            { return nil }
+func (p *Plugin) Requires() []engine.Requirement    { return nil }
+func (p *Plugin) Capabilities() []engine.Capability { return nil }
+
+// Subscriptions declares the events forwarded to clients. We attach a
+// vetoable subscription for before:tool.invoke for read-only observation —
+// the handler never sets Veto. The remainder are post-event observers.
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "llm.stream.chunk", Priority: 50},
+		{EventType: "llm.stream.end", Priority: 50},
+		{EventType: "before:tool.invoke", Priority: 100}, // read-only, low priority
+		{EventType: "voice.audio.output.chunk", Priority: 50},
+		{EventType: "cancel.complete", Priority: 50},
+		{EventType: "hitl.requested", Priority: 50},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"io.input",
+		"before:io.input",
+		"voice.audio.input.chunk",
+		"cancel.request",
+		"hitl.responded",
+	}
+}
+
+// Init reads config and constructs (but does not start) the server.
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+
+	p.listenAddr = ":7676"
+	if v, ok := ctx.Config["listen_addr"].(string); ok && v != "" {
+		p.listenAddr = v
+	}
+	p.path = "/ws"
+	if v, ok := ctx.Config["path"].(string); ok && v != "" {
+		p.path = v
+	}
+	p.maxClients = 16
+	if v, ok := ctx.Config["max_clients"].(int); ok && v > 0 {
+		p.maxClients = v
+	}
+
+	p.server = NewServer(p.logger, p.listenAddr, p.path, p.maxClients, p.handleInbound)
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("llm.stream.chunk", p.handleStreamChunk, engine.WithSource(pluginID)),
+		p.bus.Subscribe("llm.stream.end", p.handleStreamEnd, engine.WithSource(pluginID)),
+		p.bus.Subscribe("before:tool.invoke", p.handleBeforeToolInvoke,
+			engine.WithSource(pluginID), engine.WithPriority(100)),
+		p.bus.Subscribe("voice.audio.output.chunk", p.handleVoiceAudioOutput, engine.WithSource(pluginID)),
+		p.bus.Subscribe("cancel.complete", p.handleCancelComplete, engine.WithSource(pluginID)),
+		p.bus.Subscribe("hitl.requested", p.handleHITLRequest, engine.WithSource(pluginID)),
+	)
+
+	p.logger.Info("realtime IO plugin initialized",
+		"listen_addr", p.listenAddr, "path", p.path, "max_clients", p.maxClients)
+	return nil
+}
+
+// Ready starts the HTTP server.
+func (p *Plugin) Ready() error {
+	if err := p.server.Start(); err != nil {
+		return fmt.Errorf("starting realtime server: %w", err)
+	}
+	return nil
+}
+
+// Shutdown unsubscribes and closes all client connections.
+func (p *Plugin) Shutdown(ctx context.Context) error {
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	if p.server == nil {
+		return nil
+	}
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return p.server.Shutdown(shutdownCtx)
+}
+
+// --- outbound (bus -> clients) ---
+
+func (p *Plugin) handleStreamChunk(e engine.Event[any]) {
+	chunk, ok := e.Payload.(events.StreamChunk)
+	if !ok || chunk.Content == "" {
+		return
+	}
+	p.server.Broadcast(envelope{
+		Type:    "stream.delta",
+		TurnID:  chunk.TurnID,
+		Content: chunk.Content,
+	})
+}
+
+func (p *Plugin) handleStreamEnd(e engine.Event[any]) {
+	end, ok := e.Payload.(events.StreamEnd)
+	if !ok {
+		return
+	}
+	p.server.Broadcast(envelope{
+		Type:         "stream.end",
+		TurnID:       end.TurnID,
+		FinishReason: end.FinishReason,
+	})
+}
+
+// handleBeforeToolInvoke is a read-only observer: it inspects the wrapped
+// ToolCall, forwards a tool.preview envelope to clients, and never sets
+// Veto. Subscribing to before:* (rather than tool.invoke) lets clients see
+// a tool call before any potential gate veto suppresses it.
+func (p *Plugin) handleBeforeToolInvoke(e engine.Event[any]) {
+	vp, ok := e.Payload.(*engine.VetoablePayload)
+	if !ok {
+		return
+	}
+	tc, ok := vp.Original.(*events.ToolCall)
+	if !ok {
+		return
+	}
+	p.server.Broadcast(envelope{
+		Type: "tool.preview",
+		ID:   tc.ID,
+		Name: tc.Name,
+		Args: tc.Arguments,
+	})
+}
+
+func (p *Plugin) handleVoiceAudioOutput(e engine.Event[any]) {
+	chunk, ok := e.Payload.(events.VoiceAudioOutputChunk)
+	if !ok {
+		return
+	}
+	p.server.Broadcast(envelope{
+		Type:        "audio.chunk",
+		TurnID:      chunk.TurnID,
+		Sequence:    chunk.Sequence,
+		AudioBase64: chunk.AudioBase64,
+		MimeType:    chunk.MimeType,
+		Final:       chunk.Final,
+	})
+}
+
+func (p *Plugin) handleCancelComplete(e engine.Event[any]) {
+	cc, ok := e.Payload.(events.CancelComplete)
+	if !ok {
+		return
+	}
+	p.server.Broadcast(envelope{
+		Type:      "cancel.complete",
+		TurnID:    cc.TurnID,
+		Resumable: &cc.Resumable,
+	})
+}
+
+func (p *Plugin) handleHITLRequest(e engine.Event[any]) {
+	req, ok := e.Payload.(events.HITLRequest)
+	if !ok {
+		return
+	}
+	p.server.Broadcast(envelope{
+		Type:   "hitl.request",
+		ID:     req.ID,
+		Prompt: req.Prompt,
+	})
+}
+
+// --- inbound (clients -> bus) ---
+//
+// handleInbound runs on the server's read pump goroutine. The bus dispatch
+// is synchronous, so any handler chain that might block (e.g. the HITL
+// path, where another plugin waits on the response) must not run inline:
+// we'd deadlock the read pump and never see further frames from the same
+// client. Following io/browser's pattern, we offload to a goroutine for
+// io.input; the lighter cancel/audio/approval emits are short-circuit
+// dispatches that complete quickly enough to ride the read pump.
+func (p *Plugin) handleInbound(env envelope) {
+	switch env.Type {
+	case "input":
+		go func(content string) {
+			input := events.UserInput{
+				SchemaVersion: events.UserInputVersion,
+				Content:       content,
+			}
+			if veto, err := p.bus.EmitVetoable("before:io.input", &input); err == nil && veto.Vetoed {
+				return
+			}
+			_ = p.bus.Emit("io.input", input)
+		}(env.Content)
+
+	case "audio.chunk":
+		_ = p.bus.Emit("voice.audio.input.chunk", events.VoiceAudioInputChunk{
+			SchemaVersion: events.VoiceAudioInputChunkVersion,
+			TurnID:        env.TurnID,
+			Sequence:      env.Sequence,
+			AudioBase64:   env.AudioBase64,
+			MimeType:      env.MimeType,
+			Final:         env.Final,
+		})
+
+	case "cancel":
+		_ = p.bus.Emit("cancel.request", events.CancelRequest{
+			SchemaVersion: events.CancelRequestVersion,
+			TurnID:        env.TurnID,
+			Source:        "realtime",
+		})
+
+	case "approval":
+		// Map the realtime "approval" envelope onto hitl.responded — the
+		// modern unified human-in-the-loop path. ChoiceID carries the
+		// decision verbatim ("approve" / "reject" / arbitrary plugin id);
+		// we deliberately do not interpret it here.
+		_ = p.bus.Emit("hitl.responded", events.HITLResponse{
+			SchemaVersion: events.HITLResponseVersion,
+			RequestID:     env.RequestID,
+			ChoiceID:      env.Decision,
+		})
+
+	default:
+		p.logger.Debug("unknown realtime envelope type", "type", env.Type)
+	}
+}

--- a/plugins/io/realtime/plugin_test.go
+++ b/plugins/io/realtime/plugin_test.go
@@ -1,0 +1,223 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// newTestPlugin wires a Plugin against a real engine.EventBus and a
+// httptest.Server hosting the plugin's handler. It returns the plugin,
+// the bus, the websocket dial URL, and a teardown that shuts everything
+// down. Tests that need multiple steps share one teardown via t.Cleanup.
+func newTestPlugin(t *testing.T) (*Plugin, engine.EventBus, string) {
+	t.Helper()
+
+	bus := engine.NewEventBus()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	p := New().(*Plugin)
+	p.bus = bus
+	p.logger = logger
+	p.listenAddr = ":0"
+	p.path = "/ws"
+	p.maxClients = 4
+	p.server = NewServer(logger, p.listenAddr, p.path, p.maxClients, p.handleInbound)
+
+	// Mirror Init's bus subscriptions. We do not call Init() because that
+	// requires a full engine.PluginContext; this approximation keeps the
+	// test focused on bus<->client wiring.
+	p.unsubs = append(p.unsubs,
+		bus.Subscribe("llm.stream.chunk", p.handleStreamChunk),
+		bus.Subscribe("llm.stream.end", p.handleStreamEnd),
+		bus.Subscribe("before:tool.invoke", p.handleBeforeToolInvoke,
+			engine.WithPriority(100)),
+		bus.Subscribe("voice.audio.output.chunk", p.handleVoiceAudioOutput),
+		bus.Subscribe("cancel.complete", p.handleCancelComplete),
+		bus.Subscribe("hitl.requested", p.handleHITLRequest),
+	)
+
+	srv := httptest.NewServer(p.server.Handler())
+	// httptest gives us http://...; swap to ws://.
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+
+	t.Cleanup(func() {
+		for _, unsub := range p.unsubs {
+			unsub()
+		}
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.server.Shutdown(shutdownCtx)
+		srv.Close()
+	})
+
+	return p, bus, wsURL
+}
+
+// dialAndWait dials the websocket and waits until the server has
+// registered the connection. Polling on ClientCount avoids a race where
+// the test broadcasts before the read pump's accept finishes.
+func dialAndWait(t *testing.T, ctx context.Context, p *Plugin, wsURL string) *websocket.Conn {
+	t.Helper()
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.server.ClientCount() >= 1 {
+			return conn
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("server never registered client")
+	return conn
+}
+
+func TestPlugin_ConnectAndStreamDelta(t *testing.T) {
+	p, bus, wsURL := newTestPlugin(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	conn := dialAndWait(t, ctx, p, wsURL)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Emit a synthesized stream chunk and assert the client reads
+	// stream.delta with the matching turn id and content.
+	if err := bus.Emit("llm.stream.chunk", events.StreamChunk{
+		SchemaVersion: events.StreamChunkVersion,
+		Content:       "hello",
+		TurnID:        "t-1",
+	}); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	var got envelope
+	if err := wsjson.Read(ctx, conn, &got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.Type != "stream.delta" {
+		t.Fatalf("expected stream.delta; got %s", got.Type)
+	}
+	if got.TurnID != "t-1" {
+		t.Fatalf("expected turn_id=t-1; got %q", got.TurnID)
+	}
+	if got.Content != "hello" {
+		t.Fatalf("expected content=hello; got %q", got.Content)
+	}
+}
+
+func TestPlugin_InboundInputEmitsUserInput(t *testing.T) {
+	p, bus, wsURL := newTestPlugin(t)
+
+	// Subscribe before the connection is live so we don't miss the emit.
+	var (
+		mu   sync.Mutex
+		seen events.UserInput
+		got  atomic.Bool
+	)
+	bus.Subscribe("io.input", func(e engine.Event[any]) {
+		ui, ok := e.Payload.(events.UserInput)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		seen = ui
+		mu.Unlock()
+		got.Store(true)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	conn := dialAndWait(t, ctx, p, wsURL)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Send the input envelope.
+	frame := envelope{Type: "input", Content: "hi"}
+	data, _ := json.Marshal(frame)
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// io.input is dispatched from a goroutine on the read pump; poll.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got.Load() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !got.Load() {
+		t.Fatalf("io.input never emitted")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if seen.Content != "hi" {
+		t.Fatalf("expected content=hi; got %q", seen.Content)
+	}
+	if seen.SchemaVersion != events.UserInputVersion {
+		t.Fatalf("expected schema_version=%d; got %d", events.UserInputVersion, seen.SchemaVersion)
+	}
+}
+
+func TestPlugin_InboundCancelEmitsCancelRequest(t *testing.T) {
+	p, bus, wsURL := newTestPlugin(t)
+
+	var (
+		mu   sync.Mutex
+		seen events.CancelRequest
+		got  atomic.Bool
+	)
+	bus.Subscribe("cancel.request", func(e engine.Event[any]) {
+		cr, ok := e.Payload.(events.CancelRequest)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		seen = cr
+		mu.Unlock()
+		got.Store(true)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	conn := dialAndWait(t, ctx, p, wsURL)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	frame := envelope{Type: "cancel"}
+	data, _ := json.Marshal(frame)
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got.Load() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !got.Load() {
+		t.Fatalf("cancel.request never emitted")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if seen.Source != "realtime" {
+		t.Fatalf("expected source=realtime; got %q", seen.Source)
+	}
+}

--- a/plugins/io/realtime/server.go
+++ b/plugins/io/realtime/server.go
@@ -1,0 +1,287 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+// envelope is the JSON message carried over the WebSocket in either
+// direction. Fields are a flat union — only the ones relevant to a given
+// envelope Type are populated. JSON tags use omitempty so each frame
+// stays compact.
+type envelope struct {
+	Type string `json:"type"`
+
+	// Common fields used by multiple envelope types.
+	TurnID  string `json:"turn_id,omitempty"`
+	Content string `json:"content,omitempty"`
+
+	// stream.end
+	FinishReason string `json:"finish_reason,omitempty"`
+
+	// tool.preview
+	ID   string         `json:"id,omitempty"`
+	Name string         `json:"name,omitempty"`
+	Args map[string]any `json:"args,omitempty"`
+
+	// audio.chunk (both directions)
+	Sequence    int    `json:"sequence,omitempty"`
+	AudioBase64 string `json:"audio_base64,omitempty"`
+	MimeType    string `json:"mime_type,omitempty"`
+	Final       bool   `json:"final,omitempty"`
+
+	// cancel.complete (server -> client). Pointer so we can distinguish
+	// "not set" from "explicit false" — Resumable=false matters to clients.
+	Resumable *bool `json:"resumable,omitempty"`
+
+	// hitl.request (server -> client) and approval (client -> server).
+	Prompt    string `json:"prompt,omitempty"`
+	RequestID string `json:"request_id,omitempty"`
+	Decision  string `json:"decision,omitempty"`
+}
+
+// Server is the HTTP/WebSocket front-end for the realtime IO plugin. It
+// owns a connection set, a single mux registered at the configured path,
+// and a handler that the plugin calls into for each inbound envelope.
+type Server struct {
+	logger     *slog.Logger
+	addr       string
+	path       string
+	maxClients int
+	onInbound  func(envelope)
+
+	mu       sync.RWMutex
+	clients  map[*client]struct{}
+	listener net.Listener
+	httpSrv  *http.Server
+
+	// rootCtx is cancelled on Shutdown so all read/write pumps exit. New
+	// connections accepted after Shutdown see an immediately-cancelled
+	// context and close cleanly.
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+}
+
+// client is a single connected websocket peer.
+type client struct {
+	conn *websocket.Conn
+	send chan envelope
+	done chan struct{}
+}
+
+// NewServer constructs a server but does not listen yet — call Start.
+// Mostly broken out from the plugin so tests can construct a server
+// against an ephemeral port without touching plugin lifecycle.
+func NewServer(logger *slog.Logger, addr, path string, maxClients int, onInbound func(envelope)) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	return &Server{
+		logger:     logger,
+		addr:       addr,
+		path:       path,
+		maxClients: maxClients,
+		onInbound:  onInbound,
+		clients:    make(map[*client]struct{}),
+		rootCtx:    rootCtx,
+		rootCancel: rootCancel,
+	}
+}
+
+// Handler returns the http.Handler the server uses to upgrade incoming
+// WebSocket connections. Exposed so tests can mount it on httptest.Server
+// without going through Start().
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(s.path, s.handleWebSocket)
+	return mux
+}
+
+// Start binds to the configured address and serves WebSocket upgrades.
+// Returns once the listener is bound; the actual Serve runs in a
+// background goroutine.
+func (s *Server) Start() error {
+	ln, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", s.addr, err)
+	}
+	s.listener = ln
+
+	s.httpSrv = &http.Server{
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	s.logger.Info("realtime IO server started", "addr", ln.Addr().String(), "path", s.path)
+
+	go func() {
+		if err := s.httpSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			s.logger.Error("realtime server error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+// Addr returns the listener's bound address (useful for tests where
+// addr=":0" picks an ephemeral port).
+func (s *Server) Addr() string {
+	if s.listener == nil {
+		return s.addr
+	}
+	return s.listener.Addr().String()
+}
+
+// Shutdown closes all client connections and stops the HTTP server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.rootCancel()
+
+	s.mu.Lock()
+	for c := range s.clients {
+		_ = c.conn.Close(websocket.StatusGoingAway, "server shutting down")
+		select {
+		case <-c.done:
+		default:
+			close(c.done)
+		}
+	}
+	s.clients = make(map[*client]struct{})
+	s.mu.Unlock()
+
+	if s.httpSrv == nil {
+		return nil
+	}
+	return s.httpSrv.Shutdown(ctx)
+}
+
+// Broadcast queues an envelope for every connected client. A client whose
+// send buffer is full is logged and dropped on this frame — we do not
+// block on slow consumers.
+func (s *Server) Broadcast(env envelope) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for c := range s.clients {
+		select {
+		case c.send <- env:
+		default:
+			s.logger.Warn("realtime client send buffer full, dropping frame",
+				"type", env.Type)
+		}
+	}
+}
+
+// ClientCount returns the number of currently-connected clients.
+func (s *Server) ClientCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.clients)
+}
+
+// handleWebSocket upgrades the request and runs read/write pumps until
+// the connection closes. **No auth in v1** — operators must front this
+// with a reverse proxy when exposed beyond localhost. See the package
+// godoc and docs/src/configuration/reference.md for the follow-up.
+func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	// Cap at maxClients before upgrading so an abusive caller can't
+	// exhaust descriptors. Race window between this check and Add is
+	// acceptable for an alpha — exact enforcement is a follow-up if it
+	// matters.
+	if s.ClientCount() >= s.maxClients {
+		http.Error(w, "max clients reached", http.StatusServiceUnavailable)
+		return
+	}
+
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// Permissive origin policy — same as io/browser. Tighter origin
+		// checks land alongside auth in a future revision.
+		OriginPatterns: []string{"*"},
+	})
+	if err != nil {
+		s.logger.Error("websocket accept failed", "error", err)
+		return
+	}
+
+	c := &client{
+		conn: conn,
+		send: make(chan envelope, 256),
+		done: make(chan struct{}),
+	}
+
+	s.mu.Lock()
+	s.clients[c] = struct{}{}
+	s.mu.Unlock()
+
+	s.logger.Debug("realtime client connected", "remote", r.RemoteAddr)
+
+	// Bind the per-connection lifetime to rootCtx so Shutdown propagates.
+	ctx, cancel := context.WithCancel(s.rootCtx)
+	defer cancel()
+
+	go s.writePump(ctx, c)
+	s.readPump(ctx, c)
+
+	s.mu.Lock()
+	delete(s.clients, c)
+	s.mu.Unlock()
+
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+	s.logger.Debug("realtime client disconnected", "remote", r.RemoteAddr)
+}
+
+func (s *Server) readPump(ctx context.Context, c *client) {
+	defer func() {
+		select {
+		case <-c.done:
+		default:
+			close(c.done)
+		}
+	}()
+	for {
+		var env envelope
+		if err := wsjson.Read(ctx, c.conn, &env); err != nil {
+			if ctx.Err() == nil {
+				s.logger.Debug("realtime read error", "error", err)
+			}
+			return
+		}
+		if s.onInbound != nil {
+			s.onInbound(env)
+		}
+	}
+}
+
+func (s *Server) writePump(ctx context.Context, c *client) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.done:
+			return
+		case env, ok := <-c.send:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(env)
+			if err != nil {
+				s.logger.Error("realtime marshal failed", "error", err)
+				continue
+			}
+			if err := c.conn.Write(ctx, websocket.MessageText, data); err != nil {
+				if ctx.Err() == nil {
+					s.logger.Debug("realtime write error", "error", err)
+				}
+				return
+			}
+		}
+	}
+}

--- a/plugins/io/voice/asr.go
+++ b/plugins/io/voice/asr.go
@@ -1,0 +1,129 @@
+package voice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+)
+
+// defaultASREndpoint is OpenAI's audio transcription endpoint.
+const defaultASREndpoint = "https://api.openai.com/v1/audio/transcriptions"
+
+// asrClient wraps an OpenAI-compatible /audio/transcriptions endpoint. The
+// endpoint is overridable via config (asr.endpoint) so tests can spin up an
+// httptest server.
+type asrClient struct {
+	endpoint string
+	apiKey   string
+	model    string
+	http     *http.Client
+}
+
+// transcribe POSTs the buffered audio as a multipart form with `file`,
+// `model`, `response_format=json` fields and returns the parsed `text`.
+//
+// The provided mimeType is used to choose the upload filename's extension so
+// the server-side decoder picks the right parser. We do not attempt any
+// container-conversion locally — we ship the bytes as-is.
+func (c *asrClient) transcribe(ctx context.Context, audio []byte, mimeType string) (string, error) {
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+
+	// File field. Filename extension hints the server at the codec; default
+	// to .wav since whisper's strongest path is PCM/WAV.
+	fileName := "audio" + extForMime(mimeType)
+	fw, err := mw.CreateFormFile("file", fileName)
+	if err != nil {
+		return "", fmt.Errorf("voice: build multipart form: %w", err)
+	}
+	if _, err := fw.Write(audio); err != nil {
+		return "", fmt.Errorf("voice: write multipart audio: %w", err)
+	}
+
+	// Model field.
+	if err := mw.WriteField("model", c.model); err != nil {
+		return "", fmt.Errorf("voice: write multipart model: %w", err)
+	}
+	// Force JSON response so the response shape stays {"text": "..."}.
+	if err := mw.WriteField("response_format", "json"); err != nil {
+		return "", fmt.Errorf("voice: write multipart response_format: %w", err)
+	}
+
+	if err := mw.Close(); err != nil {
+		return "", fmt.Errorf("voice: close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, body)
+	if err != nil {
+		return "", fmt.Errorf("voice: build ASR request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	client := c.http
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("voice: ASR HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("voice: ASR status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("voice: parse ASR response: %w (body=%q)", err, string(respBody))
+	}
+	return parsed.Text, nil
+}
+
+// extForMime returns a likely filename extension for the given mime type.
+// Whisper accepts wav/mp3/m4a/webm/ogg/flac; this map covers the common ones
+// our realtime IO plugin produces. Unknown types default to .wav.
+func extForMime(mime string) string {
+	if mime == "" {
+		return ".wav"
+	}
+	// Strip codec parameters.
+	if i := indexByte(mime, ';'); i >= 0 {
+		mime = mime[:i]
+	}
+	switch mime {
+	case "audio/wav", "audio/x-wav", "audio/wave", "audio/pcm", "audio/l16", "audio/x-l16":
+		return ".wav"
+	case "audio/webm":
+		return ".webm"
+	case "audio/ogg":
+		return ".ogg"
+	case "audio/mpeg", "audio/mp3":
+		return ".mp3"
+	case "audio/mp4", "audio/m4a", "audio/x-m4a":
+		return ".m4a"
+	case "audio/flac":
+		return ".flac"
+	}
+	return ".wav"
+}
+
+// indexByte is a tiny stand-in for strings.IndexByte without the import (the
+// caller of extForMime is hot-path-adjacent and doesn't need the strings
+// package elsewhere).
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/plugins/io/voice/plugin.go
+++ b/plugins/io/voice/plugin.go
@@ -1,0 +1,638 @@
+// Package voice provides the nexus.io.voice plugin: a bus-driven voice IO
+// transport that consumes microphone audio chunks (voice.audio.input.chunk),
+// runs simple energy-based VAD + ASR (OpenAI Whisper API) to emit io.input,
+// and consumes llm.response to drive TTS (OpenAI /audio/speech) chunks back
+// out (voice.audio.output.chunk).
+//
+// Local-model providers are out of scope for this PR — see #92. Configuring
+// asr.provider or tts.provider with a local-model id (e.g. local_whisper,
+// faster_whisper, kokoro) makes Init return a clear error pointing operators
+// at #92.
+//
+// Barge-in: while a TTS turn is in flight (i.e. between llm.response and the
+// final voice.audio.output.chunk), if any input chunk's RMS exceeds the
+// barge-in threshold, we emit cancel.request{Source: "voice"} so the
+// existing cooperative-cancellation chain terminates the in-flight LLM/turn.
+// The new utterance is then processed normally.
+package voice
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const pluginID = "nexus.io.voice"
+
+// asrConfig holds resolved ASR settings.
+type asrConfig struct {
+	provider string
+	apiKey   string
+	model    string
+	endpoint string
+}
+
+// ttsConfig holds resolved TTS settings.
+type ttsConfig struct {
+	provider   string
+	apiKey     string
+	model      string
+	voice      string
+	endpoint   string
+	chunkBytes int
+}
+
+// vadConfig holds resolved VAD settings.
+type vadConfig struct {
+	threshold float64
+	silenceMS int
+}
+
+// bargeInConfig holds resolved barge-in settings.
+type bargeInConfig struct {
+	enabled   bool
+	threshold float64
+}
+
+// turnBuffer accumulates audio chunks for a single utterance.
+type turnBuffer struct {
+	turnID         string
+	mimeType       string
+	audio          []byte
+	lastChunkAt    time.Time
+	lastSpeechAt   time.Time
+	hasSpeech      bool
+	flushed        bool
+	flushTimer     *time.Timer
+	expectedSeqNxt int // next expected sequence number; -1 = unknown
+}
+
+// Plugin implements engine.Plugin for nexus.io.voice.
+type Plugin struct {
+	bus     engine.EventBus
+	logger  *slog.Logger
+	session *engine.SessionWorkspace
+	unsubs  []func()
+
+	// Config (resolved at Init).
+	asr      asrConfig
+	tts      ttsConfig
+	vad      vadConfig
+	bargeIn  bargeInConfig
+	textPass bool
+
+	// Test/HTTP injection.
+	httpClient *http.Client
+
+	// State.
+	mu      sync.Mutex
+	buffers map[string]*turnBuffer // turnID -> buffer
+	// ttsActive tracks the turnID of the in-flight TTS operation. Empty
+	// when no TTS is currently in flight. Set when llm.response handler
+	// kicks off synthesis; cleared when the final output chunk has been
+	// emitted (or the operation is cancelled).
+	ttsActive    string
+	ttsCancel    context.CancelFunc
+	bargeInFired bool
+}
+
+// New returns a new voice IO plugin instance.
+func New() engine.Plugin {
+	return &Plugin{
+		buffers: make(map[string]*turnBuffer),
+	}
+}
+
+func (p *Plugin) ID() string                        { return pluginID }
+func (p *Plugin) Name() string                      { return "Voice IO" }
+func (p *Plugin) Version() string                   { return "0.1.0" }
+func (p *Plugin) Dependencies() []string            { return nil }
+func (p *Plugin) Requires() []engine.Requirement    { return nil }
+func (p *Plugin) Capabilities() []engine.Capability { return nil }
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "voice.audio.input.chunk", Priority: 50},
+		{EventType: "llm.response", Priority: 50},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"io.input",
+		"voice.audio.output.chunk",
+		"cancel.request",
+	}
+}
+
+// Init parses config and wires bus subscriptions.
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+	p.session = ctx.Session
+
+	if err := p.parseConfig(ctx.Config); err != nil {
+		return err
+	}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("voice.audio.input.chunk", p.handleInputChunk, engine.WithSource(pluginID)),
+		p.bus.Subscribe("llm.response", p.handleLLMResponse, engine.WithSource(pluginID)),
+	)
+
+	p.logger.Info("voice IO plugin initialized",
+		"asr_provider", p.asr.provider,
+		"asr_model", p.asr.model,
+		"tts_provider", p.tts.provider,
+		"tts_model", p.tts.model,
+		"tts_voice", p.tts.voice,
+		"vad_threshold", p.vad.threshold,
+		"vad_silence_ms", p.vad.silenceMS,
+		"barge_in_enabled", p.bargeIn.enabled,
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error { return nil }
+
+// Shutdown cancels any in-flight TTS and unsubscribes.
+func (p *Plugin) Shutdown(ctx context.Context) error {
+	p.mu.Lock()
+	if p.ttsCancel != nil {
+		p.ttsCancel()
+		p.ttsCancel = nil
+	}
+	for _, b := range p.buffers {
+		if b.flushTimer != nil {
+			b.flushTimer.Stop()
+		}
+	}
+	p.buffers = nil
+	p.mu.Unlock()
+
+	for _, unsub := range p.unsubs {
+		unsub()
+	}
+	return nil
+}
+
+// parseConfig resolves the plugin config map into typed structs and validates
+// the provider settings (incl. the #92 local-model rejection).
+func (p *Plugin) parseConfig(cfg map[string]any) error {
+	// ASR.
+	asr, _ := cfg["asr"].(map[string]any)
+	if asr == nil {
+		asr = map[string]any{}
+	}
+	p.asr.provider = stringOrDefault(asr, "provider", "openai_whisper")
+	if err := rejectLocalASR(p.asr.provider); err != nil {
+		return err
+	}
+	p.asr.model = stringOrDefault(asr, "model", "whisper-1")
+	p.asr.endpoint = stringOrDefault(asr, "endpoint", defaultASREndpoint)
+	p.asr.apiKey = resolveAPIKey(asr, "OPENAI_API_KEY")
+	if p.asr.apiKey == "" && !isTestEndpoint(p.asr.endpoint) {
+		return fmt.Errorf("voice: ASR API key not found (set asr.api_key, asr.api_key_env, or OPENAI_API_KEY)")
+	}
+
+	// TTS.
+	tts, _ := cfg["tts"].(map[string]any)
+	if tts == nil {
+		tts = map[string]any{}
+	}
+	p.tts.provider = stringOrDefault(tts, "provider", "openai")
+	if err := rejectLocalTTS(p.tts.provider); err != nil {
+		return err
+	}
+	p.tts.model = stringOrDefault(tts, "model", "tts-1")
+	p.tts.voice = stringOrDefault(tts, "voice", "alloy")
+	p.tts.endpoint = stringOrDefault(tts, "endpoint", defaultTTSEndpoint)
+	p.tts.apiKey = resolveAPIKey(tts, "OPENAI_API_KEY")
+	if p.tts.apiKey == "" && !isTestEndpoint(p.tts.endpoint) {
+		return fmt.Errorf("voice: TTS API key not found (set tts.api_key, tts.api_key_env, or OPENAI_API_KEY)")
+	}
+	p.tts.chunkBytes = intOrDefault(tts, "chunk_bytes", defaultTTSChunkBytes)
+	if p.tts.chunkBytes <= 0 {
+		p.tts.chunkBytes = defaultTTSChunkBytes
+	}
+
+	// VAD.
+	vad, _ := cfg["vad"].(map[string]any)
+	if vad == nil {
+		vad = map[string]any{}
+	}
+	p.vad.threshold = floatOrDefault(vad, "threshold", 0.02)
+	p.vad.silenceMS = intOrDefault(vad, "silence_ms", 600)
+
+	// Barge-in.
+	bi, _ := cfg["barge_in"].(map[string]any)
+	if bi == nil {
+		bi = map[string]any{}
+	}
+	p.bargeIn.enabled = boolOrDefault(bi, "enabled", true)
+	p.bargeIn.threshold = floatOrDefault(bi, "threshold", p.vad.threshold)
+
+	// Text fallback.
+	p.textPass = boolOrDefault(cfg, "text_fallback", true)
+
+	return nil
+}
+
+// rejectLocalASR returns the #92 error when the configured provider is one of
+// the known local-model ids. Schema accepts these strings so configs migrate
+// once #92 lands; Init refuses to run with them today.
+func rejectLocalASR(provider string) error {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "local_whisper", "faster_whisper", "distil_whisper":
+		return errors.New("local-model voice providers tracked under #92; not available in this PR — use openai_whisper / openai for ASR/TTS")
+	case "openai_whisper", "":
+		return nil
+	default:
+		return fmt.Errorf("voice: unsupported asr.provider %q (only openai_whisper is wired in this PR)", provider)
+	}
+}
+
+// rejectLocalTTS mirrors rejectLocalASR for TTS providers.
+func rejectLocalTTS(provider string) error {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	if p == "kokoro" || strings.HasPrefix(p, "local_") || strings.HasSuffix(p, "_local") {
+		return errors.New("local-model voice providers tracked under #92; not available in this PR — use openai_whisper / openai for ASR/TTS")
+	}
+	switch p {
+	case "openai", "":
+		return nil
+	default:
+		return fmt.Errorf("voice: unsupported tts.provider %q (only openai is wired in this PR)", provider)
+	}
+}
+
+// resolveAPIKey reads api_key (literal) then api_key_env (env var) from the
+// supplied sub-config; falls back to the supplied default env var when
+// api_key_env is unset.
+func resolveAPIKey(cfg map[string]any, defaultEnv string) string {
+	if v, ok := cfg["api_key"].(string); ok && v != "" {
+		return v
+	}
+	envVar, _ := cfg["api_key_env"].(string)
+	if envVar == "" {
+		envVar = defaultEnv
+	}
+	return os.Getenv(envVar)
+}
+
+// isTestEndpoint reports whether the configured endpoint points at an
+// httptest server (loopback). Used to relax the api-key requirement so unit
+// tests don't have to set OPENAI_API_KEY just to exercise plumbing.
+func isTestEndpoint(url string) bool {
+	return strings.Contains(url, "127.0.0.1") || strings.Contains(url, "localhost")
+}
+
+// -- handlers ---------------------------------------------------------------
+
+func (p *Plugin) handleInputChunk(e engine.Event[any]) {
+	chunk, ok := e.Payload.(events.VoiceAudioInputChunk)
+	if !ok {
+		// Allow pointer payloads too in case future emitters use *VoiceAudioInputChunk.
+		if ptr, ok := e.Payload.(*events.VoiceAudioInputChunk); ok && ptr != nil {
+			chunk = *ptr
+		} else {
+			return
+		}
+	}
+
+	audio, err := base64.StdEncoding.DecodeString(chunk.AudioBase64)
+	if err != nil {
+		p.logger.Warn("voice: failed to decode input chunk audio",
+			"turn_id", chunk.TurnID, "error", err)
+		return
+	}
+
+	rms := computeRMS(audio, chunk.MimeType)
+
+	// Barge-in: if a TTS is in flight and the new chunk shows speech-level
+	// energy, cancel the active turn before processing.
+	p.maybeBargeIn(rms)
+
+	p.appendChunk(chunk, audio, rms)
+}
+
+// maybeBargeIn emits cancel.request{Source: "voice"} when the configured
+// barge-in policy fires. Only fires once per active TTS turn.
+func (p *Plugin) maybeBargeIn(rms float64) {
+	if !p.bargeIn.enabled {
+		return
+	}
+	p.mu.Lock()
+	active := p.ttsActive
+	already := p.bargeInFired
+	if active == "" || already {
+		p.mu.Unlock()
+		return
+	}
+	if rms < p.bargeIn.threshold {
+		p.mu.Unlock()
+		return
+	}
+	p.bargeInFired = true
+	cancel := p.ttsCancel
+	p.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	p.logger.Info("voice: barge-in detected; cancelling active TTS", "turn_id", active, "rms", rms)
+	_ = p.bus.Emit("cancel.request", events.CancelRequest{
+		SchemaVersion: events.CancelRequestVersion,
+		TurnID:        active,
+		Source:        "voice",
+	})
+}
+
+// appendChunk merges a chunk into the per-turn buffer, updates speech state,
+// and either schedules a silence-flush timer or force-flushes immediately
+// when chunk.Final is set.
+func (p *Plugin) appendChunk(chunk events.VoiceAudioInputChunk, audio []byte, rms float64) {
+	p.mu.Lock()
+
+	buf, ok := p.buffers[chunk.TurnID]
+	if !ok {
+		buf = &turnBuffer{turnID: chunk.TurnID, mimeType: chunk.MimeType}
+		p.buffers[chunk.TurnID] = buf
+	}
+	if buf.flushed {
+		// Late chunks for an already-flushed turn — start a new buffer
+		// under the same turn id (treating Final=true as "end of utterance",
+		// not "end of session"). This matches the realtime IO contract that
+		// chunks emitted after Final=true are a new turn.
+		buf = &turnBuffer{turnID: chunk.TurnID, mimeType: chunk.MimeType}
+		p.buffers[chunk.TurnID] = buf
+	}
+	if buf.mimeType == "" {
+		buf.mimeType = chunk.MimeType
+	}
+	buf.audio = append(buf.audio, audio...)
+	now := time.Now()
+	buf.lastChunkAt = now
+	speaking := rms >= p.vad.threshold
+	if speaking {
+		buf.hasSpeech = true
+		buf.lastSpeechAt = now
+	}
+
+	// Cancel any pending silence-flush timer; we'll re-arm below.
+	if buf.flushTimer != nil {
+		buf.flushTimer.Stop()
+		buf.flushTimer = nil
+	}
+
+	if chunk.Final {
+		// Mark flushed inline so a concurrent timer can't double-fire.
+		buf.flushed = true
+		audioCopy := append([]byte(nil), buf.audio...)
+		mime := buf.mimeType
+		hasSpeech := buf.hasSpeech || rms >= p.vad.threshold
+		p.mu.Unlock()
+		go p.flush(chunk.TurnID, audioCopy, mime, hasSpeech)
+		return
+	}
+
+	if buf.hasSpeech {
+		// Arm a silence flush. Will fire after silence_ms of no further chunks.
+		turnID := chunk.TurnID
+		buf.flushTimer = time.AfterFunc(time.Duration(p.vad.silenceMS)*time.Millisecond, func() {
+			p.silenceFlush(turnID)
+		})
+	}
+	p.mu.Unlock()
+}
+
+// silenceFlush is invoked when the silence timer fires for the given turn.
+// It pulls the buffered audio and runs ASR.
+func (p *Plugin) silenceFlush(turnID string) {
+	p.mu.Lock()
+	buf, ok := p.buffers[turnID]
+	if !ok || buf.flushed || !buf.hasSpeech {
+		p.mu.Unlock()
+		return
+	}
+	buf.flushed = true
+	audio := append([]byte(nil), buf.audio...)
+	mime := buf.mimeType
+	p.mu.Unlock()
+	p.flush(turnID, audio, mime, true)
+}
+
+// flush runs ASR on the buffered audio and emits io.input with the result.
+// Empty utterances and transcribe failures are logged but not fatal.
+func (p *Plugin) flush(turnID string, audio []byte, mime string, hasSpeech bool) {
+	if !hasSpeech || len(audio) == 0 {
+		return
+	}
+
+	client := &asrClient{
+		endpoint: p.asr.endpoint,
+		apiKey:   p.asr.apiKey,
+		model:    p.asr.model,
+		http:     p.httpClient,
+	}
+
+	// Use a fresh context per ASR call. Bound it to a generous timeout so a
+	// hung server doesn't pin the goroutine forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	text, err := client.transcribe(ctx, audio, mime)
+	if err != nil {
+		p.logger.Error("voice: ASR transcribe failed",
+			"turn_id", turnID, "error", err)
+		return
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		p.logger.Debug("voice: ASR returned empty text; suppressing io.input", "turn_id", turnID)
+		return
+	}
+
+	sessionID := ""
+	if p.session != nil {
+		sessionID = p.session.ID
+	}
+	input := events.UserInput{
+		SchemaVersion: events.UserInputVersion,
+		Content:       text,
+		SessionID:     sessionID,
+	}
+	if veto, err := p.bus.EmitVetoable("before:io.input", &input); err == nil && veto.Vetoed {
+		return
+	}
+	_ = p.bus.Emit("io.input", input)
+}
+
+// -- TTS ---------------------------------------------------------------------
+
+func (p *Plugin) handleLLMResponse(e engine.Event[any]) {
+	resp, ok := e.Payload.(events.LLMResponse)
+	if !ok {
+		if ptr, ok := e.Payload.(*events.LLMResponse); ok && ptr != nil {
+			resp = *ptr
+		} else {
+			return
+		}
+	}
+	text := strings.TrimSpace(resp.Content)
+	if text == "" {
+		return
+	}
+
+	turnID := ""
+	if resp.Metadata != nil {
+		if tid, ok := resp.Metadata["turn_id"].(string); ok {
+			turnID = tid
+		}
+	}
+	if turnID == "" {
+		turnID = engine.GenerateID()
+	}
+
+	go p.runTTS(turnID, text)
+}
+
+// runTTS performs the TTS HTTP call and emits chunked audio events.
+func (p *Plugin) runTTS(turnID, text string) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	p.mu.Lock()
+	// If a previous TTS is somehow still active for the same turn, cancel it.
+	if p.ttsCancel != nil {
+		p.ttsCancel()
+	}
+	p.ttsActive = turnID
+	p.ttsCancel = cancel
+	p.bargeInFired = false
+	p.mu.Unlock()
+
+	defer func() {
+		p.mu.Lock()
+		if p.ttsActive == turnID {
+			p.ttsActive = ""
+			p.ttsCancel = nil
+		}
+		p.mu.Unlock()
+		cancel()
+	}()
+
+	client := &ttsClient{
+		endpoint: p.tts.endpoint,
+		apiKey:   p.tts.apiKey,
+		model:    p.tts.model,
+		voice:    p.tts.voice,
+		http:     p.httpClient,
+	}
+
+	data, mime, err := client.synthesize(ctx, text)
+	if err != nil {
+		// Cancellation is the expected path for barge-in; degrade quietly.
+		if errors.Is(ctx.Err(), context.Canceled) {
+			p.logger.Debug("voice: TTS cancelled", "turn_id", turnID)
+			return
+		}
+		p.logger.Error("voice: TTS synthesize failed", "turn_id", turnID, "error", err)
+		return
+	}
+	if mime == "" {
+		mime = "audio/mpeg"
+	}
+
+	chunkSize := p.tts.chunkBytes
+	if chunkSize <= 0 {
+		chunkSize = defaultTTSChunkBytes
+	}
+
+	total := len(data)
+	if total == 0 {
+		// Emit a single final chunk so consumers see a clean turn boundary.
+		_ = p.bus.Emit("voice.audio.output.chunk", events.VoiceAudioOutputChunk{
+			SchemaVersion: events.VoiceAudioOutputChunkVersion,
+			TurnID:        turnID,
+			Sequence:      0,
+			MimeType:      mime,
+			Final:         true,
+		})
+		return
+	}
+
+	seq := 0
+	for off := 0; off < total; off += chunkSize {
+		end := off + chunkSize
+		if end > total {
+			end = total
+		}
+		final := end == total
+		// Honor barge-in / shutdown cancel between frames so a long MP3
+		// doesn't keep flooding the bus after the user has interrupted.
+		if ctx.Err() != nil {
+			return
+		}
+		_ = p.bus.Emit("voice.audio.output.chunk", events.VoiceAudioOutputChunk{
+			SchemaVersion: events.VoiceAudioOutputChunkVersion,
+			TurnID:        turnID,
+			Sequence:      seq,
+			AudioBase64:   base64.StdEncoding.EncodeToString(data[off:end]),
+			MimeType:      mime,
+			Final:         final,
+		})
+		seq++
+	}
+}
+
+// -- config helpers ----------------------------------------------------------
+
+func stringOrDefault(m map[string]any, key, def string) string {
+	if v, ok := m[key].(string); ok && v != "" {
+		return v
+	}
+	return def
+}
+
+func intOrDefault(m map[string]any, key string, def int) int {
+	switch v := m[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return def
+}
+
+func floatOrDefault(m map[string]any, key string, def float64) float64 {
+	switch v := m[key].(type) {
+	case float64:
+		return v
+	case float32:
+		return float64(v)
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	}
+	return def
+}
+
+func boolOrDefault(m map[string]any, key string, def bool) bool {
+	if v, ok := m[key].(bool); ok {
+		return v
+	}
+	return def
+}

--- a/plugins/io/voice/plugin.go
+++ b/plugins/io/voice/plugin.go
@@ -66,15 +66,14 @@ type bargeInConfig struct {
 
 // turnBuffer accumulates audio chunks for a single utterance.
 type turnBuffer struct {
-	turnID         string
-	mimeType       string
-	audio          []byte
-	lastChunkAt    time.Time
-	lastSpeechAt   time.Time
-	hasSpeech      bool
-	flushed        bool
-	flushTimer     *time.Timer
-	expectedSeqNxt int // next expected sequence number; -1 = unknown
+	turnID       string
+	mimeType     string
+	audio        []byte
+	lastChunkAt  time.Time
+	lastSpeechAt time.Time
+	hasSpeech    bool
+	flushed      bool
+	flushTimer   *time.Timer
 }
 
 // Plugin implements engine.Plugin for nexus.io.voice.

--- a/plugins/io/voice/plugin_test.go
+++ b/plugins/io/voice/plugin_test.go
@@ -1,0 +1,520 @@
+package voice
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// newPluginForTest wires a Plugin against a real engine.EventBus and a
+// pair of httptest servers for ASR + TTS. It returns the plugin, the bus,
+// and the two server URLs. Caller is responsible for invoking Shutdown.
+func newPluginForTest(t *testing.T, asrURL, ttsURL string, mutate func(map[string]any)) (*Plugin, engine.EventBus) {
+	t.Helper()
+
+	bus := engine.NewEventBus()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	cfg := map[string]any{
+		"asr": map[string]any{
+			"endpoint": asrURL,
+			"api_key":  "test",
+		},
+		"tts": map[string]any{
+			"endpoint":    ttsURL,
+			"api_key":     "test",
+			"chunk_bytes": 16,
+		},
+		"vad": map[string]any{
+			"threshold":  0.05,
+			"silence_ms": 50,
+		},
+		"barge_in": map[string]any{
+			"enabled":   true,
+			"threshold": 0.05,
+		},
+	}
+	if mutate != nil {
+		mutate(cfg)
+	}
+
+	p := New().(*Plugin)
+	if err := p.Init(engine.PluginContext{
+		Config: cfg,
+		Bus:    bus,
+		Logger: logger,
+	}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = p.Shutdown(nil)
+	})
+
+	return p, bus
+}
+
+// makePCMChunk builds a base64-encoded little-endian int16 PCM buffer at the
+// given amplitude (0..1). amp=0 produces silence, amp=0.5 produces ~half-
+// scale energy.
+func makePCMChunk(amp float64, samples int) string {
+	buf := make([]byte, samples*2)
+	val := int16(amp * 32767)
+	for i := 0; i < samples; i++ {
+		// Square wave, alternating sign — gives consistent RMS = amp.
+		v := val
+		if i%2 == 1 {
+			v = -val
+		}
+		binary.LittleEndian.PutUint16(buf[i*2:], uint16(v))
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+// startASRServer returns an httptest server that always returns the supplied
+// transcription text for /v1/audio/transcriptions.
+func startASRServer(t *testing.T, transcription string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Multipart parsing — best effort. We do not assert on the body to
+		// keep the test focused on the plugin's plumbing.
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			t.Logf("server: parse multipart: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"text": transcription})
+	})
+	return httptest.NewServer(mux)
+}
+
+// startTTSServer returns an httptest server that returns the supplied audio
+// bytes with content-type audio/mpeg.
+func startTTSServer(t *testing.T, audio []byte) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write(audio)
+	})
+	return httptest.NewServer(mux)
+}
+
+// --- VAD tests --------------------------------------------------------------
+
+func TestComputeRMS_PCMSilence(t *testing.T) {
+	silent := make([]byte, 2048) // all zeros == silence
+	rms := computeRMS(silent, "audio/wav")
+	if rms != 0 {
+		t.Fatalf("silence RMS expected 0, got %v", rms)
+	}
+}
+
+func TestComputeRMS_PCMHalfScale(t *testing.T) {
+	// 16384 (~half scale int16) signed alternating gives RMS ~ 0.5.
+	buf := make([]byte, 4096)
+	for i := 0; i < len(buf); i += 2 {
+		var v int16 = 16384
+		if (i/2)%2 == 1 {
+			v = -16384
+		}
+		binary.LittleEndian.PutUint16(buf[i:], uint16(v))
+	}
+	rms := computeRMS(buf, "audio/wav")
+	if math.Abs(rms-0.5) > 0.01 {
+		t.Fatalf("expected ~0.5 RMS, got %v", rms)
+	}
+}
+
+func TestComputeRMS_OpaqueByteHeuristic(t *testing.T) {
+	// Bytes near 128 -> low energy; bytes near 0/255 -> high energy.
+	low := []byte{128, 128, 128, 128, 129, 127, 128, 128}
+	high := []byte{0, 255, 0, 255, 0, 255, 0, 255}
+
+	lowRMS := computeRMS(low, "audio/webm")
+	highRMS := computeRMS(high, "audio/webm")
+	if lowRMS >= highRMS {
+		t.Fatalf("expected low<high, got low=%v high=%v", lowRMS, highRMS)
+	}
+}
+
+// --- VAD silence flush ------------------------------------------------------
+
+// TestVAD_SilenceFlushTriggersASR feeds a chunk of speech-level audio, waits
+// past silence_ms with no further chunks, and asserts io.input fires.
+func TestVAD_SilenceFlushTriggersASR(t *testing.T) {
+	asr := startASRServer(t, "hello world")
+	defer asr.Close()
+	tts := startTTSServer(t, []byte("audio"))
+	defer tts.Close()
+
+	_, bus := newPluginForTest(t, asr.URL, tts.URL, nil)
+
+	var (
+		mu        sync.Mutex
+		gotInputs []events.UserInput
+	)
+	bus.Subscribe("io.input", func(e engine.Event[any]) {
+		if u, ok := e.Payload.(events.UserInput); ok {
+			mu.Lock()
+			gotInputs = append(gotInputs, u)
+			mu.Unlock()
+		}
+	})
+
+	// Speech-level chunk.
+	if err := bus.Emit("voice.audio.input.chunk", events.VoiceAudioInputChunk{
+		SchemaVersion: events.VoiceAudioInputChunkVersion,
+		TurnID:        "t1",
+		AudioBase64:   makePCMChunk(0.5, 256),
+		MimeType:      "audio/wav",
+	}); err != nil {
+		t.Fatalf("emit chunk: %v", err)
+	}
+
+	// Wait for silence_ms (50ms) + ASR roundtrip + emit.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := len(gotInputs)
+		mu.Unlock()
+		if got > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(gotInputs) != 1 {
+		t.Fatalf("expected 1 io.input, got %d", len(gotInputs))
+	}
+	if gotInputs[0].Content != "hello world" {
+		t.Fatalf("expected content 'hello world', got %q", gotInputs[0].Content)
+	}
+}
+
+// TestVAD_FinalForcesFlush sends a single chunk with Final=true, verifies the
+// flush fires immediately (not waiting for silence_ms).
+func TestVAD_FinalForcesFlush(t *testing.T) {
+	asr := startASRServer(t, "final flushed")
+	defer asr.Close()
+	tts := startTTSServer(t, []byte("audio"))
+	defer tts.Close()
+
+	// Use a long silence_ms to prove final overrides it.
+	_, bus := newPluginForTest(t, asr.URL, tts.URL, func(cfg map[string]any) {
+		cfg["vad"].(map[string]any)["silence_ms"] = 60000
+	})
+
+	gotCh := make(chan events.UserInput, 1)
+	bus.Subscribe("io.input", func(e engine.Event[any]) {
+		if u, ok := e.Payload.(events.UserInput); ok {
+			select {
+			case gotCh <- u:
+			default:
+			}
+		}
+	})
+
+	if err := bus.Emit("voice.audio.input.chunk", events.VoiceAudioInputChunk{
+		SchemaVersion: events.VoiceAudioInputChunkVersion,
+		TurnID:        "t-final",
+		AudioBase64:   makePCMChunk(0.5, 256),
+		MimeType:      "audio/wav",
+		Final:         true,
+	}); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	select {
+	case got := <-gotCh:
+		if got.Content != "final flushed" {
+			t.Fatalf("got %q", got.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("io.input never emitted on Final=true within 2s")
+	}
+}
+
+// --- TTS roundtrip ----------------------------------------------------------
+
+func TestTTS_EmitsChunkedAudio(t *testing.T) {
+	asr := startASRServer(t, "")
+	defer asr.Close()
+	// 40 bytes of fake MP3 — at chunk_bytes=16 we expect ceil(40/16)=3 chunks.
+	want := []byte("FAKEMP3FAKEMP3FAKEMP3FAKEMP3FAKEMP3FAKEM") // 40 bytes
+	tts := startTTSServer(t, want)
+	defer tts.Close()
+
+	_, bus := newPluginForTest(t, asr.URL, tts.URL, nil)
+
+	var (
+		mu     sync.Mutex
+		chunks []events.VoiceAudioOutputChunk
+	)
+	done := make(chan struct{})
+	bus.Subscribe("voice.audio.output.chunk", func(e engine.Event[any]) {
+		ch, ok := e.Payload.(events.VoiceAudioOutputChunk)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		chunks = append(chunks, ch)
+		final := ch.Final
+		mu.Unlock()
+		if final {
+			select {
+			case <-done:
+			default:
+				close(done)
+			}
+		}
+	})
+
+	if err := bus.Emit("llm.response", events.LLMResponse{
+		SchemaVersion: events.LLMResponseVersion,
+		Content:       "speak this",
+		Metadata:      map[string]any{"turn_id": "t-tts"},
+	}); err != nil {
+		t.Fatalf("emit llm.response: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("never received final voice.audio.output.chunk")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks (40 bytes / 16), got %d", len(chunks))
+	}
+	if !chunks[len(chunks)-1].Final {
+		t.Fatal("last chunk should have Final=true")
+	}
+	// Reassemble decoded audio and compare to the server's response body.
+	var out []byte
+	for _, c := range chunks {
+		if c.AudioBase64 == "" {
+			continue
+		}
+		dec, err := base64.StdEncoding.DecodeString(c.AudioBase64)
+		if err != nil {
+			t.Fatalf("decode chunk: %v", err)
+		}
+		out = append(out, dec...)
+	}
+	if string(out) != string(want) {
+		t.Fatalf("reassembled audio mismatch:\n got=%q\nwant=%q", out, want)
+	}
+	for _, c := range chunks {
+		if c.MimeType != "audio/mpeg" {
+			t.Fatalf("expected mime audio/mpeg, got %q", c.MimeType)
+		}
+		if c.TurnID != "t-tts" {
+			t.Fatalf("expected turn id t-tts, got %q", c.TurnID)
+		}
+	}
+}
+
+// --- Barge-in ---------------------------------------------------------------
+
+func TestBargeIn_EmitsCancelDuringTTS(t *testing.T) {
+	asr := startASRServer(t, "post barge")
+	defer asr.Close()
+
+	// TTS server: hold the connection open until we close `release`. That
+	// simulates a long-running synthesis so the barge-in chunk arrives while
+	// it's still in flight.
+	release := make(chan struct{})
+	ttsHandler := http.NewServeMux()
+	ttsHandler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte("audio"))
+	})
+	tts := httptest.NewServer(ttsHandler)
+	defer tts.Close()
+	defer close(release)
+
+	_, bus := newPluginForTest(t, asr.URL, tts.URL, nil)
+
+	cancelCh := make(chan events.CancelRequest, 1)
+	bus.Subscribe("cancel.request", func(e engine.Event[any]) {
+		if c, ok := e.Payload.(events.CancelRequest); ok {
+			select {
+			case cancelCh <- c:
+			default:
+			}
+		}
+	})
+
+	// Kick off TTS: the handler holds the connection so ttsActive stays set.
+	if err := bus.Emit("llm.response", events.LLMResponse{
+		SchemaVersion: events.LLMResponseVersion,
+		Content:       "agent reply",
+		Metadata:      map[string]any{"turn_id": "agent-1"},
+	}); err != nil {
+		t.Fatalf("emit llm.response: %v", err)
+	}
+
+	// Wait briefly for runTTS to register itself.
+	time.Sleep(50 * time.Millisecond)
+
+	// Now send a speech-energy chunk that should fire barge-in.
+	if err := bus.Emit("voice.audio.input.chunk", events.VoiceAudioInputChunk{
+		SchemaVersion: events.VoiceAudioInputChunkVersion,
+		TurnID:        "user-2",
+		AudioBase64:   makePCMChunk(0.5, 256),
+		MimeType:      "audio/wav",
+	}); err != nil {
+		t.Fatalf("emit chunk: %v", err)
+	}
+
+	select {
+	case got := <-cancelCh:
+		if got.Source != "voice" {
+			t.Fatalf("expected Source=voice, got %q", got.Source)
+		}
+		if got.TurnID != "agent-1" {
+			t.Fatalf("expected TurnID=agent-1, got %q", got.TurnID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancel.request never emitted on barge-in")
+	}
+}
+
+// TestBargeIn_DisabledNoCancel asserts that turning barge-in off prevents the
+// cancel.request emission even when speech-level audio arrives mid-TTS.
+func TestBargeIn_DisabledNoCancel(t *testing.T) {
+	asr := startASRServer(t, "")
+	defer asr.Close()
+
+	release := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte("audio"))
+	})
+	tts := httptest.NewServer(mux)
+	defer tts.Close()
+	defer close(release)
+
+	_, bus := newPluginForTest(t, asr.URL, tts.URL, func(cfg map[string]any) {
+		cfg["barge_in"].(map[string]any)["enabled"] = false
+	})
+
+	cancelCh := make(chan events.CancelRequest, 1)
+	bus.Subscribe("cancel.request", func(e engine.Event[any]) {
+		if c, ok := e.Payload.(events.CancelRequest); ok {
+			select {
+			case cancelCh <- c:
+			default:
+			}
+		}
+	})
+
+	_ = bus.Emit("llm.response", events.LLMResponse{
+		SchemaVersion: events.LLMResponseVersion,
+		Content:       "agent reply",
+		Metadata:      map[string]any{"turn_id": "agent-2"},
+	})
+	time.Sleep(50 * time.Millisecond)
+	_ = bus.Emit("voice.audio.input.chunk", events.VoiceAudioInputChunk{
+		SchemaVersion: events.VoiceAudioInputChunkVersion,
+		TurnID:        "user-3",
+		AudioBase64:   makePCMChunk(0.5, 256),
+		MimeType:      "audio/wav",
+	})
+
+	select {
+	case got := <-cancelCh:
+		t.Fatalf("did not expect cancel.request, got %+v", got)
+	case <-time.After(300 * time.Millisecond):
+		// good
+	}
+}
+
+// --- local-provider rejection ----------------------------------------------
+
+func TestInit_RejectsLocalASRProvider(t *testing.T) {
+	bus := engine.NewEventBus()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := New().(*Plugin)
+	err := p.Init(engine.PluginContext{
+		Bus:    bus,
+		Logger: logger,
+		Config: map[string]any{
+			"asr": map[string]any{"provider": "local_whisper"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "#92") {
+		t.Fatalf("expected error to mention #92, got %v", err)
+	}
+}
+
+func TestInit_RejectsLocalTTSProvider(t *testing.T) {
+	bus := engine.NewEventBus()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := New().(*Plugin)
+	err := p.Init(engine.PluginContext{
+		Bus:    bus,
+		Logger: logger,
+		Config: map[string]any{
+			"asr": map[string]any{"endpoint": "http://localhost", "api_key": "x"},
+			"tts": map[string]any{"provider": "kokoro"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "#92") {
+		t.Fatalf("expected error to mention #92, got %v", err)
+	}
+}
+
+// TestInit_RejectsUnknownASRProvider asserts unknown values are not silently
+// accepted.
+func TestInit_RejectsUnknownASRProvider(t *testing.T) {
+	bus := engine.NewEventBus()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := New().(*Plugin)
+	err := p.Init(engine.PluginContext{
+		Bus:    bus,
+		Logger: logger,
+		Config: map[string]any{
+			"asr": map[string]any{"provider": "deepgram"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if strings.Contains(err.Error(), "#92") {
+		t.Fatalf("did not expect #92 hint for unknown provider, got %v", err)
+	}
+}

--- a/plugins/io/voice/plugin_test.go
+++ b/plugins/io/voice/plugin_test.go
@@ -1,6 +1,7 @@
 package voice
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -60,7 +61,7 @@ func newPluginForTest(t *testing.T, asrURL, ttsURL string, mutate func(map[strin
 	}
 
 	t.Cleanup(func() {
-		_ = p.Shutdown(nil)
+		_ = p.Shutdown(context.Background())
 	})
 
 	return p, bus

--- a/plugins/io/voice/schema.go
+++ b/plugins/io/voice/schema.go
@@ -1,0 +1,9 @@
+package voice
+
+import _ "embed"
+
+//go:embed schema.json
+var configSchemaBytes []byte
+
+// ConfigSchema implements engine.ConfigSchemaProvider.
+func (p *Plugin) ConfigSchema() []byte { return configSchemaBytes }

--- a/plugins/io/voice/schema.json
+++ b/plugins/io/voice/schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexus.local/schemas/plugins/nexus.io.voice.json",
+  "title": "nexus.io.voice",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "asr": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "ASR provider id. Only 'openai_whisper' is wired in this PR; local-model providers (local_whisper, faster_whisper, distil_whisper) are accepted by the schema but rejected at Init pending #92."
+        },
+        "api_key_env": {"type": "string", "description": "Env var that holds the API key. Default OPENAI_API_KEY."},
+        "api_key":     {"type": "string", "description": "Inline API key. Overrides api_key_env when set."},
+        "model":       {"type": "string", "description": "Whisper model id. Default whisper-1."},
+        "endpoint":    {"type": "string", "description": "Override URL for the transcription endpoint (test injection)."}
+      }
+    },
+    "tts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider":    {"type": "string", "description": "TTS provider id. Only 'openai' is wired in this PR; local-model providers (kokoro, local_*, *_local) are accepted by the schema but rejected at Init pending #92."},
+        "api_key_env": {"type": "string", "description": "Env var that holds the API key. Default OPENAI_API_KEY."},
+        "api_key":     {"type": "string", "description": "Inline API key. Overrides api_key_env when set."},
+        "model":       {"type": "string", "description": "TTS model id. Default tts-1."},
+        "voice":       {"type": "string", "description": "Voice preset id. Default alloy."},
+        "streaming":   {"type": "boolean", "description": "Always true in v1; reserved for future non-streaming mode."},
+        "endpoint":    {"type": "string", "description": "Override URL for the speech endpoint (test injection)."},
+        "chunk_bytes": {"type": "integer", "description": "Frame size in bytes for emitted output chunks. Default 8192."}
+      }
+    },
+    "vad": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "threshold":  {"type": "number",  "description": "RMS energy threshold (normalized 0..1) above which the buffer is considered speech. Default 0.02."},
+        "silence_ms": {"type": "integer", "description": "Milliseconds of below-threshold audio that triggers an utterance flush. Default 600."}
+      }
+    },
+    "barge_in": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":   {"type": "boolean", "description": "Cancel an in-flight TTS turn when new speech is detected. Default true."},
+        "threshold": {"type": "number",  "description": "RMS threshold above which an incoming chunk is treated as barge-in. Default 0.02."}
+      }
+    },
+    "text_fallback": {"type": "boolean", "description": "Allow io.input from non-voice transports to flow through unchanged. Default true."}
+  }
+}

--- a/plugins/io/voice/tts.go
+++ b/plugins/io/voice/tts.go
@@ -1,0 +1,81 @@
+package voice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// defaultTTSEndpoint is OpenAI's audio speech (TTS) endpoint.
+const defaultTTSEndpoint = "https://api.openai.com/v1/audio/speech"
+
+// defaultTTSChunkBytes is the default frame size for emitted output chunks.
+// Picked at ~8 KB so each frame is small enough to stream over a websocket
+// without head-of-line blocking but large enough to avoid event-bus chatter.
+const defaultTTSChunkBytes = 8192
+
+// ttsClient wraps an OpenAI-compatible /audio/speech endpoint. The endpoint
+// is overridable via config (tts.endpoint) so tests can spin up an httptest
+// server returning canned audio bytes.
+type ttsClient struct {
+	endpoint string
+	apiKey   string
+	model    string
+	voice    string
+	http     *http.Client
+}
+
+// synthesize POSTs the request body and returns the full MP3 bytes plus the
+// content-type the server claimed. The TTS endpoint streams MP3 by default;
+// we read the entire body up front because the bus envelope (chunked output
+// events) prefers a complete buffer to slice from.
+func (c *ttsClient) synthesize(ctx context.Context, text string) ([]byte, string, error) {
+	if text == "" {
+		return nil, "", nil
+	}
+	payload := map[string]any{
+		"model":           c.model,
+		"voice":           c.voice,
+		"input":           text,
+		"response_format": "mp3",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("voice: marshal TTS request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, "", fmt.Errorf("voice: build TTS request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "audio/mpeg")
+
+	client := c.http
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("voice: TTS HTTP error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("voice: read TTS body: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, "", fmt.Errorf("voice: TTS status %d: %s", resp.StatusCode, string(data))
+	}
+
+	mime := resp.Header.Get("Content-Type")
+	if mime == "" {
+		mime = "audio/mpeg"
+	}
+	return data, mime, nil
+}

--- a/plugins/io/voice/vad.go
+++ b/plugins/io/voice/vad.go
@@ -1,0 +1,87 @@
+package voice
+
+import (
+	"encoding/binary"
+	"math"
+	"strings"
+)
+
+// computeRMS computes a normalized 0..1 RMS energy value for a chunk of audio
+// bytes.
+//
+// For PCM container types ("audio/wav", "audio/pcm", "audio/l16") the bytes
+// are interpreted as little-endian signed 16-bit samples and the result is
+// the standard RMS divided by the int16 max (32767).
+//
+// For compressed containers (webm/opus, mpeg/mp3, etc.) the bytes are not
+// PCM, so a true RMS is unavailable here. We fall back to a byte-level energy
+// heuristic: average absolute deviation of each byte from 128 normalized to
+// 0..1. This is approximate — it correlates loosely with audio energy because
+// silence in compressed streams produces low-variance bytes — but it is good
+// enough for a heuristic-grade barge-in / VAD signal until a proper decode is
+// wired in. TODO(#91): decode webm/opus and mpeg before computing energy so
+// VAD numbers match true loudness on browser MediaRecorder streams.
+func computeRMS(audio []byte, mimeType string) float64 {
+	if len(audio) == 0 {
+		return 0
+	}
+	if isPCMMime(mimeType) {
+		return rmsPCM16LE(audio)
+	}
+	return rmsByteHeuristic(audio)
+}
+
+// isPCMMime reports whether the given mime indicates raw 16-bit PCM-like
+// content. WAV is included even though it has a header — the header is small
+// relative to the body and the heuristic is robust to its inclusion.
+func isPCMMime(mime string) bool {
+	m := strings.ToLower(strings.TrimSpace(mime))
+	if m == "" {
+		return false
+	}
+	// Strip codec parameters: "audio/wav; codecs=1" -> "audio/wav".
+	if i := strings.IndexByte(m, ';'); i >= 0 {
+		m = strings.TrimSpace(m[:i])
+	}
+	switch m {
+	case "audio/wav", "audio/x-wav", "audio/wave",
+		"audio/pcm", "audio/l16", "audio/x-l16":
+		return true
+	}
+	return false
+}
+
+// rmsPCM16LE treats audio as little-endian signed 16-bit samples.
+func rmsPCM16LE(audio []byte) float64 {
+	// Each sample is 2 bytes; if odd byte count, drop the trailing byte.
+	n := len(audio) &^ 1
+	if n == 0 {
+		return 0
+	}
+	var sumSq float64
+	count := 0
+	for i := 0; i < n; i += 2 {
+		s := int16(binary.LittleEndian.Uint16(audio[i : i+2]))
+		f := float64(s) / 32768.0
+		sumSq += f * f
+		count++
+	}
+	if count == 0 {
+		return 0
+	}
+	return math.Sqrt(sumSq / float64(count))
+}
+
+// rmsByteHeuristic returns the mean absolute deviation from byte midpoint
+// (128) divided by 128 — a 0..1 energy proxy for opaque/compressed bytes.
+func rmsByteHeuristic(audio []byte) float64 {
+	var sum float64
+	for _, b := range audio {
+		d := float64(int(b) - 128)
+		if d < 0 {
+			d = -d
+		}
+		sum += d
+	}
+	return sum / float64(len(audio)) / 128.0
+}

--- a/plugins/memory/capped/plugin.go
+++ b/plugins/memory/capped/plugin.go
@@ -262,6 +262,7 @@ func (p *Plugin) handleToolResult(e engine.Event[any]) {
 		Role:       "tool",
 		Content:    content,
 		ToolCallID: result.ID,
+		Parts:      result.OutputParts,
 	})
 }
 

--- a/plugins/memory/capped/plugin_test.go
+++ b/plugins/memory/capped/plugin_test.go
@@ -53,6 +53,34 @@ func TestToolResult_SkipsInternalCalls(t *testing.T) {
 	}
 }
 
+// TestToolResultParts_CarriedToMessage verifies that the multimodal carrier
+// (ToolResult.OutputParts) lands on the resulting tool-role Message.Parts
+// so the next LLM request includes the multimodal content alongside the
+// tool result.
+func TestToolResultParts_CarriedToMessage(t *testing.T) {
+	p := New().(*Plugin)
+	p.logger = slog.Default()
+	p.persist = false
+
+	p.handleToolResult(engine.Event[any]{Payload: events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: "tm-1",
+		Name:   "read_image",
+		Output: "Loaded image diagram.png",
+		OutputParts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", URI: "nexus-blob:abc123"},
+		},
+	}})
+
+	if n := len(p.messages); n != 1 {
+		t.Fatalf("expected 1 message; got %d", n)
+	}
+	if got := len(p.messages[0].Parts); got != 1 {
+		t.Fatalf("Message.Parts len = %d, want 1", got)
+	}
+	if p.messages[0].Parts[0].URI != "nexus-blob:abc123" {
+		t.Errorf("Parts[0].URI = %q, want nexus-blob:abc123", p.messages[0].Parts[0].URI)
+	}
+}
+
 // TestPairSafeTruncation proves that when the buffer caps out on a boundary
 // that would orphan a tool result from its assistant tool_use, the plugin
 // drops the leading orphan "tool" messages so the buffer stays well-formed

--- a/plugins/memory/simple/plugin.go
+++ b/plugins/memory/simple/plugin.go
@@ -176,6 +176,7 @@ func (p *Plugin) handleToolResult(e engine.Event[any]) {
 		Role:       "tool",
 		Content:    content,
 		ToolCallID: result.ID,
+		Parts:      result.OutputParts,
 	})
 }
 

--- a/plugins/memory/simple/plugin_test.go
+++ b/plugins/memory/simple/plugin_test.go
@@ -40,6 +40,36 @@ func TestAppendMessages(t *testing.T) {
 	}
 }
 
+// TestToolResultParts_CarriedToMessage verifies that ToolResult.OutputParts
+// (the multimodal carrier) are copied onto the resulting tool-role
+// Message.Parts so the next LLM request includes the multimodal content.
+func TestToolResultParts_CarriedToMessage(t *testing.T) {
+	p := New().(*Plugin)
+	p.logger = slog.Default()
+
+	p.handleToolResult(engine.Event[any]{Payload: events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: "tm-1",
+		Name:   "read_image",
+		Output: "Loaded image diagram.png",
+		OutputParts: []events.MessagePart{
+			{Type: "image", MimeType: "image/png", URI: "nexus-blob:abc123"},
+		},
+	}})
+
+	msgs := p.GetHistory()
+	if len(msgs) != 1 {
+		t.Fatalf("len(history) = %d, want 1", len(msgs))
+	}
+	if got := len(msgs[0].Parts); got != 1 {
+		t.Fatalf("Message.Parts len = %d, want 1", got)
+	}
+	if msgs[0].Parts[0].URI != "nexus-blob:abc123" {
+		t.Errorf("Parts[0].URI = %q, want nexus-blob:abc123", msgs[0].Parts[0].URI)
+	}
+	if msgs[0].Parts[0].Type != "image" {
+		t.Errorf("Parts[0].Type = %q, want image", msgs[0].Parts[0].Type)
+	}
+}
+
 // TestInternalCallsFiltered proves that tool results for ParentCallID-flagged
 // calls never reach history. Same invariant as the capped plugin.
 func TestInternalCallsFiltered(t *testing.T) {

--- a/plugins/memory/summary_buffer/plugin.go
+++ b/plugins/memory/summary_buffer/plugin.go
@@ -340,6 +340,7 @@ func (p *Plugin) handleToolResult(e engine.Event[any]) {
 		Role:       "tool",
 		Content:    content,
 		ToolCallID: result.ID,
+		Parts:      result.OutputParts,
 	})
 }
 

--- a/plugins/memory/vector/image_test.go
+++ b/plugins/memory/vector/image_test.go
@@ -1,0 +1,218 @@
+package vector
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// imageStubBus wires a Plugin with a stub multimodal embeddings.provider
+// that returns a 4-dim vector for every input, recording the inputs it
+// received so tests can assert image bytes flowed through.
+func imageStubBus(t *testing.T, storeImages bool) (*Plugin, engine.EventBus, *[]events.EmbeddingsRequest, *[]events.VectorUpsert) {
+	t.Helper()
+	bus := engine.NewEventBus()
+	p := New().(*Plugin)
+	p.bus = bus
+	p.logger = slog.Default()
+	p.namespace = "test-text-ns"
+	p.storeImages = storeImages
+
+	var embedReqs []events.EmbeddingsRequest
+	bus.Subscribe("embeddings.request", func(ev engine.Event[any]) {
+		req, ok := ev.Payload.(*events.EmbeddingsRequest)
+		if !ok {
+			return
+		}
+		// Snapshot the request before we mutate it for assertions.
+		snapshot := *req
+		embedReqs = append(embedReqs, snapshot)
+		req.Vectors = [][]float32{{0.1, 0.2, 0.3, 0.4}}
+		req.Provider = "test.embedder"
+	}, engine.WithPriority(50))
+
+	var upserts []events.VectorUpsert
+	bus.Subscribe("vector.upsert", func(ev engine.Event[any]) {
+		if up, ok := ev.Payload.(*events.VectorUpsert); ok {
+			upserts = append(upserts, *up)
+		}
+	}, engine.WithPriority(100))
+
+	return p, bus, &embedReqs, &upserts
+}
+
+func TestStoreImages_OffByDefault(t *testing.T) {
+	p, _, embedReqs, upserts := imageStubBus(t, false)
+
+	in := events.UserInput{
+		SchemaVersion: events.UserInputVersion,
+		Content:       "look at this picture",
+		Files: []events.FileAttachment{
+			{Name: "cat.png", MimeType: "image/png", Data: []byte{0x01, 0x02}},
+		},
+	}
+	p.handleInput(engine.Event[any]{Payload: in})
+
+	// Only the text path should run when store_images is false: a single
+	// embeddings.request for the user content (recall / autoStore are off
+	// by default, so no upsert happens).
+	if len(*embedReqs) != 1 {
+		t.Fatalf("expected 1 embed request (text recall), got %d", len(*embedReqs))
+	}
+	if len((*embedReqs)[0].Texts) != 1 || (*embedReqs)[0].Texts[0] != "look at this picture" {
+		t.Errorf("expected text recall request; got %+v", (*embedReqs)[0])
+	}
+	for _, r := range *embedReqs {
+		if len(r.Inputs) > 0 {
+			t.Errorf("store_images=false: should not produce image Inputs; got %+v", r.Inputs)
+		}
+	}
+	if len(*upserts) != 0 {
+		t.Errorf("store_images=false: should not upsert; got %d upserts", len(*upserts))
+	}
+}
+
+func TestStoreImages_OnEmbedsAndUpserts(t *testing.T) {
+	p, _, embedReqs, upserts := imageStubBus(t, true)
+
+	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+	in := events.UserInput{
+		SchemaVersion: events.UserInputVersion,
+		Content:       "check the image",
+		SessionID:     "sess-1",
+		Files: []events.FileAttachment{
+			{Name: "diagram.png", MimeType: "image/png", Data: pngBytes},
+			{Name: "notes.txt", MimeType: "text/plain", Data: []byte("ignore me")},
+		},
+	}
+	p.handleInput(engine.Event[any]{Payload: in})
+
+	// Two embed requests: one for the image (Inputs path), one for the
+	// text content (Texts path).
+	if len(*embedReqs) != 2 {
+		t.Fatalf("expected 2 embed requests (image + text), got %d", len(*embedReqs))
+	}
+	imgIdx := -1
+	for i, r := range *embedReqs {
+		if len(r.Inputs) == 1 && r.Inputs[0].Image != nil {
+			imgIdx = i
+			break
+		}
+	}
+	if imgIdx < 0 {
+		t.Fatalf("no image embed request found; got %+v", *embedReqs)
+	}
+	imgReq := (*embedReqs)[imgIdx]
+	if string(imgReq.Inputs[0].Image) != string(pngBytes) {
+		t.Errorf("image bytes mismatch")
+	}
+	if imgReq.Inputs[0].MimeType != "image/png" {
+		t.Errorf("image mime mismatch: %q", imgReq.Inputs[0].MimeType)
+	}
+
+	// One vector.upsert into the image namespace.
+	if len(*upserts) != 1 {
+		t.Fatalf("expected 1 image upsert, got %d", len(*upserts))
+	}
+	up := (*upserts)[0]
+	if up.Namespace != "test-text-ns-images" {
+		t.Errorf("namespace mismatch: %q", up.Namespace)
+	}
+	if len(up.Docs) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(up.Docs))
+	}
+	doc := up.Docs[0]
+	if len(doc.Vector) != 4 {
+		t.Errorf("vector dim mismatch: %d", len(doc.Vector))
+	}
+	if doc.Metadata["source"] != "user_image" {
+		t.Errorf("source metadata: %q", doc.Metadata["source"])
+	}
+	if doc.Metadata["file_name"] != "diagram.png" {
+		t.Errorf("file_name metadata: %q", doc.Metadata["file_name"])
+	}
+	if doc.Metadata["mime_type"] != "image/png" {
+		t.Errorf("mime_type metadata: %q", doc.Metadata["mime_type"])
+	}
+	if doc.Metadata["session"] != "sess-1" {
+		t.Errorf("session metadata: %q", doc.Metadata["session"])
+	}
+	if !strings.Contains(doc.Content, "diagram.png") {
+		t.Errorf("descriptor should reference filename; got %q", doc.Content)
+	}
+}
+
+func TestStoreImages_CustomNamespace(t *testing.T) {
+	p, _, _, upserts := imageStubBus(t, true)
+	p.imageNamespace = "shared/team-a-images"
+
+	in := events.UserInput{
+		SchemaVersion: events.UserInputVersion,
+		Content:       "image please",
+		Files: []events.FileAttachment{
+			{Name: "x.jpg", MimeType: "image/jpeg", Data: []byte{0x01}},
+		},
+	}
+	p.handleInput(engine.Event[any]{Payload: in})
+
+	if len(*upserts) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(*upserts))
+	}
+	if (*upserts)[0].Namespace != "shared/team-a-images" {
+		t.Errorf("expected custom namespace, got %q", (*upserts)[0].Namespace)
+	}
+}
+
+func TestStoreImages_RejectionLogsAndContinues(t *testing.T) {
+	// Stub embeddings.provider that rejects images (mimicking text-only
+	// adapters such as nexus.embeddings.openai). The text recall path
+	// should still complete.
+	bus := engine.NewEventBus()
+	p := New().(*Plugin)
+	p.bus = bus
+	p.logger = slog.Default()
+	p.namespace = "test-text-ns"
+	p.storeImages = true
+
+	bus.Subscribe("embeddings.request", func(ev engine.Event[any]) {
+		req, ok := ev.Payload.(*events.EmbeddingsRequest)
+		if !ok {
+			return
+		}
+		if len(req.Inputs) > 0 {
+			req.Error = "openai text-embedding-* models accept text only"
+			req.Provider = "stub"
+			return
+		}
+		req.Vectors = [][]float32{{0.5, 0.5, 0.5, 0.5}}
+		req.Provider = "stub"
+	}, engine.WithPriority(50))
+
+	var upserts []events.VectorUpsert
+	bus.Subscribe("vector.upsert", func(ev engine.Event[any]) {
+		if up, ok := ev.Payload.(*events.VectorUpsert); ok {
+			upserts = append(upserts, *up)
+		}
+	}, engine.WithPriority(100))
+
+	in := events.UserInput{
+		SchemaVersion: events.UserInputVersion,
+		Content:       "what about this?",
+		Files: []events.FileAttachment{
+			{Name: "x.png", MimeType: "image/png", Data: []byte{0x01, 0x02}},
+		},
+	}
+	p.handleInput(engine.Event[any]{Payload: in})
+
+	// Image rejection must NOT produce an upsert.
+	for _, u := range upserts {
+		for _, d := range u.Docs {
+			if d.Metadata["source"] == "user_image" {
+				t.Errorf("rejected image should not upsert: %+v", d)
+			}
+		}
+	}
+}

--- a/plugins/memory/vector/plugin.go
+++ b/plugins/memory/vector/plugin.go
@@ -55,6 +55,8 @@ type Plugin struct {
 	embeddingModel      string
 	autoStoreCompaction bool
 	autoStoreUserInput  bool // default false — conservative
+	storeImages         bool // default false — opt-in; only useful when a multimodal embeddings.provider is active
+	imageNamespace      string
 	sectionPriority     int
 	// hasHybrid mirrors the knowledge_search switch: when search.hybrid is
 	// active, recall queries go through the orchestrator so memory benefits
@@ -138,6 +140,12 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	if v, ok := ctx.Config["section_priority"].(int); ok {
 		p.sectionPriority = v
 	}
+	if v, ok := ctx.Config["store_images"].(bool); ok {
+		p.storeImages = v
+	}
+	if v, ok := ctx.Config["image_namespace"].(string); ok && v != "" {
+		p.imageNamespace = v
+	}
 	if v, ok := ctx.Config["recall_via_hybrid"].(bool); ok {
 		p.recallViaHybrid = v
 	}
@@ -166,6 +174,7 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		"top_k", p.topK,
 		"auto_store_compaction", p.autoStoreCompaction,
 		"auto_store_user_input", p.autoStoreUserInput,
+		"store_images", p.storeImages,
 	)
 	return nil
 }
@@ -208,11 +217,18 @@ func (p *Plugin) Emissions() []string {
 
 // handleInput runs on every user message: embeds it, queries, stashes hits
 // for the next prompt section render. Optionally stores the input itself.
+// When `store_images: true`, also embeds and stores any image attachments
+// on the user input under the image namespace.
 func (p *Plugin) handleInput(event engine.Event[any]) {
 	in, ok := event.Payload.(events.UserInput)
 	if !ok {
 		return
 	}
+
+	if p.storeImages {
+		p.storeImageAttachments(in)
+	}
+
 	content := strings.TrimSpace(in.Content)
 	if content == "" {
 		return
@@ -234,6 +250,92 @@ func (p *Plugin) handleInput(event engine.Event[any]) {
 		p.storeDoc(content, "user", map[string]string{
 			"session": in.SessionID,
 		}, vec)
+	}
+}
+
+// storeImageAttachments embeds every image FileAttachment on the user
+// input via the multimodal embeddings.provider and stores the resulting
+// vector under the configured image namespace. Image parts whose
+// MimeType doesn't start with "image/" are skipped — non-image
+// attachments are out of scope for this opt-in path.
+//
+// On embed failure (e.g. the active embeddings.provider is text-only and
+// returned a clear rejection), this method logs a Warn and continues —
+// it must not break the text recall path that runs after.
+func (p *Plugin) storeImageAttachments(in events.UserInput) {
+	if len(in.Files) == 0 {
+		return
+	}
+	ns := p.imageNamespace
+	if ns == "" {
+		ns = p.namespace + "-images"
+	}
+	for _, f := range in.Files {
+		if !strings.HasPrefix(strings.ToLower(f.MimeType), "image/") {
+			continue
+		}
+		if len(f.Data) == 0 {
+			continue
+		}
+		req := &events.EmbeddingsRequest{
+			SchemaVersion: events.EmbeddingsRequestVersion,
+			Model:         p.embeddingModel,
+			Inputs: []events.EmbeddingsInput{{
+				Image:    f.Data,
+				MimeType: f.MimeType,
+			}},
+		}
+		if err := p.bus.Emit("embeddings.request", req); err != nil {
+			p.logger.Warn("vector memory: image embed emit failed", "err", err, "file", f.Name)
+			continue
+		}
+		if req.Error != "" {
+			p.logger.Warn("vector memory: image embed rejected", "err", req.Error, "file", f.Name)
+			continue
+		}
+		if len(req.Vectors) != 1 || len(req.Vectors[0]) == 0 {
+			p.logger.Warn("vector memory: image embed returned no vector", "file", f.Name)
+			continue
+		}
+
+		meta := map[string]string{
+			"source":    "user_image",
+			"session":   in.SessionID,
+			"file_name": f.Name,
+			"mime_type": f.MimeType,
+			"stored":    time.Now().UTC().Format(time.RFC3339),
+		}
+		// Content is left as a brief descriptor: image vectors recall by
+		// embedding similarity, but the prompt section needs *something*
+		// to render. Storing raw bytes inline would balloon the JSON
+		// vector store; we record the file name + caption hint instead.
+		descriptor := f.Name
+		if descriptor == "" {
+			descriptor = "(unnamed image)"
+		}
+		descriptor = "[image] " + descriptor + " (" + f.MimeType + ")"
+
+		id := docID(descriptor, "user_image", time.Now())
+		up := &events.VectorUpsert{
+			SchemaVersion: events.VectorUpsertVersion,
+			Namespace:     ns,
+			Docs: []events.VectorDoc{{
+				ID:       id,
+				Vector:   req.Vectors[0],
+				Content:  descriptor,
+				Metadata: meta,
+			}},
+		}
+		if err := p.bus.Emit("vector.upsert", up); err != nil {
+			p.logger.Warn("vector memory: image upsert emit failed", "err", err, "file", f.Name)
+			continue
+		}
+		if up.Error != "" {
+			p.logger.Warn("vector memory: image upsert failed", "err", up.Error, "file", f.Name)
+			continue
+		}
+		p.logger.Debug("vector memory: stored image embedding",
+			"namespace", ns, "file", f.Name, "id", id)
 	}
 }
 

--- a/plugins/memory/vector/schema.json
+++ b/plugins/memory/vector/schema.json
@@ -13,6 +13,8 @@
     "auto_store_user_input": {"type": "boolean"},
     "section_priority":      {"type": "integer"},
     "recall_via_hybrid":     {"type": "boolean"},
+    "store_images":          {"type": "boolean", "description": "Embed image FileAttachments on user input via the multimodal embeddings.provider and store under image_namespace. Off by default."},
+    "image_namespace":       {"type": "string", "description": "Vector store namespace for image embeddings. Defaults to <namespace>-images."},
     "require_approval": {
       "type": "object",
       "additionalProperties": false,

--- a/plugins/providers/gemini/modality.go
+++ b/plugins/providers/gemini/modality.go
@@ -1,0 +1,41 @@
+package gemini
+
+import "strings"
+
+// geminiModalityBreakdown extracts a per-modality token map from Gemini's
+// usageMetadata, summing prompt + candidate + cache modality detail entries
+// per modality. Modality keys returned are lowercase ("text", "image",
+// "audio", "video", "document") to match the cross-provider convention on
+// events.Usage.ModalityBreakdown.
+//
+// Returns nil when the response carries no per-modality detail (e.g. a
+// model that doesn't emit promptTokensDetails) so callers leave
+// events.Usage.ModalityBreakdown nil instead of an empty allocated map.
+func geminiModalityBreakdown(u *apiUsageMetadata) map[string]int {
+	if u == nil {
+		return nil
+	}
+	if len(u.PromptTokensDetails) == 0 && len(u.CandidatesTokensDetails) == 0 && len(u.CacheTokensDetails) == 0 {
+		return nil
+	}
+	out := map[string]int{}
+	add := func(details []apiModalityDetail) {
+		for _, d := range details {
+			if d.TokenCount == 0 {
+				continue
+			}
+			key := strings.ToLower(d.Modality)
+			if key == "" {
+				continue
+			}
+			out[key] += d.TokenCount
+		}
+	}
+	add(u.PromptTokensDetails)
+	add(u.CandidatesTokensDetails)
+	add(u.CacheTokensDetails)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/plugins/providers/gemini/modality_test.go
+++ b/plugins/providers/gemini/modality_test.go
@@ -1,0 +1,109 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestGeminiModalityBreakdown_PromptDetails verifies that promptTokensDetails
+// entries are summed under lowercase modality keys.
+func TestGeminiModalityBreakdown_PromptDetails(t *testing.T) {
+	u := &apiUsageMetadata{
+		PromptTokenCount: 1000,
+		PromptTokensDetails: []apiModalityDetail{
+			{Modality: "TEXT", TokenCount: 800},
+			{Modality: "IMAGE", TokenCount: 200},
+		},
+	}
+
+	mb := geminiModalityBreakdown(u)
+	if got := mb["text"]; got != 800 {
+		t.Errorf("text modality tokens: got %d want 800", got)
+	}
+	if got := mb["image"]; got != 200 {
+		t.Errorf("image modality tokens: got %d want 200", got)
+	}
+}
+
+// TestGeminiModalityBreakdown_PromptAndCandidates verifies that prompt and
+// candidate modality details accumulate per-modality across both sides.
+func TestGeminiModalityBreakdown_PromptAndCandidates(t *testing.T) {
+	u := &apiUsageMetadata{
+		PromptTokensDetails: []apiModalityDetail{
+			{Modality: "AUDIO", TokenCount: 300},
+			{Modality: "TEXT", TokenCount: 100},
+		},
+		CandidatesTokensDetails: []apiModalityDetail{
+			{Modality: "AUDIO", TokenCount: 50},
+			{Modality: "TEXT", TokenCount: 200},
+		},
+	}
+
+	mb := geminiModalityBreakdown(u)
+	if got, want := mb["audio"], 350; got != want {
+		t.Errorf("audio: got %d want %d", got, want)
+	}
+	if got, want := mb["text"], 300; got != want {
+		t.Errorf("text: got %d want %d", got, want)
+	}
+}
+
+// TestGeminiModalityBreakdown_NoDetails verifies that responses without any
+// modality detail return nil so callers leave events.Usage.ModalityBreakdown
+// unset.
+func TestGeminiModalityBreakdown_NoDetails(t *testing.T) {
+	u := &apiUsageMetadata{
+		PromptTokenCount:     500,
+		CandidatesTokenCount: 200,
+	}
+	if mb := geminiModalityBreakdown(u); mb != nil {
+		t.Errorf("expected nil ModalityBreakdown when no details present; got %v", mb)
+	}
+}
+
+// TestGeminiModalityBreakdown_NilSafe guards the nil-input path.
+func TestGeminiModalityBreakdown_NilSafe(t *testing.T) {
+	if mb := geminiModalityBreakdown(nil); mb != nil {
+		t.Errorf("expected nil for nil usage; got %v", mb)
+	}
+}
+
+// TestApiUsageMetadata_ParsesModalityDetails verifies the JSON tags match
+// Gemini's wire shape — a producer test against the documented payload.
+func TestApiUsageMetadata_ParsesModalityDetails(t *testing.T) {
+	raw := []byte(`{
+		"promptTokenCount": 1000,
+		"candidatesTokenCount": 200,
+		"totalTokenCount": 1200,
+		"promptTokensDetails": [
+			{"modality": "TEXT", "tokenCount": 800},
+			{"modality": "IMAGE", "tokenCount": 200}
+		],
+		"candidatesTokensDetails": [
+			{"modality": "TEXT", "tokenCount": 200}
+		]
+	}`)
+
+	var u apiUsageMetadata
+	if err := json.Unmarshal(raw, &u); err != nil {
+		t.Fatalf("unmarshal apiUsageMetadata: %v", err)
+	}
+
+	if got := len(u.PromptTokensDetails); got != 2 {
+		t.Fatalf("PromptTokensDetails len: got %d want 2", got)
+	}
+	if u.PromptTokensDetails[0].Modality != "TEXT" || u.PromptTokensDetails[0].TokenCount != 800 {
+		t.Errorf("PromptTokensDetails[0]: got %+v", u.PromptTokensDetails[0])
+	}
+	if u.PromptTokensDetails[1].Modality != "IMAGE" || u.PromptTokensDetails[1].TokenCount != 200 {
+		t.Errorf("PromptTokensDetails[1]: got %+v", u.PromptTokensDetails[1])
+	}
+
+	mb := geminiModalityBreakdown(&u)
+	if got := mb["text"]; got != 1000 {
+		t.Errorf("text combined: got %d want 1000", got)
+	}
+	if got := mb["image"]; got != 200 {
+		t.Errorf("image combined: got %d want 200", got)
+	}
+}

--- a/plugins/providers/gemini/plugin.go
+++ b/plugins/providers/gemini/plugin.go
@@ -673,11 +673,22 @@ type apiInlineData struct {
 }
 
 type apiUsageMetadata struct {
-	PromptTokenCount        int `json:"promptTokenCount"`
-	CandidatesTokenCount    int `json:"candidatesTokenCount"`
-	TotalTokenCount         int `json:"totalTokenCount"`
-	ThoughtsTokenCount      int `json:"thoughtsTokenCount"`
-	CachedContentTokenCount int `json:"cachedContentTokenCount"`
+	PromptTokenCount        int                 `json:"promptTokenCount"`
+	CandidatesTokenCount    int                 `json:"candidatesTokenCount"`
+	TotalTokenCount         int                 `json:"totalTokenCount"`
+	ThoughtsTokenCount      int                 `json:"thoughtsTokenCount"`
+	CachedContentTokenCount int                 `json:"cachedContentTokenCount"`
+	PromptTokensDetails     []apiModalityDetail `json:"promptTokensDetails,omitempty"`
+	CandidatesTokensDetails []apiModalityDetail `json:"candidatesTokensDetails,omitempty"`
+	CacheTokensDetails      []apiModalityDetail `json:"cacheTokensDetails,omitempty"`
+}
+
+// apiModalityDetail mirrors Gemini's `{ modality, tokenCount }` entries inside
+// promptTokensDetails / candidatesTokensDetails. Modality is one of "TEXT",
+// "IMAGE", "AUDIO", "VIDEO", "DOCUMENT" per the API.
+type apiModalityDetail struct {
+	Modality   string `json:"modality"`
+	TokenCount int    `json:"tokenCount"`
 }
 
 func (p *Plugin) handleSyncResponse(body io.Reader) {
@@ -767,6 +778,9 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse, turnID string) events.L
 		usage.TotalTokens = apiResp.UsageMetadata.TotalTokenCount
 		usage.ReasoningTokens = apiResp.UsageMetadata.ThoughtsTokenCount
 		usage.CachedTokens = apiResp.UsageMetadata.CachedContentTokenCount
+		if mb := geminiModalityBreakdown(apiResp.UsageMetadata); len(mb) > 0 {
+			usage.ModalityBreakdown = mb
+		}
 	}
 
 	return events.LLMResponse{SchemaVersion: events.LLMResponseVersion, Content: content.String(),
@@ -913,6 +927,9 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		TotalTokens:      totalUsage.TotalTokenCount,
 		ReasoningTokens:  totalUsage.ThoughtsTokenCount,
 		CachedTokens:     totalUsage.CachedContentTokenCount,
+	}
+	if mb := geminiModalityBreakdown(&totalUsage); len(mb) > 0 {
+		finalUsage.ModalityBreakdown = mb
 	}
 
 	_ = p.bus.Emit("llm.stream.end", events.StreamEnd{SchemaVersion: events.StreamEndVersion, TurnID: turnID,

--- a/plugins/providers/openai/modality.go
+++ b/plugins/providers/openai/modality.go
@@ -1,0 +1,18 @@
+package openai
+
+// openaiModalityBreakdown extracts a per-modality token map from an apiUsage.
+// OpenAI exposes modality detail through prompt_tokens_details.audio_tokens
+// and completion_tokens_details.audio_tokens (both Realtime audio paths and
+// gpt-4o-audio-preview). Only audio is broken out today; image tokens roll
+// into prompt_tokens with no separate field.
+//
+// Returns nil when no non-zero modality counts are present so callers can
+// leave events.Usage.ModalityBreakdown as nil instead of an empty allocated
+// map.
+func openaiModalityBreakdown(u apiUsage) map[string]int {
+	audio := u.PromptTokensDetails.AudioTokens + u.CompletionTokensDetails.AudioTokens
+	if audio == 0 {
+		return nil
+	}
+	return map[string]int{"audio": audio}
+}

--- a/plugins/providers/openai/modality_test.go
+++ b/plugins/providers/openai/modality_test.go
@@ -1,0 +1,75 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine/pricing"
+)
+
+// TestOpenaiModalityBreakdown_AudioOnly verifies that prompt audio tokens are
+// surfaced under the "audio" key, matching the cross-provider lowercase
+// convention on events.Usage.ModalityBreakdown.
+func TestOpenaiModalityBreakdown_AudioOnly(t *testing.T) {
+	u := apiUsage{
+		PromptTokens:     1000,
+		CompletionTokens: 200,
+	}
+	u.PromptTokensDetails.AudioTokens = 320
+	u.CompletionTokensDetails.AudioTokens = 80
+
+	mb := openaiModalityBreakdown(u)
+	if got, want := mb["audio"], 400; got != want {
+		t.Errorf("audio modality tokens: got %d want %d", got, want)
+	}
+	if got := len(mb); got != 1 {
+		t.Errorf("expected single modality entry; got %d (%v)", got, mb)
+	}
+}
+
+// TestOpenaiModalityBreakdown_NoAudio verifies that text-only requests yield
+// nil so callers can leave events.Usage.ModalityBreakdown unset rather than
+// emitting an empty map.
+func TestOpenaiModalityBreakdown_NoAudio(t *testing.T) {
+	u := apiUsage{
+		PromptTokens:     500,
+		CompletionTokens: 200,
+	}
+	if mb := openaiModalityBreakdown(u); mb != nil {
+		t.Errorf("expected nil ModalityBreakdown for text-only request; got %v", mb)
+	}
+}
+
+// TestConvertAPIResponse_PopulatesModalityBreakdown verifies the wire path:
+// when the OpenAI usage payload reports audio tokens, the resulting
+// events.Usage carries a ModalityBreakdown map ready for cost-attribution
+// consumers.
+func TestConvertAPIResponse_PopulatesModalityBreakdown(t *testing.T) {
+	tbl := pricing.DefaultsFor(pricing.ProviderOpenAI)
+	p := &Plugin{pricing: tbl}
+
+	raw := []byte(`{
+		"prompt_tokens": 1500,
+		"completion_tokens": 300,
+		"total_tokens": 1800,
+		"prompt_tokens_details": {
+			"cached_tokens": 0,
+			"audio_tokens": 250
+		},
+		"completion_tokens_details": {
+			"reasoning_tokens": 0,
+			"audio_tokens": 100
+		}
+	}`)
+	var u apiUsage
+	if err := json.Unmarshal(raw, &u); err != nil {
+		t.Fatalf("unmarshal apiUsage: %v", err)
+	}
+
+	apiResp := apiResponse{ID: "chatcmpl-test", Model: "gpt-4o-audio-preview", Usage: u}
+	resp := p.convertAPIResponse(apiResp)
+
+	if got, want := resp.Usage.ModalityBreakdown["audio"], 350; got != want {
+		t.Errorf("Usage.ModalityBreakdown[audio]: got %d want %d", got, want)
+	}
+}

--- a/plugins/providers/openai/plugin.go
+++ b/plugins/providers/openai/plugin.go
@@ -703,6 +703,9 @@ func (p *Plugin) convertAPIResponse(apiResp apiResponse) events.LLMResponse {
 		CachedTokens:     apiResp.Usage.PromptTokensDetails.CachedTokens,
 		ReasoningTokens:  apiResp.Usage.CompletionTokensDetails.ReasoningTokens,
 	}
+	if mb := openaiModalityBreakdown(apiResp.Usage); len(mb) > 0 {
+		usage.ModalityBreakdown = mb
+	}
 
 	resp := events.LLMResponse{SchemaVersion: events.LLMResponseVersion, Model: apiResp.Model,
 		Usage:   usage,
@@ -889,6 +892,9 @@ func (p *Plugin) handleStreamResponse(body io.Reader) {
 		TotalTokens:      usage.TotalTokens,
 		CachedTokens:     usage.PromptTokensDetails.CachedTokens,
 		ReasoningTokens:  usage.CompletionTokensDetails.ReasoningTokens,
+	}
+	if mb := openaiModalityBreakdown(usage); len(mb) > 0 {
+		finalUsage.ModalityBreakdown = mb
 	}
 
 	// Emit stream end.

--- a/plugins/tools/codeexec/nexus_pkg.go
+++ b/plugins/tools/codeexec/nexus_pkg.go
@@ -1,0 +1,77 @@
+package codeexec
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/traefik/yaegi/interp"
+)
+
+// imageBuffer collects images emitted by a script via nexus.ReturnImage.
+// One buffer per run_code invocation; appended via the script-callable
+// closure built in buildNexusExports. The plugin's runScript flushes
+// this buffer onto the resulting ToolResult.OutputParts after Run
+// completes (success or failure — emits whatever was already captured).
+//
+// Mutex-protected because parallel.* primitives may legitimately call
+// nexus.ReturnImage from multiple goroutines spawned by the script.
+type imageBuffer struct {
+	mu     sync.Mutex
+	images []capturedImage
+}
+
+// capturedImage is the in-memory record of a single nexus.ReturnImage
+// call. We hold the raw bytes and the script-supplied mimeType until
+// runScript's tail decides whether to inline or route through the blob
+// store; doing the routing here would couple nexus_pkg.go to the blob
+// store and force tests that exercise the buffer to also configure a
+// blob store.
+type capturedImage struct {
+	Data     []byte
+	MimeType string
+}
+
+func (b *imageBuffer) Add(data []byte, mimeType string) {
+	if len(data) == 0 {
+		return
+	}
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+	// Defensive copy — the script might mutate its slice after the call.
+	dup := make([]byte, len(data))
+	copy(dup, data)
+	b.mu.Lock()
+	b.images = append(b.images, capturedImage{Data: dup, MimeType: mimeType})
+	b.mu.Unlock()
+}
+
+func (b *imageBuffer) Snapshot() []capturedImage {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]capturedImage, len(b.images))
+	copy(out, b.images)
+	return out
+}
+
+// buildNexusExports returns a Yaegi package at import path "nexus" that
+// exposes a single helper:
+//
+//	nexus.ReturnImage(data []byte, mimeType string)
+//
+// Scripts call it to attach an image to the resulting ToolResult.OutputParts
+// (alongside the JSON return value from main.Run). One typical use case:
+// a script reads a chart-rendering tool's bytes and wants the next LLM turn
+// to see the rendered chart, not just a description.
+//
+// The function is wired to the per-invocation buffer so multiple calls
+// stack in script order, and so a panic mid-script doesn't lose previous
+// captures (runScript still reads buf.Snapshot() in its tail).
+func buildNexusExports(buf *imageBuffer) interp.Exports {
+	pkg := map[string]reflect.Value{
+		"ReturnImage": reflect.ValueOf(func(data []byte, mimeType string) {
+			buf.Add(data, mimeType)
+		}),
+	}
+	return interp.Exports{"nexus/nexus": pkg}
+}

--- a/plugins/tools/codeexec/nexus_pkg_test.go
+++ b/plugins/tools/codeexec/nexus_pkg_test.go
@@ -1,0 +1,135 @@
+package codeexec
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
+)
+
+// minPNG is the 8-byte PNG signature plus a tiny trailing chunk — enough
+// for tests that only care about routing, not pixels.
+var nexusMinPNG = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00}
+
+func TestReturnImage_Inline(t *testing.T) {
+	h := newHarness(t, nil)
+
+	// Yaegi gets the PNG bytes from a string literal — Go source for a
+	// short script doesn't have a clean way to embed binary, so we
+	// `make` a small []byte and call ReturnImage with it.
+	res := h.runCode(`
+package main
+
+import (
+	"context"
+	"nexus"
+)
+
+func Run(ctx context.Context) (any, error) {
+	nexus.ReturnImage([]byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00}, "image/png")
+	return "ok", nil
+}
+`)
+
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %q", res.Error)
+	}
+	if len(res.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(res.OutputParts))
+	}
+	part := res.OutputParts[0]
+	if part.Type != "image" {
+		t.Errorf("part.Type: got %q want image", part.Type)
+	}
+	if part.MimeType != "image/png" {
+		t.Errorf("part.MimeType: got %q want image/png", part.MimeType)
+	}
+	if !bytes.Equal(part.Data, nexusMinPNG) {
+		t.Errorf("part.Data does not match fixture")
+	}
+	// Default cutoff is 256 KiB; 12-byte payload should ride inline.
+	if part.URI != "" {
+		t.Errorf("expected inline (empty URI); got URI=%q", part.URI)
+	}
+}
+
+func TestReturnImage_Blob(t *testing.T) {
+	h := newHarness(t, map[string]any{
+		"blob_store": map[string]any{
+			"inline_threshold": 16,
+		},
+	})
+
+	// Script generates a payload bigger than the cutoff. Use bytes.Repeat
+	// inside the script so the test data path exercises the host
+	// runtime end-to-end.
+	res := h.runCode(`
+package main
+
+import (
+	"bytes"
+	"context"
+	"nexus"
+)
+
+func Run(ctx context.Context) (any, error) {
+	prefix := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00}
+	body := append(prefix, bytes.Repeat([]byte{0xAA}, 4096)...)
+	nexus.ReturnImage(body, "image/png")
+	return "ok", nil
+}
+`)
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %q", res.Error)
+	}
+	if len(res.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(res.OutputParts))
+	}
+	part := res.OutputParts[0]
+	if part.URI == "" || blobs.SHAFromURI(part.URI) == "" {
+		t.Fatalf("expected nexus-blob URI; got %q", part.URI)
+	}
+	if len(part.Data) != 0 {
+		t.Errorf("expected blob path with no inline Data; got %d inline bytes", len(part.Data))
+	}
+	got, mt, err := h.plugin.blobStore.Get(blobs.SHAFromURI(part.URI))
+	if err != nil {
+		t.Fatalf("blob store Get: %v", err)
+	}
+	if mt != "image/png" {
+		t.Errorf("blob media type: got %q want image/png", mt)
+	}
+	if len(got) != 4096+12 {
+		t.Errorf("blob bytes len: got %d want %d", len(got), 4096+12)
+	}
+}
+
+func TestReturnImage_Multiple(t *testing.T) {
+	h := newHarness(t, nil)
+	res := h.runCode(`
+package main
+
+import (
+	"context"
+	"nexus"
+)
+
+func Run(ctx context.Context) (any, error) {
+	nexus.ReturnImage([]byte{0x01, 0x02}, "image/png")
+	nexus.ReturnImage([]byte{0x03, 0x04}, "image/jpeg")
+	return nil, nil
+}
+`)
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %q", res.Error)
+	}
+	if len(res.OutputParts) != 2 {
+		t.Fatalf("OutputParts len: got %d want 2", len(res.OutputParts))
+	}
+	if res.OutputParts[0].MimeType != "image/png" {
+		t.Errorf("first MimeType: got %q want image/png", res.OutputParts[0].MimeType)
+	}
+	if res.OutputParts[1].MimeType != "image/jpeg" {
+		t.Errorf("second MimeType: got %q want image/jpeg", res.OutputParts[1].MimeType)
+	}
+}

--- a/plugins/tools/codeexec/plugin.go
+++ b/plugins/tools/codeexec/plugin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/traefik/yaegi/interp"
 
 	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
 	"github.com/frankbardon/nexus/pkg/engine/sandbox"
 	"github.com/frankbardon/nexus/pkg/events"
 )
@@ -48,6 +49,12 @@ const (
 const (
 	defaultTimeout        = 30 * time.Second
 	defaultMaxOutputBytes = 64 * 1024
+
+	// Blob store knobs for nexus.ReturnImage. Mirror nexus.tool.file so
+	// scripts that emit images share the same routing behaviour as
+	// read_image / read_document / take_screenshot.
+	defaultBlobByteBudget      int64 = 2 * 1024 * 1024 * 1024
+	defaultBlobInlineThreshold int64 = 256 * 1024
 )
 
 // Plugin implements programmatic tool calling via an embedded Yaegi interpreter.
@@ -70,6 +77,13 @@ type Plugin struct {
 	allowedImports   map[string]bool
 	persistScripts   bool
 	rejectGoroutines bool
+
+	// blobStore backs nexus.ReturnImage when the script emits a payload
+	// larger than blobInlineCutoff. Created at Init when a session
+	// workspace is available; nil otherwise (script-emitted images then
+	// always inline regardless of size).
+	blobStore        *blobs.Store
+	blobInlineCutoff int64
 
 	// Registry of other tools — snapshot from tool.register events. Keyed by
 	// tool name. Used to generate typed bindings at run_code time.
@@ -174,6 +188,26 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		if len(out) > 0 {
 			p.allowedPackages = out
 		}
+	}
+
+	// Blob store wiring for nexus.ReturnImage. Same field shape as
+	// nexus.tool.file: blob_store.{byte_budget, inline_threshold}.
+	budget := defaultBlobByteBudget
+	p.blobInlineCutoff = defaultBlobInlineThreshold
+	if bs, ok := ctx.Config["blob_store"].(map[string]any); ok {
+		if v, ok := intLike(bs["byte_budget"]); ok {
+			budget = v
+		}
+		if v, ok := intLike(bs["inline_threshold"]); ok {
+			p.blobInlineCutoff = v
+		}
+	}
+	if p.session != nil {
+		store, err := blobs.New(p.session.BlobsDir(), budget)
+		if err != nil {
+			return fmt.Errorf("code_exec: blob store init: %w", err)
+		}
+		p.blobStore = store
 	}
 
 	p.rebuildAllowedImports()
@@ -287,6 +321,7 @@ func (p *Plugin) buildBindingsSection() string {
 	}
 
 	b.WriteString("\nAlways available: parallel.Map, parallel.ForEach, parallel.All.")
+	b.WriteString("\nMultimodal helper: import \"nexus\" for nexus.ReturnImage(data []byte, mimeType string) — attach images to the next LLM turn.")
 	return b.String()
 }
 
@@ -314,13 +349,29 @@ func (p *Plugin) Emissions() []string {
 }
 
 func (p *Plugin) rebuildAllowedImports() {
-	out := make(map[string]bool, len(p.allowedPackages)+2)
+	out := make(map[string]bool, len(p.allowedPackages)+3)
 	for _, s := range p.allowedPackages {
 		out[s] = true
 	}
 	out["tools"] = true
 	out["parallel"] = true
+	out["nexus"] = true
 	p.allowedImports = out
+}
+
+// intLike accepts the JSON-ish numeric kinds yaml.v3 unmarshals into and
+// returns an int64. Mirrors the helper in nexus.tool.file / screenshot /
+// web so blob_store config keys parse identically across plugins.
+func intLike(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	}
+	return 0, false
 }
 
 // -- event handlers ---------------------------------------------------------
@@ -457,13 +508,15 @@ func (p *Plugin) runScript(tc events.ToolCall) {
 	}
 
 	stdout := newStreamingWriter(p.bus, tc.ID, tc.TurnID, p.maxOutputBytes)
+	imageBuf := &imageBuffer{}
 	// finish closes the stdout stream (flushing a Final chunk) and then emits
 	// code.exec.result / tool.result. Ordering matters: consumers expect
 	// code.exec.stdout{Final:true} to land before the result so they can
 	// mark the live-output section closed before showing the summary.
 	finish := func(result, errMsg string, durationMs int64) {
 		stdout.Close()
-		p.emitResult(tc, stdout.String(), result, errMsg, durationMs, stdout.Truncated())
+		parts := p.flushImageBuffer(imageBuf)
+		p.emitResultParts(tc, stdout.String(), result, errMsg, durationMs, stdout.Truncated(), parts)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 	defer cancel()
@@ -530,6 +583,10 @@ func (p *Plugin) runScript(tc events.ToolCall) {
 	}
 	if err := i.Use(buildParallelExports(p.maxWorkers)); err != nil {
 		finish("", fmt.Sprintf("install parallel package: %v", err), 0)
+		return
+	}
+	if err := i.Use(buildNexusExports(imageBuf)); err != nil {
+		finish("", fmt.Sprintf("install nexus package: %v", err), 0)
 		return
 	}
 
@@ -695,11 +752,50 @@ func (p *Plugin) persist(tc events.ToolCall, script, stdout, result, errMsg stri
 	}
 }
 
-// emitResult sends code.exec.result + tool.result (with vetoable guard) back
-// to the agent. The Output of tool.result is a JSON document containing
-// stdout, the return value, and any error — giving the model a structured
-// surface to reason over.
-func (p *Plugin) emitResult(tc events.ToolCall, stdout, result, errMsg string, durationMs int64, truncated bool) {
+// flushImageBuffer routes captured nexus.ReturnImage payloads through the
+// blob store using the shared inline / blob threshold pattern. Returns
+// the resulting MessageParts; nil when the buffer is empty.
+//
+// Failure to store a blob is logged and the corresponding image is
+// skipped — partial OutputParts (everything that did store) still ship,
+// rather than dropping the whole batch on a single transient error.
+func (p *Plugin) flushImageBuffer(buf *imageBuffer) []events.MessagePart {
+	if buf == nil {
+		return nil
+	}
+	images := buf.Snapshot()
+	if len(images) == 0 {
+		return nil
+	}
+	parts := make([]events.MessagePart, 0, len(images))
+	for _, img := range images {
+		part := events.MessagePart{Type: "image", MimeType: img.MimeType}
+		// When the blob store isn't available (no session workspace) we
+		// inline regardless of size — gives test harnesses a working
+		// path without forcing them to wire a session.
+		if p.blobStore == nil || int64(len(img.Data)) <= p.blobInlineCutoff {
+			part.Data = img.Data
+			parts = append(parts, part)
+			continue
+		}
+		h, err := p.blobStore.Put(img.Data, img.MimeType)
+		if err != nil {
+			p.logger.Warn("code_exec: blob store put failed", "error", err)
+			continue
+		}
+		if _, _, err := p.blobStore.Sweep(); err != nil {
+			p.logger.Warn("code_exec: blob store sweep failed", "error", err)
+		}
+		part.URI = h.URI()
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+// emitResultParts is emitResult with multimodal MessagePart support
+// threaded through. The original emitResult delegates here with no
+// parts so existing callers stay byte-identical on the wire.
+func (p *Plugin) emitResultParts(tc events.ToolCall, stdout, result, errMsg string, durationMs int64, truncated bool, parts []events.MessagePart) {
 	if errMsg != "" && p.persistScripts && p.session != nil {
 		base := fmt.Sprintf("plugins/%s/%s", pluginID, tc.ID)
 		_ = p.session.WriteFile(base+"/error.txt", []byte(errMsg))
@@ -727,16 +823,24 @@ func (p *Plugin) emitResult(tc events.ToolCall, stdout, result, errMsg string, d
 	out, _ := json.Marshal(envelope)
 
 	r := events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: tc.ID,
-		Name:   tc.Name,
-		Output: string(out),
-		Error:  errMsg,
-		TurnID: tc.TurnID,
+		Name:        tc.Name,
+		Output:      string(out),
+		Error:       errMsg,
+		OutputParts: parts,
+		TurnID:      tc.TurnID,
 	}
 	if veto, verr := p.bus.EmitVetoable("before:tool.result", &r); verr == nil && veto.Vetoed {
 		p.logger.Info("code_exec tool.result vetoed", "reason", veto.Reason)
 		return
 	}
 	_ = p.bus.Emit("tool.result", r)
+}
+
+// emitResult is the back-compat wrapper for the parts-less path
+// (everything except runScript's host loop). Forwards to emitResultParts
+// with a nil OutputParts slice so existing callers stay byte-identical.
+func (p *Plugin) emitResult(tc events.ToolCall, stdout, result, errMsg string, durationMs int64, truncated bool) {
+	p.emitResultParts(tc, stdout, result, errMsg, durationMs, truncated, nil)
 }
 
 // runCodeShortDescription is the tool-schema description. Kept tight — the
@@ -791,6 +895,11 @@ Available imports:
     Use these to fan out independent work (tool calls or compute) instead of
     serializing — first error cancels the rest. Map returns any; cast to the
     typed slice: results.([]T).
+  - nexus: nexus.ReturnImage(data []byte, mimeType string) attaches an image
+    to the resulting tool_result (alongside main.Run's JSON return) so the
+    next LLM turn sees it. Multiple calls stack in script order. Useful for
+    scripts that render charts, fetch image bytes from a tool, or otherwise
+    need to surface visual content to the model.
   - skills/<skill_name>: helper functions shipped with currently-active skills.
 
 Forbidden: import "os", "net/*", "syscall", "unsafe", "reflect", "runtime";

--- a/plugins/tools/codeexec/schema.json
+++ b/plugins/tools/codeexec/schema.json
@@ -12,6 +12,15 @@
     "persist_scripts":   {"type": "boolean"},
     "reject_goroutines": {"type": "boolean"},
     "allowed_packages":  {"type": "array", "items": {"type": "string"}},
+    "blob_store": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings for the per-session blob store backing nexus.ReturnImage.",
+      "properties": {
+        "byte_budget":      {"type": "integer", "description": "Soft cap on total stored blob bytes per session. 0 = unbounded.", "default": 2147483648},
+        "inline_threshold": {"type": "integer", "description": "Payloads at or below this size are inlined on the MessagePart instead of being stored as a blob.", "default": 262144}
+      }
+    },
     "sandbox": {
       "type": "object",
       "additionalProperties": true,

--- a/plugins/tools/fileio/multimodal_test.go
+++ b/plugins/tools/fileio/multimodal_test.go
@@ -1,0 +1,228 @@
+package fileio
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// minPNG is the 8-byte PNG signature plus a tiny trailing chunk —
+// readable by the fileio plugin's mime detection (extension-based) without
+// pulling a real image library into the test path.
+var minPNG = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00}
+
+// minPDF is the 5-byte PDF magic + EOF marker. fileio dispatches on
+// extension, not content sniffing, but we still write byte-realistic bytes
+// in case future code paths add content checks.
+var minPDF = []byte{'%', 'P', 'D', 'F', '-', '1', '.', '4', '\n', '%', '%', 'E', 'O', 'F'}
+
+// busCapture wraps a real engine.EventBus and records every tool.result so
+// tests can assert what the plugin emitted without booting the full
+// engine.
+type busCapture struct {
+	engine.EventBus
+
+	mu      sync.Mutex
+	results []events.ToolResult
+}
+
+func newBusCapture(t *testing.T) *busCapture {
+	t.Helper()
+	bus := engine.NewEventBus()
+	bc := &busCapture{EventBus: bus}
+	bus.Subscribe("tool.result", func(e engine.Event[any]) {
+		if r, ok := e.Payload.(events.ToolResult); ok {
+			bc.mu.Lock()
+			bc.results = append(bc.results, r)
+			bc.mu.Unlock()
+		}
+	})
+	return bc
+}
+
+func (b *busCapture) lastResult(t *testing.T) events.ToolResult {
+	t.Helper()
+	// Drain pending dispatch so async-flagged events flush before assert.
+	_ = b.EventBus.Drain(contextWithDeadline(t, 200*time.Millisecond))
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.results) == 0 {
+		t.Fatal("no tool.result emitted")
+	}
+	return b.results[len(b.results)-1]
+}
+
+func contextWithDeadline(t *testing.T, d time.Duration) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// makePlugin spins up a fileio plugin scoped to dir with both multimodal
+// tools enabled and an explicit inline cutoff so tests can choose between
+// inline and blob-stored paths.
+func makePlugin(t *testing.T, dir string, inlineCutoff int64) (*Plugin, *busCapture) {
+	t.Helper()
+	bus := newBusCapture(t)
+	store, err := blobs.New(filepath.Join(dir, "blobs"), 0)
+	if err != nil {
+		t.Fatalf("blobs.New: %v", err)
+	}
+	p := &Plugin{
+		bus:              bus,
+		baseDir:          dir,
+		enabled:          map[string]bool{"read_image": true, "read_document": true},
+		blobStore:        store,
+		blobInlineCutoff: inlineCutoff,
+	}
+	return p, bus
+}
+
+func TestReadImage_Inline(t *testing.T) {
+	dir := t.TempDir()
+	pngPath := filepath.Join(dir, "small.png")
+	if err := os.WriteFile(pngPath, minPNG, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Cutoff well above payload size — should inline.
+	p, bus := makePlugin(t, dir, 1<<20)
+	p.handleReadBinary(events.ToolCall{ID: "img-1", Name: "read_image", Arguments: map[string]any{"path": "small.png"}}, kindImage)
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	part := r.OutputParts[0]
+	if part.Type != "image" {
+		t.Errorf("part.Type: got %q want image", part.Type)
+	}
+	if part.MimeType != "image/png" {
+		t.Errorf("part.MimeType: got %q want image/png", part.MimeType)
+	}
+	if !bytes.Equal(part.Data, minPNG) {
+		t.Errorf("part.Data does not match fixture")
+	}
+	if part.URI != "" {
+		t.Errorf("expected inline (empty URI); got URI=%q", part.URI)
+	}
+}
+
+func TestReadImage_Blob(t *testing.T) {
+	dir := t.TempDir()
+	pngPath := filepath.Join(dir, "big.png")
+	bigData := append(append([]byte{}, minPNG...), bytes.Repeat([]byte{0xAA}, 4096)...)
+	if err := os.WriteFile(pngPath, bigData, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Cutoff below payload size — must go through blob store.
+	p, bus := makePlugin(t, dir, 1024)
+	p.handleReadBinary(events.ToolCall{ID: "img-2", Name: "read_image", Arguments: map[string]any{"path": "big.png"}}, kindImage)
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	part := r.OutputParts[0]
+	if part.URI == "" || blobs.SHAFromURI(part.URI) == "" {
+		t.Errorf("expected nexus-blob URI; got %q", part.URI)
+	}
+	if len(part.Data) != 0 {
+		t.Errorf("expected blob path with no inline Data; got %d inline bytes", len(part.Data))
+	}
+	got, mt, err := p.blobStore.Get(blobs.SHAFromURI(part.URI))
+	if err != nil {
+		t.Fatalf("blob store Get: %v", err)
+	}
+	if !bytes.Equal(got, bigData) {
+		t.Errorf("blob bytes do not match fixture")
+	}
+	if mt != "image/png" {
+		t.Errorf("blob media type: got %q want image/png", mt)
+	}
+	bu, _ := r.OutputStructured["blob_uri"].(string)
+	if bu != part.URI {
+		t.Errorf("OutputStructured.blob_uri %q != part.URI %q", bu, part.URI)
+	}
+}
+
+func TestReadImage_UnsupportedExtension(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "data.bin"), []byte{0, 1, 2}, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	p, bus := makePlugin(t, dir, 1<<20)
+	p.handleReadBinary(events.ToolCall{ID: "img-3", Name: "read_image", Arguments: map[string]any{"path": "data.bin"}}, kindImage)
+
+	r := bus.lastResult(t)
+	if r.Error == "" {
+		t.Fatalf("expected error on unsupported extension")
+	}
+	if len(r.OutputParts) != 0 {
+		t.Errorf("expected no OutputParts on error; got %d", len(r.OutputParts))
+	}
+}
+
+func TestReadDocument_PDF(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.pdf"), minPDF, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	p, bus := makePlugin(t, dir, 1<<20)
+	p.handleReadBinary(events.ToolCall{ID: "doc-1", Name: "read_document", Arguments: map[string]any{"path": "spec.pdf"}}, kindDocument)
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	part := r.OutputParts[0]
+	if part.Type != "file" {
+		t.Errorf("part.Type: got %q want file", part.Type)
+	}
+	if part.MimeType != "application/pdf" {
+		t.Errorf("part.MimeType: got %q want application/pdf", part.MimeType)
+	}
+}
+
+func TestReadBinary_NoBlobStore(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.png"), minPNG, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	bus := newBusCapture(t)
+	// blobStore deliberately nil — simulates a non-session embedder that
+	// disabled multimodal reads.
+	p := &Plugin{
+		bus:     bus,
+		baseDir: dir,
+		enabled: map[string]bool{"read_image": true},
+	}
+	p.handleReadBinary(events.ToolCall{ID: "img-4", Name: "read_image", Arguments: map[string]any{"path": "x.png"}}, kindImage)
+
+	r := bus.lastResult(t)
+	if r.Error == "" {
+		t.Fatalf("expected error when blob store missing")
+	}
+}

--- a/plugins/tools/fileio/plugin.go
+++ b/plugins/tools/fileio/plugin.go
@@ -11,7 +11,18 @@ import (
 	"sync/atomic"
 
 	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
 	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// Default knobs for the per-session blob store backing read_image /
+// read_document. byteBudget is 2 GiB so a long session of screenshot- or
+// document-heavy turns doesn't quietly fill the home directory; payloads at
+// or under inlineThreshold ride inline on the MessagePart so a single small
+// PNG never round-trips through the blob store.
+const (
+	defaultBlobByteBudget      int64 = 2 * 1024 * 1024 * 1024
+	defaultBlobInlineThreshold int64 = 256 * 1024
 )
 
 const (
@@ -31,6 +42,9 @@ type Plugin struct {
 	allowExternalWrites bool
 	enabled             map[string]bool
 	unsubs              []func()
+
+	blobStore        *blobs.Store // nil when read_image and read_document are both disabled
+	blobInlineCutoff int64
 
 	liveCalls atomic.Uint64
 }
@@ -63,6 +77,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		"write_file":      true,
 		"check_file_size": true,
 		"list_files":      true,
+		"read_image":      true,
+		"read_document":   true,
 	}
 
 	// Allow per-tool enable/disable via config.
@@ -90,6 +106,35 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	// session workspace unless the user explicitly configures a base_dir.
 	if p.baseDir == "" && p.session != nil {
 		p.baseDir = p.session.FilesDir()
+	}
+
+	// Set up the per-session blob store iff at least one multimodal read
+	// tool is active. Avoids creating an empty blobs/ subdir for sessions
+	// that never call read_image / read_document.
+	budget := defaultBlobByteBudget
+	p.blobInlineCutoff = defaultBlobInlineThreshold
+	if bs, ok := ctx.Config["blob_store"].(map[string]any); ok {
+		if v, ok := bs["byte_budget"].(int); ok {
+			budget = int64(v)
+		} else if v, ok := bs["byte_budget"].(int64); ok {
+			budget = v
+		} else if v, ok := bs["byte_budget"].(float64); ok {
+			budget = int64(v)
+		}
+		if v, ok := bs["inline_threshold"].(int); ok {
+			p.blobInlineCutoff = int64(v)
+		} else if v, ok := bs["inline_threshold"].(int64); ok {
+			p.blobInlineCutoff = v
+		} else if v, ok := bs["inline_threshold"].(float64); ok {
+			p.blobInlineCutoff = int64(v)
+		}
+	}
+	if (p.enabled["read_image"] || p.enabled["read_document"]) && p.session != nil {
+		store, err := blobs.New(p.session.BlobsDir(), budget)
+		if err != nil {
+			return fmt.Errorf("fileio: blob store init: %w", err)
+		}
+		p.blobStore = store
 	}
 
 	// Register event handler.
@@ -201,6 +246,60 @@ func (p *Plugin) Ready() error {
 	})
 
 	p.registerTool(events.ToolDef{
+		Name:        "read_image",
+		Description: "Load an image file (PNG, JPEG, GIF, WebP, BMP) from the configured base directory and attach it to the next LLM turn as multimodal content. Use when the user asks about a picture, diagram, screenshot, or chart on disk.",
+		Class:       "filesystem",
+		Subclass:    "read",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Path to the image file relative to the base directory.",
+				},
+			},
+			"required": []string{"path"},
+		},
+		OutputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":       map[string]any{"type": "string"},
+				"media_type": map[string]any{"type": "string"},
+				"size":       map[string]any{"type": "integer"},
+				"blob_uri":   map[string]any{"type": "string", "description": "nexus-blob:<sha256> reference when stored as a blob; empty when inlined."},
+			},
+			"required": []string{"path", "media_type", "size"},
+		},
+	})
+
+	p.registerTool(events.ToolDef{
+		Name:        "read_document",
+		Description: "Load a document file (currently PDF) from the configured base directory and attach it to the next LLM turn as multimodal content. Pairs with multimodal-capable providers that accept native documents (Anthropic, Gemini); other providers will see a text placeholder.",
+		Class:       "filesystem",
+		Subclass:    "read",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Path to the document file relative to the base directory.",
+				},
+			},
+			"required": []string{"path"},
+		},
+		OutputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path":       map[string]any{"type": "string"},
+				"media_type": map[string]any{"type": "string"},
+				"size":       map[string]any{"type": "integer"},
+				"blob_uri":   map[string]any{"type": "string"},
+			},
+			"required": []string{"path", "media_type", "size"},
+		},
+	})
+
+	p.registerTool(events.ToolDef{
 		Name:        "list_files",
 		Description: "List files in a directory, optionally matching a glob pattern.",
 		Class:       "filesystem",
@@ -296,7 +395,138 @@ func (p *Plugin) handleEvent(event engine.Event[any]) {
 		p.handleCheckFileSize(tc)
 	case "list_files":
 		p.handleListFiles(tc)
+	case "read_image":
+		p.handleReadBinary(tc, kindImage)
+	case "read_document":
+		p.handleReadBinary(tc, kindDocument)
 	}
+}
+
+// binaryKind tags whether handleReadBinary should accept image MIME types
+// (read_image) or document MIME types (read_document). Keeps a single
+// handler for the two near-identical tools.
+type binaryKind int
+
+const (
+	kindImage binaryKind = iota
+	kindDocument
+)
+
+// imageMimeByExt maps a lowercase extension to the IANA media type the
+// provider plugins expect on a MessagePart.MimeType. Limited to formats
+// Anthropic + OpenAI + Gemini all handle natively as image content.
+var imageMimeByExt = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+	".bmp":  "image/bmp",
+}
+
+// documentMimeByExt currently covers PDF only — the one document type all
+// three multimodal-capable providers handle as a native document block.
+// .docx / .pptx etc are out of scope for v1; add when we have a provider
+// path for them.
+var documentMimeByExt = map[string]string{
+	".pdf": "application/pdf",
+}
+
+func (p *Plugin) handleReadBinary(tc events.ToolCall, kind binaryKind) {
+	if p.blobStore == nil {
+		p.emitResult(tc, "", "binary read is unavailable: blob store not initialised (no session workspace)", nil)
+		return
+	}
+	path, _ := tc.Arguments["path"].(string)
+	if path == "" {
+		p.emitResult(tc, "", "path argument is required", nil)
+		return
+	}
+
+	resolved, err := p.resolvePath(path)
+	if err != nil {
+		p.emitResult(tc, "", err.Error(), nil)
+		return
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		p.emitResult(tc, "", fmt.Sprintf("failed to stat file: %s", err), nil)
+		return
+	}
+	if info.IsDir() {
+		p.emitResult(tc, "", fmt.Sprintf("%s is a directory, not a file", path), nil)
+		return
+	}
+
+	ext := strings.ToLower(filepath.Ext(resolved))
+	var (
+		mime     string
+		partKind string
+	)
+	switch kind {
+	case kindImage:
+		mime = imageMimeByExt[ext]
+		partKind = "image"
+	case kindDocument:
+		mime = documentMimeByExt[ext]
+		partKind = "file"
+	}
+	if mime == "" {
+		p.emitResult(tc, "",
+			fmt.Sprintf("unsupported extension %q for %s", ext, tc.Name),
+			nil)
+		return
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		p.emitResult(tc, "", fmt.Sprintf("failed to read file: %s", err), nil)
+		return
+	}
+
+	part := events.MessagePart{
+		Type:     partKind,
+		MimeType: mime,
+	}
+	structured := map[string]any{
+		"path":       path,
+		"media_type": mime,
+		"size":       int64(len(data)),
+	}
+	if int64(len(data)) <= p.blobInlineCutoff {
+		// Small payload — inline on the part. Avoids a blob round-trip for
+		// every tiny PNG icon.
+		part.Data = data
+	} else {
+		h, err := p.blobStore.Put(data, mime)
+		if err != nil {
+			p.emitResult(tc, "", fmt.Sprintf("failed to store blob: %s", err), nil)
+			return
+		}
+		// Best-effort budget enforcement. Sweep failures are logged and the
+		// load still succeeds — the freshly-Put blob is the newest and would
+		// not have been evicted anyway.
+		if _, _, err := p.blobStore.Sweep(); err != nil {
+			p.logger.Warn("fileio: blob store sweep failed", "error", err)
+		}
+		part.URI = h.URI()
+		structured["blob_uri"] = h.URI()
+	}
+
+	summary := fmt.Sprintf("Loaded %s %q (%s, %d bytes)", partKind, path, mime, len(data))
+	result := events.ToolResult{SchemaVersion: events.ToolResultVersion, ID: tc.ID,
+		Name:             tc.Name,
+		Output:           summary,
+		OutputStructured: structured,
+		OutputParts:      []events.MessagePart{part},
+		TurnID:           tc.TurnID,
+	}
+	if veto, vErr := p.bus.EmitVetoable("before:tool.result", &result); vErr == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
 }
 
 // resolvePath resolves a path relative to the base directory and ensures it

--- a/plugins/tools/fileio/schema.json
+++ b/plugins/tools/fileio/schema.json
@@ -7,6 +7,15 @@
   "properties": {
     "base_dir":              {"type": "string", "description": "Base directory for file operations."},
     "allow_external_writes": {"type": "boolean", "description": "Permit reads/writes outside base_dir."},
+    "blob_store": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings for the per-session blob store backing read_image / read_document.",
+      "properties": {
+        "byte_budget":     {"type": "integer", "description": "Soft cap on total stored blob bytes per session. 0 = unbounded.", "default": 2147483648},
+        "inline_threshold": {"type": "integer", "description": "Payloads at or below this size are inlined on the MessagePart instead of being stored as a blob.", "default": 262144}
+      }
+    },
     "tools": {
       "type": "object",
       "additionalProperties": false,
@@ -15,7 +24,9 @@
         "read_file":       {"type": "boolean"},
         "write_file":      {"type": "boolean"},
         "check_file_size": {"type": "boolean"},
-        "list_files":      {"type": "boolean"}
+        "list_files":      {"type": "boolean"},
+        "read_image":      {"type": "boolean", "description": "Load an image file (.png/.jpg/.gif/.webp/.bmp) and return it as a multimodal MessagePart for the next LLM turn."},
+        "read_document":   {"type": "boolean", "description": "Load a document file (.pdf) and return it as a multimodal MessagePart for the next LLM turn."}
       }
     }
   }

--- a/plugins/tools/pdf/plugin.go
+++ b/plugins/tools/pdf/plugin.go
@@ -35,7 +35,14 @@ type Plugin struct {
 	timeout       time.Duration // per-command timeout
 	saveToSession bool          // persist extracted text to session files
 	saveFileName  string        // custom filename for session save (default: derived from PDF name)
-	unsubs        []func()
+
+	// defaultMode chooses between text extraction and native-document
+	// pass-through when the LLM doesn't supply a `mode` argument.
+	// Values: "text" (default — current behaviour, runs pdftotext) or
+	// "document" (returns the raw PDF bytes as a file MessagePart).
+	defaultMode string
+
+	unsubs []func()
 
 	liveCalls atomic.Uint64
 }
@@ -46,9 +53,18 @@ func (p *Plugin) LiveCalls() uint64 { return p.liveCalls.Load() }
 
 func New() engine.Plugin {
 	return &Plugin{
-		timeout: 30 * time.Second,
+		timeout:     30 * time.Second,
+		defaultMode: modeText,
 	}
 }
+
+// Modes for read_pdf. modeText runs pdftotext like before; modeDocument
+// returns the raw PDF bytes as a file MessagePart so multimodal-capable
+// providers (Anthropic, Gemini) can read the document natively.
+const (
+	modeText     = "text"
+	modeDocument = "document"
+)
 
 func (p *Plugin) ID() string                        { return pluginID }
 func (p *Plugin) Name() string                      { return pluginName }
@@ -71,15 +87,25 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.timeout = d
 	}
 
-	// Allow overriding the binary path via config.
+	if dm, ok := ctx.Config["default_mode"].(string); ok && dm != "" {
+		if dm != modeText && dm != modeDocument {
+			return fmt.Errorf("pdf: invalid default_mode %q (want %q or %q)", dm, modeText, modeDocument)
+		}
+		p.defaultMode = dm
+	}
+
+	// Allow overriding the binary path via config. pdftotext is only
+	// required for text mode; if the operator wired default_mode:
+	// document and never opts back into text per-call, the binary
+	// stays absent and the document path still works.
 	if bin, ok := ctx.Config["pdftotext_bin"].(string); ok {
 		p.pdftotext = bin
 	} else {
-		path, err := exec.LookPath("pdftotext")
-		if err != nil {
-			return fmt.Errorf("pdf: pdftotext not found in PATH — install poppler (brew install poppler / apt install poppler-utils): %w", err)
+		if path, err := exec.LookPath("pdftotext"); err == nil {
+			p.pdftotext = path
+		} else if p.defaultMode == modeText {
+			return fmt.Errorf("pdf: pdftotext not found in PATH — install poppler (brew install poppler / apt install poppler-utils) or set default_mode: document: %w", err)
 		}
-		p.pdftotext = path
 	}
 
 	if save, ok := ctx.Config["save_to_session"].(bool); ok {
@@ -109,7 +135,7 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 func (p *Plugin) Ready() error {
 	_ = p.bus.Emit("tool.register", events.ToolDef{
 		Name:        "read_pdf",
-		Description: "Extract text content from a PDF file. Returns the full text by default, or a specific page range.",
+		Description: "Read a PDF file. Default mode 'text' extracts text via poppler/pdftotext. Mode 'document' returns the raw PDF bytes as a file MessagePart so multimodal providers (Anthropic, Gemini) can read the document natively (preserves images, layout, native rendering).",
 		Class:       "data",
 		Subclass:    "extract",
 		Parameters: map[string]any{
@@ -119,17 +145,22 @@ func (p *Plugin) Ready() error {
 					"type":        "string",
 					"description": "Path to the PDF file",
 				},
+				"mode": map[string]any{
+					"type":        "string",
+					"description": "Output mode. 'text' (default) extracts text via pdftotext. 'document' returns the raw PDF bytes as a file MessagePart for native multimodal providers; pagination/layout args are ignored in document mode.",
+					"enum":        []string{modeText, modeDocument},
+				},
 				"first_page": map[string]any{
 					"type":        "integer",
-					"description": "First page to extract (1-based). Omit to start from the beginning.",
+					"description": "First page to extract (1-based). Omit to start from the beginning. Ignored in document mode.",
 				},
 				"last_page": map[string]any{
 					"type":        "integer",
-					"description": "Last page to extract (1-based). Omit to read through the end.",
+					"description": "Last page to extract (1-based). Omit to read through the end. Ignored in document mode.",
 				},
 				"layout": map[string]any{
 					"type":        "boolean",
-					"description": "Preserve original physical layout. Useful for tables and forms. Default false.",
+					"description": "Preserve original physical layout. Useful for tables and forms. Default false. Ignored in document mode.",
 				},
 			},
 			"required": []string{"path"},
@@ -194,6 +225,27 @@ func (p *Plugin) handleReadPDF(tc events.ToolCall) {
 	}
 	if info.IsDir() {
 		p.emitResult(tc, "", "path is a directory, not a file")
+		return
+	}
+
+	// Per-call mode override; falls back to plugin default. Document mode
+	// short-circuits the pdftotext path entirely so a session that only
+	// uses native-document hand-off doesn't need poppler installed.
+	mode := p.defaultMode
+	if m, ok := tc.Arguments["mode"].(string); ok && m != "" {
+		if m != modeText && m != modeDocument {
+			p.emitResult(tc, "", fmt.Sprintf("invalid mode %q (want %q or %q)", m, modeText, modeDocument))
+			return
+		}
+		mode = m
+	}
+	if mode == modeDocument {
+		p.handleReadPDFDocument(tc, path, absPath)
+		return
+	}
+
+	if p.pdftotext == "" {
+		p.emitResult(tc, "", "pdftotext binary not configured: set pdftotext_bin or install poppler-utils to use mode 'text'")
 		return
 	}
 
@@ -269,6 +321,51 @@ func (p *Plugin) handleReadPDF(tc events.ToolCall) {
 	}
 
 	p.emitResult(tc, text, "")
+}
+
+// handleReadPDFDocument is the native-document hand-off path. Reads the
+// raw PDF bytes and emits them as a file MessagePart on
+// ToolResult.OutputParts so multimodal-capable providers (Anthropic,
+// Gemini) consume the document directly. No poppler call is made.
+//
+// Bytes ride inline on the part — the PDF plugin doesn't own a blob
+// store. Operators with very large PDFs should pair this with
+// nexus.tool.file's read_document, which routes through the per-session
+// blob store. Keeping read_pdf inline avoids a duplicate blob-store
+// wiring path for the common (sub-MB) case.
+func (p *Plugin) handleReadPDFDocument(tc events.ToolCall, path, absPath string) {
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		p.emitResult(tc, "", fmt.Sprintf("read pdf bytes: %s", err))
+		return
+	}
+
+	const mime = "application/pdf"
+	part := events.MessagePart{
+		Type:     "file",
+		MimeType: mime,
+		Data:     data,
+	}
+	summary := fmt.Sprintf("Loaded PDF %q (%d bytes) as native document", path, len(data))
+	result := events.ToolResult{
+		SchemaVersion: events.ToolResultVersion,
+		ID:            tc.ID,
+		Name:          tc.Name,
+		Output:        summary,
+		OutputStructured: map[string]any{
+			"path":       path,
+			"media_type": mime,
+			"size":       int64(len(data)),
+			"mode":       modeDocument,
+		},
+		OutputParts: []events.MessagePart{part},
+		TurnID:      tc.TurnID,
+	}
+	if veto, vErr := p.bus.EmitVetoable("before:tool.result", &result); vErr == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
 }
 
 // getPageCount uses pdfinfo to extract the page count.

--- a/plugins/tools/pdf/plugin_test.go
+++ b/plugins/tools/pdf/plugin_test.go
@@ -1,0 +1,182 @@
+package pdf
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// minPDF is a minimal PDF magic + EOF marker — enough for tests that
+// only check routing (extension and mode dispatch), not parsing.
+var minPDF = []byte{'%', 'P', 'D', 'F', '-', '1', '.', '4', '\n', '%', '%', 'E', 'O', 'F'}
+
+// busCapture records every tool.result so tests can assert what the
+// plugin emitted without booting the full engine.
+type busCapture struct {
+	engine.EventBus
+
+	mu      sync.Mutex
+	results []events.ToolResult
+}
+
+func newBusCapture(t *testing.T) *busCapture {
+	t.Helper()
+	bus := engine.NewEventBus()
+	bc := &busCapture{EventBus: bus}
+	bus.Subscribe("tool.result", func(e engine.Event[any]) {
+		if r, ok := e.Payload.(events.ToolResult); ok {
+			bc.mu.Lock()
+			bc.results = append(bc.results, r)
+			bc.mu.Unlock()
+		}
+	})
+	return bc
+}
+
+func (b *busCapture) lastResult(t *testing.T) events.ToolResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = b.EventBus.Drain(ctx)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.results) == 0 {
+		t.Fatal("no tool.result emitted")
+	}
+	return b.results[len(b.results)-1]
+}
+
+// TestReadPDF_DocumentMode_NoPdftotext verifies the document-mode path
+// works without a pdftotext binary. Writes a fixture PDF, asserts the
+// raw bytes ride on a file MessagePart, and that no shell-out happened
+// (we never set p.pdftotext).
+func TestReadPDF_DocumentMode_NoPdftotext(t *testing.T) {
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "spec.pdf")
+	if err := os.WriteFile(pdfPath, minPDF, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	bus := newBusCapture(t)
+	p := &Plugin{
+		bus:         bus,
+		defaultMode: modeText, // override default in args
+	}
+	p.handleReadPDF(events.ToolCall{
+		ID:        "pdf-1",
+		Name:      "read_pdf",
+		Arguments: map[string]any{"path": pdfPath, "mode": modeDocument},
+	})
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	part := r.OutputParts[0]
+	if part.Type != "file" {
+		t.Errorf("part.Type: got %q want file", part.Type)
+	}
+	if part.MimeType != "application/pdf" {
+		t.Errorf("part.MimeType: got %q want application/pdf", part.MimeType)
+	}
+	if !bytes.Equal(part.Data, minPDF) {
+		t.Errorf("part.Data does not match fixture")
+	}
+	if got, _ := r.OutputStructured["mode"].(string); got != modeDocument {
+		t.Errorf("OutputStructured.mode: got %q want %q", got, modeDocument)
+	}
+}
+
+// TestReadPDF_DefaultMode_Document verifies that setting default_mode at
+// plugin level routes calls to document mode without an explicit arg.
+func TestReadPDF_DefaultMode_Document(t *testing.T) {
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "spec.pdf")
+	if err := os.WriteFile(pdfPath, minPDF, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	bus := newBusCapture(t)
+	p := &Plugin{
+		bus:         bus,
+		defaultMode: modeDocument,
+	}
+	p.handleReadPDF(events.ToolCall{
+		ID:        "pdf-2",
+		Name:      "read_pdf",
+		Arguments: map[string]any{"path": pdfPath},
+	})
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	if r.OutputParts[0].MimeType != "application/pdf" {
+		t.Errorf("MimeType: got %q want application/pdf", r.OutputParts[0].MimeType)
+	}
+}
+
+// TestReadPDF_TextMode_NoBinary surfaces a clear error when text mode is
+// requested but pdftotext isn't configured. Without this guard the
+// plugin would pass an empty path to exec.Command.
+func TestReadPDF_TextMode_NoBinary(t *testing.T) {
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "spec.pdf")
+	if err := os.WriteFile(pdfPath, minPDF, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	bus := newBusCapture(t)
+	p := &Plugin{
+		bus:         bus,
+		defaultMode: modeText,
+	}
+	p.handleReadPDF(events.ToolCall{
+		ID:        "pdf-3",
+		Name:      "read_pdf",
+		Arguments: map[string]any{"path": pdfPath, "mode": modeText},
+	})
+
+	r := bus.lastResult(t)
+	if r.Error == "" {
+		t.Fatalf("expected error when pdftotext binary missing")
+	}
+	if len(r.OutputParts) != 0 {
+		t.Errorf("expected no OutputParts on error; got %d", len(r.OutputParts))
+	}
+}
+
+// TestReadPDF_InvalidMode rejects unknown mode values up front.
+func TestReadPDF_InvalidMode(t *testing.T) {
+	bus := newBusCapture(t)
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "spec.pdf")
+	if err := os.WriteFile(pdfPath, minPDF, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	p := &Plugin{
+		bus:         bus,
+		defaultMode: modeText,
+	}
+	p.handleReadPDF(events.ToolCall{
+		ID:        "pdf-4",
+		Name:      "read_pdf",
+		Arguments: map[string]any{"path": pdfPath, "mode": "screenshot"},
+	})
+
+	r := bus.lastResult(t)
+	if r.Error == "" {
+		t.Fatalf("expected error on invalid mode")
+	}
+}

--- a/plugins/tools/pdf/schema.json
+++ b/plugins/tools/pdf/schema.json
@@ -9,6 +9,7 @@
     "pdftotext_bin":    {"type": "string",  "description": "Path to the pdftotext binary."},
     "save_to_session":  {"type": "boolean", "description": "Persist extracted text into the session file workspace."},
     "save_file_name":   {"type": "string",  "description": "Filename used when save_to_session is true."},
-    "pdfinfo_bin":      {"type": "string",  "description": "Path to the pdfinfo binary."}
+    "pdfinfo_bin":      {"type": "string",  "description": "Path to the pdfinfo binary."},
+    "default_mode":     {"type": "string",  "enum": ["text", "document"], "description": "Default read_pdf mode. 'text' (default) extracts text via pdftotext. 'document' returns the raw PDF bytes as a file MessagePart for native multimodal providers."}
   }
 }

--- a/plugins/tools/screenshot/plugin.go
+++ b/plugins/tools/screenshot/plugin.go
@@ -52,6 +52,15 @@ const (
 // stub that writes a fixture PNG to outPath.
 type runFunc func(ctx context.Context, bin string, args []string, outPath string) error
 
+// platformCmdFunc is the seam tests use to bypass the per-platform PATH
+// probe. CI hosts (especially headless Linux runners) typically have none
+// of `screencapture`, `gnome-screenshot`, `grim`, or `import` installed,
+// so the production probe returns "no screenshot tool found" before the
+// stubbed runFunc gets a chance to write a fixture PNG. Tests inject a
+// platformCmdFunc that returns synthetic bin/args and lets runFunc do the
+// work.
+type platformCmdFunc func(outPath string) (bin string, args []string, err error)
+
 // Plugin implements the take_screenshot tool.
 type Plugin struct {
 	bus     engine.EventBus
@@ -68,6 +77,12 @@ type Plugin struct {
 	// be installed on the CI host.
 	run runFunc
 
+	// platformCmd resolves the per-OS screenshot binary + args. Production
+	// uses defaultPlatformCommand (PATH probe); tests inject a stub that
+	// returns a synthetic command so handleScreenshot reaches runFunc on
+	// CI hosts without any screenshot tool installed.
+	platformCmd platformCmdFunc
+
 	unsubs []func()
 
 	liveCalls atomic.Uint64
@@ -80,8 +95,9 @@ func (p *Plugin) LiveCalls() uint64 { return p.liveCalls.Load() }
 // New returns a fresh screenshot plugin.
 func New() engine.Plugin {
 	return &Plugin{
-		timeout: defaultCaptureTimeout,
-		run:     execRun,
+		timeout:     defaultCaptureTimeout,
+		run:         execRun,
+		platformCmd: defaultPlatformCommand,
 	}
 }
 
@@ -99,6 +115,9 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.replay = ctx.Replay
 	if p.run == nil {
 		p.run = execRun
+	}
+	if p.platformCmd == nil {
+		p.platformCmd = defaultPlatformCommand
 	}
 
 	if ts, ok := ctx.Config["timeout"].(string); ok && ts != "" {
@@ -209,7 +228,7 @@ func (p *Plugin) handleScreenshot(tc events.ToolCall) {
 	defer os.RemoveAll(tmpDir)
 	outPath := filepath.Join(tmpDir, "screen.png")
 
-	bin, args, perr := p.platformCommand(outPath)
+	bin, args, perr := p.platformCmd(outPath)
 	if perr != nil {
 		p.emitResult(tc, "", perr.Error(), nil, nil)
 		return
@@ -262,11 +281,13 @@ func (p *Plugin) handleScreenshot(tc events.ToolCall) {
 	p.emitResult(tc, summary, "", structured, []events.MessagePart{part})
 }
 
-// platformCommand returns the binary + args to capture the full screen to
-// outPath as PNG, picking the first installed tool per platform. Returns
-// an unsupported-platform error when nothing is appropriate or no candidate
-// is on PATH.
-func (p *Plugin) platformCommand(outPath string) (string, []string, error) {
+// defaultPlatformCommand returns the binary + args to capture the full
+// screen to outPath as PNG, picking the first installed tool per platform.
+// Returns an unsupported-platform error when nothing is appropriate or no
+// candidate is on PATH. This is the production platformCmdFunc; tests
+// inject a stub instead so handleScreenshot can reach the runFunc on CI
+// hosts without any screenshot tool installed.
+func defaultPlatformCommand(outPath string) (string, []string, error) {
 	switch runtime.GOOS {
 	case "darwin":
 		bin, err := exec.LookPath("screencapture")

--- a/plugins/tools/screenshot/plugin.go
+++ b/plugins/tools/screenshot/plugin.go
@@ -1,0 +1,337 @@
+// Package screenshot registers the take_screenshot tool. The captured PNG
+// is returned as an image MessagePart on ToolResult.OutputParts so memory
+// plugins forward it to the next LLM turn alongside any text.
+//
+// Capture path is platform-specific and shells out to a tool that ships
+// with the OS or is commonly preinstalled:
+//
+//   - darwin: screencapture -t png -x <tmpfile>
+//   - linux:  gnome-screenshot -f <tmpfile>, then grim, then ImageMagick's
+//     `import -window root <tmpfile>` as fallbacks.
+//
+// All other platforms surface a "screenshot not supported on this platform"
+// error from the tool result, leaving the agent free to recover.
+package screenshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+const (
+	pluginID   = "nexus.tool.screenshot"
+	pluginName = "Screenshot Tool"
+	version    = "0.1.0"
+
+	toolName = "take_screenshot"
+)
+
+// Default knobs for the per-session blob store backing take_screenshot.
+// Values mirror nexus.tool.file so screenshots and document reads share
+// budgets when both plugins are active in a session.
+const (
+	defaultBlobByteBudget      int64 = 2 * 1024 * 1024 * 1024
+	defaultBlobInlineThreshold int64 = 256 * 1024
+	defaultCaptureTimeout            = 15 * time.Second
+)
+
+// runFunc is the seam tests use to swap out exec.Run. The default
+// implementation runs the binary via os/exec; tests substitute a
+// stub that writes a fixture PNG to outPath.
+type runFunc func(ctx context.Context, bin string, args []string, outPath string) error
+
+// Plugin implements the take_screenshot tool.
+type Plugin struct {
+	bus     engine.EventBus
+	logger  *slog.Logger
+	session *engine.SessionWorkspace
+	replay  *engine.ReplayState
+
+	timeout          time.Duration
+	blobStore        *blobs.Store // nil when session workspace is unavailable
+	blobInlineCutoff int64
+
+	// run is the exec seam. Production uses execRun; tests inject a stub
+	// to avoid actually shelling out for screenshot binaries that may not
+	// be installed on the CI host.
+	run runFunc
+
+	unsubs []func()
+
+	liveCalls atomic.Uint64
+}
+
+// LiveCalls returns the count of take_screenshot invocations that survived
+// the replay short-circuit. Tests assert zero during replay.
+func (p *Plugin) LiveCalls() uint64 { return p.liveCalls.Load() }
+
+// New returns a fresh screenshot plugin.
+func New() engine.Plugin {
+	return &Plugin{
+		timeout: defaultCaptureTimeout,
+		run:     execRun,
+	}
+}
+
+func (p *Plugin) ID() string                        { return pluginID }
+func (p *Plugin) Name() string                      { return pluginName }
+func (p *Plugin) Version() string                   { return version }
+func (p *Plugin) Dependencies() []string            { return nil }
+func (p *Plugin) Requires() []engine.Requirement    { return nil }
+func (p *Plugin) Capabilities() []engine.Capability { return nil }
+
+func (p *Plugin) Init(ctx engine.PluginContext) error {
+	p.bus = ctx.Bus
+	p.logger = ctx.Logger
+	p.session = ctx.Session
+	p.replay = ctx.Replay
+	if p.run == nil {
+		p.run = execRun
+	}
+
+	if ts, ok := ctx.Config["timeout"].(string); ok && ts != "" {
+		d, err := time.ParseDuration(ts)
+		if err != nil {
+			return fmt.Errorf("screenshot: invalid timeout %q: %w", ts, err)
+		}
+		p.timeout = d
+	}
+
+	budget := defaultBlobByteBudget
+	p.blobInlineCutoff = defaultBlobInlineThreshold
+	if bs, ok := ctx.Config["blob_store"].(map[string]any); ok {
+		if v, ok := intLike(bs["byte_budget"]); ok {
+			budget = v
+		}
+		if v, ok := intLike(bs["inline_threshold"]); ok {
+			p.blobInlineCutoff = v
+		}
+	}
+	if p.session != nil {
+		store, err := blobs.New(p.session.BlobsDir(), budget)
+		if err != nil {
+			return fmt.Errorf("screenshot: blob store init: %w", err)
+		}
+		p.blobStore = store
+	}
+
+	p.unsubs = append(p.unsubs,
+		p.bus.Subscribe("tool.invoke", p.handleEvent,
+			engine.WithPriority(50), engine.WithSource(pluginID)),
+	)
+	return nil
+}
+
+func (p *Plugin) Ready() error {
+	_ = p.bus.Emit("tool.register", events.ToolDef{
+		Name:        toolName,
+		Description: "Capture the user's screen as a PNG and attach it to the next LLM turn as multimodal content. Use when the user asks 'what's on my screen?', references something they're looking at, or wants you to inspect a UI without sharing a file path.",
+		Class:       "system",
+		Subclass:    "capture",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"region": map[string]any{
+					"type":        "string",
+					"description": "Optional region selector. Currently ignored — the tool always captures the full screen. Reserved for future per-display / per-rectangle support.",
+				},
+			},
+		},
+		OutputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"media_type": map[string]any{"type": "string"},
+				"size":       map[string]any{"type": "integer"},
+				"blob_uri":   map[string]any{"type": "string", "description": "nexus-blob:<sha256> reference when stored as a blob; empty when inlined."},
+			},
+			"required": []string{"media_type", "size"},
+		},
+	})
+	return nil
+}
+
+func (p *Plugin) Shutdown(_ context.Context) error {
+	for _, u := range p.unsubs {
+		u()
+	}
+	return nil
+}
+
+func (p *Plugin) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{
+		{EventType: "tool.invoke", Priority: 50},
+	}
+}
+
+func (p *Plugin) Emissions() []string {
+	return []string{
+		"before:tool.result",
+		"tool.result",
+		"tool.register",
+	}
+}
+
+func (p *Plugin) handleEvent(event engine.Event[any]) {
+	tc, ok := event.Payload.(events.ToolCall)
+	if !ok || tc.Name != toolName {
+		return
+	}
+	if engine.ReplayToolShortCircuit(p.replay, p.bus, tc, p.logger) {
+		return
+	}
+	p.liveCalls.Add(1)
+	p.handleScreenshot(tc)
+}
+
+func (p *Plugin) handleScreenshot(tc events.ToolCall) {
+	if p.blobStore == nil {
+		p.emitResult(tc, "", "screenshot capture is unavailable: blob store not initialised (no session workspace)", nil, nil)
+		return
+	}
+
+	tmpDir, err := os.MkdirTemp("", "nexus-screenshot-*")
+	if err != nil {
+		p.emitResult(tc, "", fmt.Sprintf("create temp dir: %s", err), nil, nil)
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+	outPath := filepath.Join(tmpDir, "screen.png")
+
+	bin, args, perr := p.platformCommand(outPath)
+	if perr != nil {
+		p.emitResult(tc, "", perr.Error(), nil, nil)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+
+	if err := p.run(ctx, bin, args, outPath); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			p.emitResult(tc, "", fmt.Sprintf("screenshot timed out after %s", p.timeout), nil, nil)
+			return
+		}
+		p.emitResult(tc, "", fmt.Sprintf("screenshot capture failed: %s", err), nil, nil)
+		return
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		p.emitResult(tc, "", fmt.Sprintf("read screenshot bytes: %s", err), nil, nil)
+		return
+	}
+	if len(data) == 0 {
+		p.emitResult(tc, "", "screenshot capture produced an empty file", nil, nil)
+		return
+	}
+
+	const mime = "image/png"
+	part := events.MessagePart{Type: "image", MimeType: mime}
+	structured := map[string]any{
+		"media_type": mime,
+		"size":       int64(len(data)),
+	}
+	if int64(len(data)) <= p.blobInlineCutoff {
+		part.Data = data
+	} else {
+		h, err := p.blobStore.Put(data, mime)
+		if err != nil {
+			p.emitResult(tc, "", fmt.Sprintf("store blob: %s", err), nil, nil)
+			return
+		}
+		if _, _, err := p.blobStore.Sweep(); err != nil {
+			p.logger.Warn("screenshot: blob store sweep failed", "error", err)
+		}
+		part.URI = h.URI()
+		structured["blob_uri"] = h.URI()
+	}
+
+	summary := fmt.Sprintf("Captured screen (%s, %d bytes)", mime, len(data))
+	p.emitResult(tc, summary, "", structured, []events.MessagePart{part})
+}
+
+// platformCommand returns the binary + args to capture the full screen to
+// outPath as PNG, picking the first installed tool per platform. Returns
+// an unsupported-platform error when nothing is appropriate or no candidate
+// is on PATH.
+func (p *Plugin) platformCommand(outPath string) (string, []string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		bin, err := exec.LookPath("screencapture")
+		if err != nil {
+			return "", nil, fmt.Errorf("screencapture not found on PATH: %w", err)
+		}
+		// -t png: PNG output. -x: silent (no shutter sound). Region capture
+		// (-R) is intentionally not wired in v1; arg validation lands when
+		// we add a region selector to the tool schema.
+		return bin, []string{"-t", "png", "-x", outPath}, nil
+	case "linux":
+		if bin, err := exec.LookPath("gnome-screenshot"); err == nil {
+			return bin, []string{"-f", outPath}, nil
+		}
+		if bin, err := exec.LookPath("grim"); err == nil {
+			return bin, []string{outPath}, nil
+		}
+		if bin, err := exec.LookPath("import"); err == nil {
+			return bin, []string{"-window", "root", outPath}, nil
+		}
+		return "", nil, errors.New("no screenshot tool found on PATH (tried gnome-screenshot, grim, ImageMagick import)")
+	default:
+		return "", nil, fmt.Errorf("screenshot not supported on this platform (%s)", runtime.GOOS)
+	}
+}
+
+// execRun is the production runFunc — runs bin with args under ctx. The
+// outPath is irrelevant here (the screenshot binary writes to it directly)
+// but we accept it so test stubs share the same signature.
+func execRun(ctx context.Context, bin string, args []string, _ string) error {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w (output: %s)", bin, err, string(out))
+	}
+	return nil
+}
+
+func (p *Plugin) emitResult(tc events.ToolCall, output, errMsg string, structured map[string]any, parts []events.MessagePart) {
+	result := events.ToolResult{
+		SchemaVersion:    events.ToolResultVersion,
+		ID:               tc.ID,
+		Name:             tc.Name,
+		Output:           output,
+		Error:            errMsg,
+		OutputStructured: structured,
+		OutputParts:      parts,
+		TurnID:           tc.TurnID,
+	}
+	if veto, err := p.bus.EmitVetoable("before:tool.result", &result); err == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
+}
+
+// intLike accepts the JSON-ish numeric kinds yaml.v3 unmarshals into.
+func intLike(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	}
+	return 0, false
+}

--- a/plugins/tools/screenshot/plugin_test.go
+++ b/plugins/tools/screenshot/plugin_test.go
@@ -1,0 +1,182 @@
+package screenshot
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// minPNG is the 8-byte PNG signature plus a tiny trailing chunk — enough
+// for tests that only care about routing, not pixels.
+var minPNG = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00}
+
+// busCapture wraps a real engine.EventBus and records every tool.result so
+// tests can assert what the plugin emitted without booting the full engine.
+type busCapture struct {
+	engine.EventBus
+
+	mu      sync.Mutex
+	results []events.ToolResult
+}
+
+func newBusCapture(t *testing.T) *busCapture {
+	t.Helper()
+	bus := engine.NewEventBus()
+	bc := &busCapture{EventBus: bus}
+	bus.Subscribe("tool.result", func(e engine.Event[any]) {
+		if r, ok := e.Payload.(events.ToolResult); ok {
+			bc.mu.Lock()
+			bc.results = append(bc.results, r)
+			bc.mu.Unlock()
+		}
+	})
+	return bc
+}
+
+func (b *busCapture) lastResult(t *testing.T) events.ToolResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = b.EventBus.Drain(ctx)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.results) == 0 {
+		t.Fatal("no tool.result emitted")
+	}
+	return b.results[len(b.results)-1]
+}
+
+// stubRun returns a runFunc that writes payload to outPath. fail, when
+// non-nil, is returned without writing.
+func stubRun(payload []byte, fail error) runFunc {
+	return func(_ context.Context, _ string, _ []string, outPath string) error {
+		if fail != nil {
+			return fail
+		}
+		return os.WriteFile(outPath, payload, 0o644)
+	}
+}
+
+// makePlugin spins up a screenshot plugin with the given inline cutoff and
+// stubbed exec runner. Returns the plugin and a busCapture for assertions.
+func makePlugin(t *testing.T, inlineCutoff int64, run runFunc) (*Plugin, *busCapture) {
+	t.Helper()
+	dir := t.TempDir()
+	bus := newBusCapture(t)
+	store, err := blobs.New(filepath.Join(dir, "blobs"), 0)
+	if err != nil {
+		t.Fatalf("blobs.New: %v", err)
+	}
+	p := &Plugin{
+		bus:              bus,
+		blobStore:        store,
+		blobInlineCutoff: inlineCutoff,
+		timeout:          5 * time.Second,
+		run:              run,
+	}
+	return p, bus
+}
+
+func TestScreenshot_Inline(t *testing.T) {
+	p, bus := makePlugin(t, 1<<20, stubRun(minPNG, nil))
+
+	p.handleScreenshot(events.ToolCall{ID: "shot-1", Name: toolName})
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	part := r.OutputParts[0]
+	if part.Type != "image" {
+		t.Errorf("part.Type: got %q want image", part.Type)
+	}
+	if part.MimeType != "image/png" {
+		t.Errorf("part.MimeType: got %q want image/png", part.MimeType)
+	}
+	if !bytes.Equal(part.Data, minPNG) {
+		t.Errorf("part.Data does not match fixture")
+	}
+	if part.URI != "" {
+		t.Errorf("expected inline (empty URI); got URI=%q", part.URI)
+	}
+}
+
+func TestScreenshot_Blob(t *testing.T) {
+	bigData := append(append([]byte{}, minPNG...), bytes.Repeat([]byte{0xAA}, 4096)...)
+	p, bus := makePlugin(t, 1024, stubRun(bigData, nil))
+
+	p.handleScreenshot(events.ToolCall{ID: "shot-2", Name: toolName})
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	part := r.OutputParts[0]
+	if part.URI == "" || blobs.SHAFromURI(part.URI) == "" {
+		t.Fatalf("expected nexus-blob URI; got %q", part.URI)
+	}
+	if len(part.Data) != 0 {
+		t.Errorf("expected blob path with no inline Data; got %d inline bytes", len(part.Data))
+	}
+	got, mt, err := p.blobStore.Get(blobs.SHAFromURI(part.URI))
+	if err != nil {
+		t.Fatalf("blob store Get: %v", err)
+	}
+	if !bytes.Equal(got, bigData) {
+		t.Errorf("blob bytes do not match fixture")
+	}
+	if mt != "image/png" {
+		t.Errorf("blob media type: got %q want image/png", mt)
+	}
+	bu, _ := r.OutputStructured["blob_uri"].(string)
+	if bu != part.URI {
+		t.Errorf("OutputStructured.blob_uri %q != part.URI %q", bu, part.URI)
+	}
+}
+
+func TestScreenshot_NoBlobStore(t *testing.T) {
+	bus := newBusCapture(t)
+	p := &Plugin{
+		bus:     bus,
+		timeout: time.Second,
+		run:     stubRun(minPNG, nil),
+	}
+	p.handleScreenshot(events.ToolCall{ID: "shot-3", Name: toolName})
+
+	r := bus.lastResult(t)
+	if r.Error == "" {
+		t.Fatalf("expected error when blob store missing")
+	}
+	if len(r.OutputParts) != 0 {
+		t.Errorf("expected no OutputParts on error; got %d", len(r.OutputParts))
+	}
+}
+
+func TestScreenshot_CaptureFailure(t *testing.T) {
+	p, bus := makePlugin(t, 1<<20, stubRun(nil, errors.New("boom")))
+
+	p.handleScreenshot(events.ToolCall{ID: "shot-4", Name: toolName})
+
+	r := bus.lastResult(t)
+	if r.Error == "" {
+		t.Fatalf("expected error from stubbed runner")
+	}
+	if len(r.OutputParts) != 0 {
+		t.Errorf("expected no OutputParts on error; got %d", len(r.OutputParts))
+	}
+}

--- a/plugins/tools/screenshot/plugin_test.go
+++ b/plugins/tools/screenshot/plugin_test.go
@@ -66,6 +66,14 @@ func stubRun(payload []byte, fail error) runFunc {
 	}
 }
 
+// stubPlatformCmd is a platformCmdFunc that returns a synthetic command so
+// handleScreenshot proceeds to runFunc without probing PATH. The returned
+// bin / args are never executed (runFunc is also stubbed) but must
+// non-empty so the plugin's "no command resolved" guard passes.
+func stubPlatformCmd(_ string) (string, []string, error) {
+	return "stub-screenshot", []string{}, nil
+}
+
 // makePlugin spins up a screenshot plugin with the given inline cutoff and
 // stubbed exec runner. Returns the plugin and a busCapture for assertions.
 func makePlugin(t *testing.T, inlineCutoff int64, run runFunc) (*Plugin, *busCapture) {
@@ -82,6 +90,7 @@ func makePlugin(t *testing.T, inlineCutoff int64, run runFunc) (*Plugin, *busCap
 		blobInlineCutoff: inlineCutoff,
 		timeout:          5 * time.Second,
 		run:              run,
+		platformCmd:      stubPlatformCmd,
 	}
 	return p, bus
 }
@@ -152,9 +161,10 @@ func TestScreenshot_Blob(t *testing.T) {
 func TestScreenshot_NoBlobStore(t *testing.T) {
 	bus := newBusCapture(t)
 	p := &Plugin{
-		bus:     bus,
-		timeout: time.Second,
-		run:     stubRun(minPNG, nil),
+		bus:         bus,
+		timeout:     time.Second,
+		run:         stubRun(minPNG, nil),
+		platformCmd: stubPlatformCmd,
 	}
 	p.handleScreenshot(events.ToolCall{ID: "shot-3", Name: toolName})
 

--- a/plugins/tools/screenshot/schema.go
+++ b/plugins/tools/screenshot/schema.go
@@ -1,0 +1,9 @@
+package screenshot
+
+import _ "embed"
+
+//go:embed schema.json
+var configSchemaBytes []byte
+
+// ConfigSchema implements engine.ConfigSchemaProvider.
+func (p *Plugin) ConfigSchema() []byte { return configSchemaBytes }

--- a/plugins/tools/screenshot/schema.json
+++ b/plugins/tools/screenshot/schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexus.local/schemas/plugins/nexus.tool.screenshot.json",
+  "title": "nexus.tool.screenshot",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "timeout": {"type": "string", "description": "Per-capture subprocess timeout (Go duration)."},
+    "blob_store": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings for the per-session blob store backing take_screenshot.",
+      "properties": {
+        "byte_budget":      {"type": "integer", "description": "Soft cap on total stored blob bytes per session. 0 = unbounded.", "default": 2147483648},
+        "inline_threshold": {"type": "integer", "description": "Payloads at or below this size are inlined on the MessagePart instead of being stored as a blob.", "default": 262144}
+      }
+    }
+  }
+}

--- a/plugins/tools/web/page_image.go
+++ b/plugins/tools/web/page_image.go
@@ -1,0 +1,256 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// pageImageProvider wires the fetch_page_image tool to an external
+// screenshot-as-a-service provider. The plugin does not bundle its own
+// renderer (would require a headless browser); operators bring their own
+// (urlbox, screenshotapi.net, browserless, etc.) and configure the
+// request shape via plugin config.
+type pageImageProvider struct {
+	url            string            // POST/GET endpoint
+	method         string            // "POST" (default) or "GET"
+	apiKeyEnv      string            // env var name; reads at request time
+	urlParamName   string            // name of the URL field in the request body / query
+	requestExtras  map[string]any    // arbitrary extra fields merged into the request body / query
+	requestHeaders map[string]string // optional fixed headers (Authorization, etc.)
+}
+
+// configured reports whether the provider has the minimum config to make
+// a request. Used by handleFetchPageImage to short-circuit with a clear
+// error instead of attempting an empty POST.
+func (p *pageImageProvider) configured() bool {
+	return p != nil && strings.TrimSpace(p.url) != ""
+}
+
+// loadPageImageProviderConfig parses cfg["screenshot_provider"] into a
+// pageImageProvider. Returns nil + nil err when the operator hasn't
+// configured anything (tool stays disabled at runtime).
+func loadPageImageProviderConfig(cfg map[string]any) (*pageImageProvider, error) {
+	raw, ok := cfg["screenshot_provider"].(map[string]any)
+	if !ok || len(raw) == 0 {
+		return nil, nil
+	}
+	p := &pageImageProvider{
+		method:       "POST",
+		urlParamName: "url",
+	}
+	if s, ok := raw["url"].(string); ok {
+		p.url = strings.TrimSpace(s)
+	}
+	if s, ok := raw["method"].(string); ok && s != "" {
+		m := strings.ToUpper(strings.TrimSpace(s))
+		if m != http.MethodGet && m != http.MethodPost {
+			return nil, fmt.Errorf("web: invalid screenshot_provider.method %q (want GET or POST)", s)
+		}
+		p.method = m
+	}
+	if s, ok := raw["api_key_env"].(string); ok {
+		p.apiKeyEnv = strings.TrimSpace(s)
+	}
+	if s, ok := raw["url_param_name"].(string); ok && s != "" {
+		p.urlParamName = s
+	}
+	if extras, ok := raw["request_template"].(map[string]any); ok {
+		// Shallow copy so a later mutation of the parsed config map cannot
+		// reach into our private state.
+		p.requestExtras = make(map[string]any, len(extras))
+		for k, v := range extras {
+			p.requestExtras[k] = v
+		}
+	}
+	if headers, ok := raw["headers"].(map[string]any); ok {
+		p.requestHeaders = make(map[string]string, len(headers))
+		for k, v := range headers {
+			if s, ok := v.(string); ok {
+				p.requestHeaders[k] = s
+			}
+		}
+	}
+	return p, nil
+}
+
+// handleFetchPageImage services a fetch_page_image tool call. The plugin
+// itself does not render web pages — it forwards the request URL to the
+// configured provider and routes the returned PNG bytes through the
+// blob store like screenshot/fileio do.
+func (p *Plugin) handleFetchPageImage(tc events.ToolCall) {
+	if p.pageImage == nil || !p.pageImage.configured() {
+		p.emitResultParts(tc, "", "fetch_page_image requires nexus.tool.web.screenshot_provider configuration; see docs", nil, nil)
+		return
+	}
+	if p.blobStore == nil {
+		p.emitResultParts(tc, "", "fetch_page_image is unavailable: blob store not initialised (no session workspace)", nil, nil)
+		return
+	}
+
+	rawURL, _ := tc.Arguments["url"].(string)
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		p.emitResultParts(tc, "", "url argument is required", nil, nil)
+		return
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		p.emitResultParts(tc, "", fmt.Sprintf("invalid url: %q", rawURL), nil, nil)
+		return
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		p.emitResultParts(tc, "", fmt.Sprintf("only http(s) schemes are allowed, got %q", parsed.Scheme), nil, nil)
+		return
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if !p.hostAllowed(host) {
+		p.emitResultParts(tc, "", fmt.Sprintf("host %q is not allowed by policy", host), nil, nil)
+		return
+	}
+
+	body, err := p.callPageImageProvider(parsed.String())
+	if err != nil {
+		p.emitResultParts(tc, "", err.Error(), nil, nil)
+		return
+	}
+	if len(body) == 0 {
+		p.emitResultParts(tc, "", "screenshot provider returned an empty body", nil, nil)
+		return
+	}
+
+	const mime = "image/png"
+	part := events.MessagePart{Type: "image", MimeType: mime}
+	structured := map[string]any{
+		"url":        parsed.String(),
+		"media_type": mime,
+		"size":       int64(len(body)),
+	}
+	if int64(len(body)) <= p.blobInlineCutoff {
+		part.Data = body
+	} else {
+		h, err := p.blobStore.Put(body, mime)
+		if err != nil {
+			p.emitResultParts(tc, "", fmt.Sprintf("store blob: %s", err), nil, nil)
+			return
+		}
+		if _, _, err := p.blobStore.Sweep(); err != nil {
+			p.logger.Warn("web: blob store sweep failed", "error", err)
+		}
+		part.URI = h.URI()
+		structured["blob_uri"] = h.URI()
+	}
+
+	summary := fmt.Sprintf("Captured %s as PNG (%d bytes)", parsed.String(), len(body))
+	p.emitResultParts(tc, summary, "", structured, []events.MessagePart{part})
+}
+
+// callPageImageProvider performs the HTTP round-trip against the
+// configured provider. Returns the raw response body bytes (expected to
+// be PNG) on success.
+func (p *Plugin) callPageImageProvider(target string) ([]byte, error) {
+	prov := p.pageImage
+
+	apiKey := ""
+	if prov.apiKeyEnv != "" {
+		apiKey = strings.TrimSpace(os.Getenv(prov.apiKeyEnv))
+	}
+
+	var req *http.Request
+	switch prov.method {
+	case http.MethodGet:
+		u, err := url.Parse(prov.url)
+		if err != nil {
+			return nil, fmt.Errorf("invalid screenshot_provider.url: %w", err)
+		}
+		q := u.Query()
+		q.Set(prov.urlParamName, target)
+		for k, v := range prov.requestExtras {
+			q.Set(k, fmt.Sprint(v))
+		}
+		if apiKey != "" {
+			q.Set("api_key", apiKey)
+		}
+		u.RawQuery = q.Encode()
+		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+	default: // POST
+		bodyMap := make(map[string]any, len(prov.requestExtras)+1)
+		for k, v := range prov.requestExtras {
+			bodyMap[k] = v
+		}
+		bodyMap[prov.urlParamName] = target
+		bodyJSON, err := json.Marshal(bodyMap)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request: %w", err)
+		}
+		req, err = http.NewRequest(http.MethodPost, prov.url, bytes.NewReader(bodyJSON))
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if apiKey != "" {
+			// Most screenshot APIs accept either a header bearer token or a
+			// query string param. We default to bearer for POST so the URL
+			// doesn't leak in proxy logs; operators that need a different
+			// shape can override via headers/request_template.
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
+	}
+	for k, v := range prov.requestHeaders {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Accept", "image/png,image/*;q=0.9,*/*;q=0.5")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("call screenshot provider: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Read a small body sample so the error includes the provider's
+		// own diagnostic text rather than just the HTTP status.
+		sample, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("screenshot provider returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(sample)))
+	}
+
+	limited := io.LimitReader(resp.Body, p.maxSize+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read provider response: %w", err)
+	}
+	if int64(len(body)) > p.maxSize {
+		return nil, fmt.Errorf("screenshot exceeds max_size (%d bytes)", p.maxSize)
+	}
+	return body, nil
+}
+
+// emitResultParts mirrors emitResult but threads OutputParts and
+// OutputStructured for multimodal-shaped results. Stays in this file so
+// the plain text path stays unchanged.
+func (p *Plugin) emitResultParts(tc events.ToolCall, output, errMsg string, structured map[string]any, parts []events.MessagePart) {
+	result := events.ToolResult{
+		SchemaVersion:    events.ToolResultVersion,
+		ID:               tc.ID,
+		Name:             tc.Name,
+		Output:           output,
+		Error:            errMsg,
+		OutputStructured: structured,
+		OutputParts:      parts,
+		TurnID:           tc.TurnID,
+	}
+	if veto, err := p.bus.EmitVetoable("before:tool.result", &result); err == nil && veto.Vetoed {
+		p.logger.Info("tool.result vetoed", "tool", tc.Name, "reason", veto.Reason)
+		return
+	}
+	_ = p.bus.Emit("tool.result", result)
+}

--- a/plugins/tools/web/page_image_test.go
+++ b/plugins/tools/web/page_image_test.go
@@ -1,0 +1,252 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// minPNG is the 8-byte PNG signature plus a tiny trailing chunk — enough
+// for tests that only care about routing, not pixels.
+var minPNG = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00}
+
+// busCapture wraps a real engine.EventBus and records every tool.result so
+// tests can assert what the plugin emitted without booting the full engine.
+type busCapture struct {
+	engine.EventBus
+
+	mu      sync.Mutex
+	results []events.ToolResult
+}
+
+func newBusCapture(t *testing.T) *busCapture {
+	t.Helper()
+	bus := engine.NewEventBus()
+	bc := &busCapture{EventBus: bus}
+	bus.Subscribe("tool.result", func(e engine.Event[any]) {
+		if r, ok := e.Payload.(events.ToolResult); ok {
+			bc.mu.Lock()
+			bc.results = append(bc.results, r)
+			bc.mu.Unlock()
+		}
+	})
+	return bc
+}
+
+func (b *busCapture) lastResult(t *testing.T) events.ToolResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_ = b.EventBus.Drain(ctx)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.results) == 0 {
+		t.Fatal("no tool.result emitted")
+	}
+	return b.results[len(b.results)-1]
+}
+
+// makePlugin builds a plugin scoped to a temp blob dir + given inline cutoff
+// + given page-image provider config. The HTTP client is wired up like Init
+// does so the provider round-trip works end-to-end.
+func makePlugin(t *testing.T, inlineCutoff int64, prov *pageImageProvider) (*Plugin, *busCapture) {
+	t.Helper()
+	dir := t.TempDir()
+	bus := newBusCapture(t)
+	store, err := blobs.New(filepath.Join(dir, "blobs"), 0)
+	if err != nil {
+		t.Fatalf("blobs.New: %v", err)
+	}
+	p := &Plugin{
+		bus:              bus,
+		client:           &http.Client{Timeout: 5 * time.Second},
+		pageImage:        prov,
+		blobStore:        store,
+		blobInlineCutoff: inlineCutoff,
+		maxSize:          5 * 1024 * 1024,
+	}
+	return p, bus
+}
+
+func TestFetchPageImage_Unconfigured(t *testing.T) {
+	p, bus := makePlugin(t, 1<<20, nil)
+	p.handleFetchPageImage(events.ToolCall{ID: "fpi-1", Name: "fetch_page_image", Arguments: map[string]any{"url": "https://example.com/"}})
+
+	r := bus.lastResult(t)
+	if r.Error == "" {
+		t.Fatalf("expected error when screenshot provider unconfigured")
+	}
+	if !contains(r.Error, "screenshot_provider") {
+		t.Errorf("error should mention screenshot_provider config; got %q", r.Error)
+	}
+	if len(r.OutputParts) != 0 {
+		t.Errorf("expected no OutputParts on error; got %d", len(r.OutputParts))
+	}
+}
+
+func TestFetchPageImage_Configured(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   map[string]any
+		gotAuth   string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(200)
+		_, _ = w.Write(minPNG)
+	}))
+	defer srv.Close()
+
+	prov := &pageImageProvider{
+		url:          srv.URL + "/screenshot",
+		method:       http.MethodPost,
+		urlParamName: "url",
+	}
+	p, bus := makePlugin(t, 1<<20, prov)
+	p.handleFetchPageImage(events.ToolCall{ID: "fpi-2", Name: "fetch_page_image", Arguments: map[string]any{"url": "https://example.com/page"}})
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	part := r.OutputParts[0]
+	if part.Type != "image" || part.MimeType != "image/png" {
+		t.Errorf("unexpected part shape: %+v", part)
+	}
+	if !bytes.Equal(part.Data, minPNG) {
+		t.Errorf("part.Data does not match server fixture")
+	}
+	if gotMethod != "POST" {
+		t.Errorf("provider method: got %q want POST", gotMethod)
+	}
+	if gotPath != "/screenshot" {
+		t.Errorf("provider path: got %q want /screenshot", gotPath)
+	}
+	if gotBody["url"] != "https://example.com/page" {
+		t.Errorf("provider body url: got %v want https://example.com/page", gotBody["url"])
+	}
+	if gotAuth != "" {
+		t.Errorf("expected no Authorization header (no api_key_env set); got %q", gotAuth)
+	}
+}
+
+func TestFetchPageImage_Blob(t *testing.T) {
+	bigData := append(append([]byte{}, minPNG...), bytes.Repeat([]byte{0xAA}, 4096)...)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(200)
+		_, _ = w.Write(bigData)
+	}))
+	defer srv.Close()
+
+	prov := &pageImageProvider{
+		url:          srv.URL,
+		method:       http.MethodPost,
+		urlParamName: "url",
+	}
+	p, bus := makePlugin(t, 1024, prov)
+	p.handleFetchPageImage(events.ToolCall{ID: "fpi-3", Name: "fetch_page_image", Arguments: map[string]any{"url": "https://example.com/big"}})
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if len(r.OutputParts) != 1 {
+		t.Fatalf("OutputParts len: got %d want 1", len(r.OutputParts))
+	}
+	part := r.OutputParts[0]
+	if part.URI == "" || blobs.SHAFromURI(part.URI) == "" {
+		t.Fatalf("expected nexus-blob URI; got %q", part.URI)
+	}
+	if len(part.Data) != 0 {
+		t.Errorf("expected blob path with no inline Data; got %d inline bytes", len(part.Data))
+	}
+	got, _, err := p.blobStore.Get(blobs.SHAFromURI(part.URI))
+	if err != nil {
+		t.Fatalf("blob store Get: %v", err)
+	}
+	if !bytes.Equal(got, bigData) {
+		t.Errorf("blob bytes do not match server fixture")
+	}
+}
+
+func TestFetchPageImage_GETWithApiKey(t *testing.T) {
+	t.Setenv("FAKE_SCREENSHOT_KEY", "k-12345")
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(200)
+		_, _ = w.Write(minPNG)
+	}))
+	defer srv.Close()
+
+	prov := &pageImageProvider{
+		url:          srv.URL,
+		method:       http.MethodGet,
+		apiKeyEnv:    "FAKE_SCREENSHOT_KEY",
+		urlParamName: "target",
+		requestExtras: map[string]any{
+			"format": "png",
+		},
+	}
+	p, bus := makePlugin(t, 1<<20, prov)
+	p.handleFetchPageImage(events.ToolCall{ID: "fpi-4", Name: "fetch_page_image", Arguments: map[string]any{"url": "https://example.org/"}})
+
+	r := bus.lastResult(t)
+	if r.Error != "" {
+		t.Fatalf("unexpected error: %q", r.Error)
+	}
+	if got := gotQuery.Get("target"); got != "https://example.org/" {
+		t.Errorf("query target: got %q want https://example.org/", got)
+	}
+	if got := gotQuery.Get("api_key"); got != "k-12345" {
+		t.Errorf("query api_key: got %q want k-12345", got)
+	}
+	if got := gotQuery.Get("format"); got != "png" {
+		t.Errorf("query format: got %q want png", got)
+	}
+}
+
+func TestFetchPageImage_ProviderError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+		_, _ = w.Write([]byte("provider down"))
+	}))
+	defer srv.Close()
+
+	prov := &pageImageProvider{url: srv.URL, method: http.MethodPost, urlParamName: "url"}
+	p, bus := makePlugin(t, 1<<20, prov)
+	p.handleFetchPageImage(events.ToolCall{ID: "fpi-5", Name: "fetch_page_image", Arguments: map[string]any{"url": "https://example.com/"}})
+
+	r := bus.lastResult(t)
+	if r.Error == "" {
+		t.Fatalf("expected error from 503 provider")
+	}
+	if !contains(r.Error, "503") {
+		t.Errorf("expected status 503 in error; got %q", r.Error)
+	}
+}
+
+func contains(s, sub string) bool { return bytes.Contains([]byte(s), []byte(sub)) }

--- a/plugins/tools/web/plugin.go
+++ b/plugins/tools/web/plugin.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/engine/blobs"
 	"github.com/frankbardon/nexus/pkg/events"
 )
 
@@ -28,6 +29,12 @@ const (
 	defaultMaxSize     = int64(5 * 1024 * 1024) // 5 MB
 	defaultSearchCount = 10
 	defaultExtractMode = "readability"
+
+	// fetch_page_image blob store knobs. Mirror nexus.tool.file defaults so
+	// page screenshots and document reads share predictable behaviour when
+	// both plugins are active.
+	defaultPageImageBlobBudget   int64 = 2 * 1024 * 1024 * 1024
+	defaultPageImageInlineCutoff int64 = 256 * 1024
 )
 
 // Plugin implements the web_search and web_fetch tools.
@@ -57,6 +64,14 @@ type Plugin struct {
 	blockedDomains  []string
 	followRedirects bool
 	maxRedirects    int
+
+	// fetch_page_image config — when pageImage is nil/unset, the tool
+	// short-circuits with an actionable error rather than silently
+	// no-oping. The blob store is created at Init when a session is
+	// available; same shape as nexus.tool.file / nexus.tool.screenshot.
+	pageImage        *pageImageProvider
+	blobStore        *blobs.Store
+	blobInlineCutoff int64
 }
 
 // New returns a fresh web tool plugin.
@@ -96,6 +111,34 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 
 	if err := p.loadConfig(ctx.Config); err != nil {
 		return err
+	}
+
+	// Optional fetch_page_image provider. Absence means the tool will
+	// surface a clear "not configured" error at invoke time.
+	provider, err := loadPageImageProviderConfig(ctx.Config)
+	if err != nil {
+		return err
+	}
+	p.pageImage = provider
+
+	// Per-session blob store, shared across web tools that need to attach
+	// binary payloads (currently only fetch_page_image).
+	budget := defaultPageImageBlobBudget
+	p.blobInlineCutoff = defaultPageImageInlineCutoff
+	if bs, ok := ctx.Config["blob_store"].(map[string]any); ok {
+		if v, ok := intLike(bs["byte_budget"]); ok {
+			budget = v
+		}
+		if v, ok := intLike(bs["inline_threshold"]); ok {
+			p.blobInlineCutoff = v
+		}
+	}
+	if p.session != nil {
+		store, err := blobs.New(p.session.BlobsDir(), budget)
+		if err != nil {
+			return fmt.Errorf("web: blob store init: %w", err)
+		}
+		p.blobStore = store
 	}
 
 	p.client = &http.Client{
@@ -178,6 +221,33 @@ func (p *Plugin) Ready() error {
 		},
 	})
 
+	_ = p.bus.Emit("tool.register", events.ToolDef{
+		Name:        "fetch_page_image",
+		Description: "Capture a rendered web page as a PNG screenshot and attach it to the next LLM turn as multimodal content. Use when the agent needs to see a page's actual layout (charts, dashboards, image-heavy pages, JS-rendered apps) rather than its text. Requires an external screenshot provider configured via plugin settings.",
+		Class:       "research",
+		Subclass:    "fetch",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"url": map[string]any{
+					"type":        "string",
+					"description": "Absolute http(s) URL to capture.",
+				},
+			},
+			"required": []string{"url"},
+		},
+		OutputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"url":        map[string]any{"type": "string"},
+				"media_type": map[string]any{"type": "string"},
+				"size":       map[string]any{"type": "integer"},
+				"blob_uri":   map[string]any{"type": "string", "description": "nexus-blob:<sha256> reference when stored as a blob; empty when inlined."},
+			},
+			"required": []string{"url", "media_type", "size"},
+		},
+	})
+
 	return nil
 }
 
@@ -212,7 +282,9 @@ func (p *Plugin) handleEvent(event engine.Event[any]) {
 	if !ok {
 		return
 	}
-	if tc.Name != "web_search" && tc.Name != "web_fetch" {
+	switch tc.Name {
+	case "web_search", "web_fetch", "fetch_page_image":
+	default:
 		return
 	}
 	if engine.ReplayToolShortCircuit(p.replay, p.bus, tc, p.logger) {
@@ -224,6 +296,8 @@ func (p *Plugin) handleEvent(event engine.Event[any]) {
 		p.handleSearch(tc)
 	case "web_fetch":
 		p.handleFetch(tc)
+	case "fetch_page_image":
+		p.handleFetchPageImage(tc)
 	}
 }
 
@@ -310,6 +384,21 @@ func toInt(v any) (int, bool) {
 		return int(n), true
 	case float64:
 		return int(n), true
+	}
+	return 0, false
+}
+
+// intLike accepts the JSON-ish numeric kinds yaml.v3 unmarshals into and
+// returns an int64. Mirrors the helper in nexus.tool.file / screenshot so
+// blob_store.byte_budget configs parse identically across plugins.
+func intLike(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
 	}
 	return 0, false
 }

--- a/plugins/tools/web/schema.json
+++ b/plugins/tools/web/schema.json
@@ -27,6 +27,28 @@
         "follow_redirects": {"type": "boolean", "description": "Follow HTTP redirects."},
         "max_redirects":    {"type": "integer", "minimum": 0, "description": "Maximum redirect chain length."}
       }
+    },
+    "screenshot_provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "External page-screenshot service used by fetch_page_image. Absent => the tool returns a clear configuration error.",
+      "properties": {
+        "url":              {"type": "string",  "description": "Provider endpoint."},
+        "method":           {"type": "string",  "enum": ["GET", "POST"], "description": "HTTP method (default POST)."},
+        "api_key_env":      {"type": "string",  "description": "Env var holding the bearer token / api key."},
+        "url_param_name":   {"type": "string",  "description": "Field name used for the target URL in the request (default 'url')."},
+        "request_template": {"type": "object",  "additionalProperties": true, "description": "Extra fields merged into the JSON body (POST) or query string (GET)."},
+        "headers":          {"type": "object",  "additionalProperties": {"type": "string"}, "description": "Fixed headers to send with every request."}
+      }
+    },
+    "blob_store": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings for the per-session blob store backing fetch_page_image.",
+      "properties": {
+        "byte_budget":      {"type": "integer", "description": "Soft cap on total stored blob bytes per session. 0 = unbounded.", "default": 2147483648},
+        "inline_threshold": {"type": "integer", "description": "Payloads at or below this size are inlined on the MessagePart instead of being stored as a blob.", "default": 262144}
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #91. Implements all phases of the multimodal-foundation + voice-IO scope minus the explicit deferrals noted below.

## Discovery: prior phases already in tree

Audit before coding showed Phases 0 and most of Phase 1 from #91 were **already shipped** on `main`:

- Cancellation events (`pkg/events/cancel.go`) + handlers in TUI / browser / wails / react agent.
- Streaming `StreamChunk` + `StreamEnd` events with provider-side SSE / chunk parsing in Anthropic, OpenAI, and Gemini.
- Multimodal `MessagePart` event type (text / image / audio / video / file) with `MimeType`, inline `Data`, `URI`, and provider `FileID`.
- Provider mapping in each `multimodal.go` (Anthropic image + native document blocks, OpenAI image_url, Gemini inline_data + Files API references).

The #91 issue body framed those as undone — was wrong relative to actual state.

## What this PR adds

Numbers correspond to issue #91 phase ordering. `(P)` marks per-phase agent-driven commits (4 isolated worktree subagents ran the back-half phases).

### Phase 1 cost gap — modality-aware Usage breakdown

`bd9f69a` — `Usage.ModalityBreakdown map[string]int` populated from OpenAI `prompt_tokens_details.audio_tokens` + `completion_tokens_details.audio_tokens` and Gemini `promptTokensDetails`/`candidatesTokensDetails`/`cacheTokensDetails` modality entries. Anthropic doesn't expose per-modality counts (image tokens roll into `input_tokens`), left nil. Additive on `Usage`; no `LLMResponse` schema bump.

### Phase 2 — blob store + multimodal-aware tools

- `d274965` — `pkg/engine/blobs` content-addressed store (sha256-keyed Put/Get/Stat/Delete + LRU `Sweep` gated by configurable byte budget; atomic temp+rename writes; `nexus-blob:<sha>` URI scheme).
- `74275eb` — `read_image` / `read_document` tools on `nexus.tool.file`. Adds `ToolResult.OutputParts []MessagePart` carrier; memory plugins (`simple`, `capped`, `summary_buffer`) copy onto `Message.Parts` so the next LLM request sees multimodal content. Inline ≤256 KiB, blob otherwise. 2 GiB soft cap (configurable).
- `cf5b054` (P) — `plugins/tools/screenshot/` with `take_screenshot` tool. Platform exec dispatch (`screencapture` on darwin, `gnome-screenshot`/`grim`/`import` on linux). Stubbable runner for tests.
- `6afd002` + `b4f57a9` (P) — `fetch_page_image` tool on `nexus.tool.web`. Operator configures an external screenshot provider; tool errors clearly when unconfigured (no hard-coded service).
- `fd45b36` (P) — `nexus.ReturnImage(data, mime)` script binding on `nexus.tool.codeexec` so yaegi-executed code can return image bytes that surface as `OutputParts`.
- `2547d41` (P) — `nexus.tool.pdf` gains a per-call `mode` arg (`text` default, `document` returns raw PDF bytes as a file MessagePart for native multimodal providers). `default_mode` config; pdftotext binary becomes optional in document-only mode.

### Phase 3 — realtime IO transport

- `73d68dd` (P) — `pkg/events/voice.go` with `VoiceAudioInputChunk` + `VoiceAudioOutputChunk` event types (schema-versioned; registered in `pkg/events/version_test.go`).
- `d279a6c` (P) — `plugins/io/realtime/` plugin `nexus.io.realtime`. WebSocket bidirectional bridge. Outbound forwards `llm.stream.chunk`, `llm.stream.end`, `before:tool.invoke` (read-only), `voice.audio.output.chunk`, `cancel.complete`, `hitl.requested` as JSON envelopes. Inbound accepts `input`, `audio.chunk`, `cancel`, `approval` frames and emits matching bus events. Multi-client broadcast; reuses `github.com/coder/websocket` (already pulled in via io/browser); no auth in v1, documented as opt-in for follow-up.

### Phase 4 — voice IO (API-only)

- `5d3dd77` (P) — `plugins/io/voice/` plugin `nexus.io.voice`. Consumes `voice.audio.input.chunk`, runs RMS-based VAD on PCM/WAV/L16; flushes on silence threshold or `Final=true`; ASR via OpenAI Whisper API → emits `events.UserInput`. Subscribes to `llm.response`, calls OpenAI TTS API, chunks MP3 bytes, emits `events.VoiceAudioOutputChunk`. Barge-in: above-threshold input during in-flight TTS emits `cancel.request{Source: "voice"}` so the cooperative-cancel chain terminates the LLM. Local-model providers (`local_whisper` / `kokoro` / etc.) are accepted by the JSON schema for forward-compat but rejected at Init with a clear error pointing at #92 (per-direction local-model bootstrap stays out of this PR).

### Phase 5 — multimodal embeddings + image vector memory

- `c742014` (P) — `events.EmbeddingsRequest.Inputs []EmbeddingsInput` (polymorphic text/image/imageURI). Backwards-compat: empty `Inputs` falls back to existing `Texts`. No schema-version bump (additive).
- `7d4361c` (P) — `plugins/embeddings/openai/` rejects image inputs with a clear error pointing at `nexus.embeddings.cohere_multimodal`. Text-only path unchanged.
- `1f1bca0` (P) — `plugins/embeddings/cohere_multimodal/` adapter (Cohere Embed v3 `POST /v2/embed`). Mixed text + image batches; `nexus-blob:<sha>` URIs resolved via per-session blob store. Registered as opt-in (not in default `plugins.active`).
- `e0997e1` (P) — `plugins/memory/vector/` gains `store_images` (default false) + `image_namespace` config. When enabled, `UserInput` image parts are embedded via `EmbeddingsRequest.Inputs` and upserted into a separate namespace.
- `10c3b62` (P) — `docs/src/multimodal/native-realtime-deferred.md` documents deferral of native OpenAI Realtime + Gemini Multimodal Live (entire new wire protocols per provider; voice users go through Whisper → LLM → TTS until they land).

## Verification

- `make fmt` clean.
- `make vet` clean.
- `make test` — 72 packages ok, 0 fails. Integration tests not run (no live API keys).

## Explicitly out of scope

- **Native Realtime APIs** (OpenAI Realtime, Gemini Multimodal Live) — deferred to follow-up. Each is an entire new wire protocol separate from the standard Chat / Generate endpoints already wired. Documented in `docs/src/multimodal/native-realtime-deferred.md`.
- **Local-model voice bootstrap** (Whisper / Kokoro / Silero download UX) — tracked in #92. Voice plugin accepts local-provider config keys for forward-compat but rejects at Init.

## Notes

- Three subagents working in isolated git worktrees produced minor commit-message drift on Phase 2/3 (e.g. realtime register hunk landed in a `feat(web): ...` commit; web tool wired across two commits). The code itself is correct and tested. Squash-merge wipes the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
