### PR TITLE
build: disable CGO and strip symbols (~25% smaller binary)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,21 @@ BUILD_DIR=bin
 GO=go
 YAEGI_WASM=pkg/engine/sandbox/wasm/yaegi.wasm.gz
 
+# cmd/nexus has no CGO deps (modernc.org/sqlite + chromem-go are pure Go).
+# Disabling CGO + stripping symbols cuts binary ~25%. Desktop builds (Wails)
+# require CGO and use a separate build path, not this Makefile.
+CGO_ENABLED ?= 0
+export CGO_ENABLED
+BUILD_LDFLAGS=-s -w
+BUILD_FLAGS=-ldflags="$(BUILD_LDFLAGS)" -trimpath
+
 ifneq (,$(wildcard ./.env))
     include .env
     export
 endif
 
 build:
-	$(GO) build -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/nexus
+	$(GO) build $(BUILD_FLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/nexus
 
 run: build
 	$(BUILD_DIR)/$(BINARY_NAME) -config configs/default.yaml


### PR DESCRIPTION
## Summary
- `cmd/nexus` has no CGO dependencies (`modernc.org/sqlite` + `chromem-go` are pure Go), so set `CGO_ENABLED=0` and add `-ldflags=\"-s -w\" -trimpath` to the `build` target.
- Binary size: **~70MB → ~52MB** (~25% reduction), fully static.
- Wails desktop builds still require CGO and use a separate build path — unaffected.
- `CGO_ENABLED` is overridable via `make build CGO_ENABLED=1` if ever needed; strip flags only apply to `build` so `test`/`vet` keep debug info.

## Test plan
- [x] `make test` passes (full suite green)
- [x] `make build` produces `bin/nexus` at ~52MB, runs normally
- [x] `file bin/nexus` shows native executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)