### PR TITLE
feat(journal): filter core.tick from durable event log

### DIFF
--- a/configs/test-journal-exclude.yaml
+++ b/configs/test-journal-exclude.yaml
@@ -1,0 +1,60 @@
+# Test: journal exclusion of core.tick. Tick interval is set well below the
+# session lifetime so many heartbeats fire on the bus, all of which must be
+# suppressed from <session>/journal/events.jsonl while the on-disk seq
+# sequence stays gap-free.
+#
+# Mock mode (no API key required).
+#
+# Run:
+#   go test -tags integration ./tests/integration/ -run TestJournalExclude
+core:
+  log_level: warn
+  tick_interval: 100ms
+  max_concurrent_events: 100
+  models:
+    default: mock
+    mock:
+      provider: nexus.llm.anthropic
+      model: mock
+      max_tokens: 4096
+  sessions:
+    root: ~/.nexus/test-sessions
+    retention: 30d
+    id_format: datetime_short
+
+journal:
+  fsync: every-event
+  retain_days: 30
+  rotate_size_mb: 4
+  exclude_events:
+    - core.tick
+
+plugins:
+  active:
+    - nexus.io.test
+    - nexus.llm.anthropic
+    - nexus.agent.react
+    - nexus.memory.capped
+
+  nexus.io.test:
+    inputs:
+      - "first"
+      - "second"
+      - "third"
+    input_delay: 600ms
+    approval_mode: approve
+    timeout: 15s
+    mock_responses:
+      - content: "ok"
+      - content: "ok"
+      - content: "ok"
+
+  nexus.llm.anthropic:
+    api_key: "sk-mock-not-used"
+
+  nexus.agent.react:
+    system_prompt: "You are a test assistant."
+
+  nexus.memory.capped:
+    max_messages: 10
+    persist: false

--- a/docs/src/architecture/sessions.md
+++ b/docs/src/architecture/sessions.md
@@ -28,6 +28,15 @@ alongside every other event. Read them via
 `journal.Writer.SubscribeProjection` (live) or `journal.ProjectFile`
 (post-mortem).
 
+The journal records every bus event **except** the types listed in
+`journal.exclude_events` (default `["core.tick"]`). Excluded events
+still dispatch to bus subscribers — only the durable log skips them,
+and their seq is not consumed, so on-disk envelopes stay gap-free.
+The default suppresses the engine heartbeat, which replay regenerates
+from the live tick goroutine and which otel / eval already treat as
+noise. See [configuration reference](../configuration/reference.md#journal)
+for the full key.
+
 ## Session Metadata
 
 Each session tracks metadata in `metadata/session.json`:

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -266,13 +266,16 @@ journal:
   fsync: turn-boundary       # turn-boundary | every-event | none
   retain_days: 30
   rotate_size_mb: 4
+  exclude_events:            # event types the journal must not record
+    - core.tick
 ```
 
-| Key              | Type   | Default          | Description |
-|------------------|--------|------------------|-------------|
-| `fsync`          | string | `turn-boundary`  | Disk-flush policy. `turn-boundary` fsyncs once per `agent.turn.end` (good throughput, recovers to last completed turn). `every-event` fsyncs after every envelope (strongest crash guarantee). `none` skips explicit fsync (test-only). |
-| `retain_days`    | int    | `30`             | Age in days past which a session's journal directory is removed on engine boot. `0` disables sweeping. In-flight sessions are never touched. |
-| `rotate_size_mb` | int    | `4`              | Active segment size threshold (MiB). When `agent.turn.end` lands and the active segment exceeds this, it is compressed into `events-NNN.jsonl.zst` and the active segment is truncated. |
+| Key              | Type     | Default          | Description |
+|------------------|----------|------------------|-------------|
+| `fsync`          | string   | `turn-boundary`  | Disk-flush policy. `turn-boundary` fsyncs once per `agent.turn.end` (good throughput, recovers to last completed turn). `every-event` fsyncs after every envelope (strongest crash guarantee). `none` skips explicit fsync (test-only). |
+| `retain_days`    | int      | `30`             | Age in days past which a session's journal directory is removed on engine boot. `0` disables sweeping. In-flight sessions are never touched. |
+| `rotate_size_mb` | int      | `4`              | Active segment size threshold (MiB). When `agent.turn.end` lands and the active segment exceeds this, it is compressed into `events-NNN.jsonl.zst` and the active segment is truncated. |
+| `exclude_events` | []string | `["core.tick"]`  | Event types the journal must not record. Excluded events still dispatch to bus subscribers (otel, eval, custom plugins); only the durable log skips them, and their seq is not consumed so on-disk envelopes stay gap-free. Default suppresses the engine heartbeat. Set to `[]` to record everything. |
 
 ### Disk layout
 

--- a/pkg/engine/bus.go
+++ b/pkg/engine/bus.go
@@ -16,6 +16,17 @@ type SeqController interface {
 	SetSeqFloor(seq uint64)
 }
 
+// ExcludeController is implemented by buses that can suppress journal-bound
+// bookkeeping for high-frequency, low-value event types. The engine installs
+// the list from JournalConfig.ExcludeEvents during startJournal. Excluded
+// events still dispatch to typed and wildcard subscribers — only seq
+// assignment, dispatch-stack tracking, and replay-ring append are skipped,
+// which keeps the journal's on-disk envelope sequence gap-free.
+type ExcludeController interface {
+	SetExcludedTypes(types []string)
+	IsExcluded(eventType string) bool
+}
+
 // EventBus is the central event dispatch system.
 type EventBus interface {
 	// Emit dispatches an event to all matching handlers synchronously.
@@ -109,6 +120,11 @@ type eventBus struct {
 	// triggered it. The journal writer reads this via CurrentSeq.
 	seqCounter atomic.Uint64
 
+	// excludedTypes is the set of event types the journal must not record.
+	// Loaded atomically so the hot dispatch path is lock-free. nil pointer
+	// means no exclusions (a fresh bus before startJournal sets the list).
+	excludedTypes atomic.Pointer[map[string]struct{}]
+
 	// dispatchMu guards dispatchStacks. Held only briefly during push/pop;
 	// not the same lock as mu so dispatch stack reads don't contend with
 	// handler-snapshot reads.
@@ -197,6 +213,33 @@ func (b *eventBus) SetLogger(l *slog.Logger) {
 // traces rather than swallowing them.
 func (b *eventBus) SetFailFast(v bool) {
 	b.failFast = v
+}
+
+// SetExcludedTypes replaces the bus's journal-exclusion set. Excluded events
+// still dispatch to subscribers but skip seq assignment, dispatch-stack
+// tracking, and the replay ring. The engine calls this during startJournal
+// with JournalConfig.ExcludeEvents (defaults to ["core.tick"]).
+func (b *eventBus) SetExcludedTypes(types []string) {
+	if len(types) == 0 {
+		b.excludedTypes.Store(nil)
+		return
+	}
+	set := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		set[t] = struct{}{}
+	}
+	b.excludedTypes.Store(&set)
+}
+
+// IsExcluded reports whether the event type is currently in the journal-
+// exclusion set. Lock-free; safe from any goroutine.
+func (b *eventBus) IsExcluded(eventType string) bool {
+	set := b.excludedTypes.Load()
+	if set == nil {
+		return false
+	}
+	_, ok := (*set)[eventType]
+	return ok
 }
 
 // SetSeqFloor advances the dispatch seq counter to at least floor. No-op if
@@ -348,12 +391,20 @@ func (b *eventBus) EmitEvent(event Event[any]) error {
 	b.drainMu.Unlock()
 	defer b.inflight.Done()
 
-	// Assign the dispatch seq before any handler runs so the journal sees
-	// this event's seq in its causally-correct slot — a nested emit from a
-	// typed handler will see this seq as its ParentSeq.
-	seq := b.seqCounter.Add(1)
-	pop := b.pushDispatch(seq)
-	defer pop()
+	// Excluded events skip seq assignment, dispatch-stack tracking, and ring
+	// append. They still dispatch to typed and wildcard subscribers, so otel
+	// and other observers continue to see them — only the journal-bound
+	// bookkeeping is suppressed, which keeps the on-disk envelope sequence
+	// gap-free.
+	excluded := b.IsExcluded(event.Type)
+	if !excluded {
+		// Assign the dispatch seq before any handler runs so the journal
+		// sees this event's seq in its causally-correct slot — a nested
+		// emit from a typed handler will see this seq as its ParentSeq.
+		seq := b.seqCounter.Add(1)
+		pop := b.pushDispatch(seq)
+		defer pop()
+	}
 
 	meta := event.Meta()
 
@@ -363,7 +414,9 @@ func (b *eventBus) EmitEvent(event Event[any]) error {
 	// the replay snapshot (if it entered the ring before the subscriber was
 	// added to wildcards) or in live dispatch (if it was emitted after).
 	b.mu.Lock()
-	b.ring.append(event)
+	if !excluded {
+		b.ring.append(event)
+	}
 	typed := make([]*subscription, len(b.handlers[event.Type]))
 	copy(typed, b.handlers[event.Type])
 	wilds := make([]*subscription, len(b.wildcards))
@@ -402,9 +455,12 @@ func (b *eventBus) EmitVetoable(eventType string, payload any) (VetoResult, erro
 	b.drainMu.Unlock()
 	defer b.inflight.Done()
 
-	seq := b.seqCounter.Add(1)
-	pop := b.pushDispatch(seq)
-	defer pop()
+	excluded := b.IsExcluded(eventType)
+	if !excluded {
+		seq := b.seqCounter.Add(1)
+		pop := b.pushDispatch(seq)
+		defer pop()
+	}
 
 	// Wrap in VetoablePayload so handlers can set Veto via the shared pointer.
 	// Handlers receive the event by value, but VetoablePayload is a pointer —
@@ -419,7 +475,9 @@ func (b *eventBus) EmitVetoable(eventType string, payload any) (VetoResult, erro
 	meta := event.Meta()
 
 	b.mu.Lock()
-	b.ring.append(event)
+	if !excluded {
+		b.ring.append(event)
+	}
 	typed := make([]*subscription, len(b.handlers[eventType]))
 	copy(typed, b.handlers[eventType])
 	wilds := make([]*subscription, len(b.wildcards))

--- a/pkg/engine/bus_test.go
+++ b/pkg/engine/bus_test.go
@@ -283,3 +283,79 @@ func TestDrain_ConcurrentEmitsDoNotPanic(t *testing.T) {
 		t.Fatalf("final Drain: %v", err)
 	}
 }
+
+// TestBus_ExcludedTypeSkipsSeqAndRing verifies that an excluded event type
+// (the journal's core.tick filter) skips seq assignment, the replay ring,
+// and dispatch-stack tracking, while still being delivered to typed and
+// wildcard subscribers. This is the contract startJournal relies on to
+// keep on-disk envelopes gap-free.
+func TestBus_ExcludedTypeSkipsSeqAndRing(t *testing.T) {
+	bus := NewEventBus()
+	ec, ok := bus.(ExcludeController)
+	if !ok {
+		t.Fatal("eventBus does not implement ExcludeController")
+	}
+	ec.SetExcludedTypes([]string{"core.tick"})
+
+	seqSrc, ok := bus.(interface {
+		CurrentSeq() uint64
+		ParentSeq() uint64
+	})
+	if !ok {
+		t.Fatal("eventBus does not expose CurrentSeq/ParentSeq")
+	}
+
+	var wildcardSeen []string
+	var wildcardSeqs []uint64
+	bus.SubscribeAll(func(e Event[any]) {
+		wildcardSeen = append(wildcardSeen, e.Type)
+		wildcardSeqs = append(wildcardSeqs, seqSrc.CurrentSeq())
+	})
+
+	var tickHits int
+	bus.Subscribe("core.tick", func(e Event[any]) { tickHits++ })
+
+	// Interleave excluded and non-excluded events.
+	for _, evt := range []string{"core.tick", "foo", "core.tick", "bar", "baz", "core.tick"} {
+		if err := bus.Emit(evt, nil); err != nil {
+			t.Fatalf("emit %s: %v", evt, err)
+		}
+	}
+
+	// Wildcard must see every event (excluded events still dispatch).
+	if got, want := len(wildcardSeen), 6; got != want {
+		t.Fatalf("wildcard saw %d events, want %d (%v)", got, want, wildcardSeen)
+	}
+	// Typed subscribers for excluded types still fire.
+	if tickHits != 3 {
+		t.Fatalf("core.tick typed handler fired %d times, want 3", tickHits)
+	}
+
+	// During an excluded event's dispatch, CurrentSeq must be 0 (no
+	// dispatch-stack push). During a non-excluded event, CurrentSeq must
+	// be the bus-assigned monotonic seq starting at 1 with no gaps for
+	// the excluded ones.
+	wantSeqs := []uint64{0, 1, 0, 2, 3, 0}
+	if len(wildcardSeqs) != len(wantSeqs) {
+		t.Fatalf("seq count mismatch: got %v want %v", wildcardSeqs, wantSeqs)
+	}
+	for i, s := range wildcardSeqs {
+		if s != wantSeqs[i] {
+			t.Errorf("wildcard seq[%d] type=%s got %d want %d", i, wildcardSeen[i], s, wantSeqs[i])
+		}
+	}
+
+	// Clearing the exclusion list restores seq assignment.
+	ec.SetExcludedTypes(nil)
+	if ec.IsExcluded("core.tick") {
+		t.Fatal("IsExcluded(core.tick) still true after clearing")
+	}
+	wildcardSeqs = wildcardSeqs[:0]
+	wildcardSeen = wildcardSeen[:0]
+	if err := bus.Emit("core.tick", nil); err != nil {
+		t.Fatalf("emit after clear: %v", err)
+	}
+	if len(wildcardSeqs) != 1 || wildcardSeqs[0] != 4 {
+		t.Fatalf("after clear, expected seq 4 for core.tick; got %v", wildcardSeqs)
+	}
+}

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -95,6 +95,15 @@ type JournalConfig struct {
 	// active segment exceeds this many MiB. Rotated segments are
 	// zstd-compressed.
 	RotateSizeMB int `yaml:"rotate_size_mb"`
+	// ExcludeEvents lists event types that the journal must not record.
+	// Excluded events still dispatch to subscribers on the bus (so otel
+	// and other observers see them); they are simply skipped at the
+	// wildcard handler that feeds the durable log and their seq is not
+	// consumed, keeping on-disk envelopes contiguous. Default is
+	// ["core.tick"] — the engine heartbeat is high-frequency noise that
+	// replay regenerates from its own goroutine. Set to [] to disable
+	// exclusion entirely.
+	ExcludeEvents []string `yaml:"exclude_events"`
 }
 
 // CoreConfig holds engine-level settings.
@@ -180,9 +189,10 @@ func DefaultConfig() *Config {
 			Configs: make(map[string]map[string]any),
 		},
 		Journal: JournalConfig{
-			Fsync:        "turn-boundary",
-			RetainDays:   30,
-			RotateSizeMB: 4,
+			Fsync:         "turn-boundary",
+			RetainDays:    30,
+			RotateSizeMB:  4,
+			ExcludeEvents: []string{"core.tick"},
 		},
 	}
 }

--- a/pkg/engine/config_validation.go
+++ b/pkg/engine/config_validation.go
@@ -192,11 +192,21 @@ func validateEngineConfig(cfg *Config) *configValidationResult {
 		"plugins": map[string]any{
 			"active": cfg.Plugins.Active,
 		},
-		"journal": map[string]any{
-			"fsync":          cfg.Journal.Fsync,
-			"retain_days":    cfg.Journal.RetainDays,
-			"rotate_size_mb": cfg.Journal.RotateSizeMB,
-		},
+		"journal": func() map[string]any {
+			m := map[string]any{
+				"fsync":          cfg.Journal.Fsync,
+				"retain_days":    cfg.Journal.RetainDays,
+				"rotate_size_mb": cfg.Journal.RotateSizeMB,
+			}
+			// Only include exclude_events when non-empty so configs built
+			// in tests (without DefaultConfig) don't get a nil slice
+			// marshaled as JSON null and rejected by the schema's array
+			// constraint.
+			if len(cfg.Journal.ExcludeEvents) > 0 {
+				m["exclude_events"] = cfg.Journal.ExcludeEvents
+			}
+			return m
+		}(),
 	}
 	if cfg.Core.ModelsRaw != nil {
 		top["core"].(map[string]any)["models"] = cfg.Core.ModelsRaw

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -748,6 +748,16 @@ func (e *Engine) startJournal() error {
 	e.Journal = w
 	e.Lifecycle.journal = w
 
+	// Install the journal-exclusion set on the bus so excluded events skip
+	// seq assignment + ring append. Without this the wildcard handler below
+	// would still see them (we double-check via excluder.IsExcluded) but
+	// the on-disk seq sequence would have phantom gaps.
+	var excluder ExcludeController
+	if ec, ok := e.Bus.(ExcludeController); ok {
+		ec.SetExcludedTypes(e.Config.Journal.ExcludeEvents)
+		excluder = ec
+	}
+
 	// Tool result cache: args-keyed disk cache rooted at journal/cache/.
 	// Bus subscriptions auto-populate it on every tool.invoke / tool.result
 	// pair, so live tools require no per-plugin wiring. Replay short-
@@ -760,7 +770,13 @@ func (e *Engine) startJournal() error {
 	// Wildcard handler builds an envelope for every dispatched event. Seq
 	// + ParentSeq are pulled from the bus's per-goroutine dispatch stack
 	// (assigned at EmitEvent / EmitVetoable entry, before typed handlers).
+	// Excluded events short-circuit here as defense-in-depth — the bus
+	// already skipped their seq assignment, so an envelope built from
+	// CurrentSeq() would carry seq=0 and corrupt the on-disk stream.
 	unsub := e.Bus.SubscribeAll(func(ev Event[any]) {
+		if excluder != nil && excluder.IsExcluded(ev.Type) {
+			return
+		}
 		env := buildEnvelope(ev, bus.CurrentSeq(), bus.ParentSeq())
 		w.Append(env)
 	})

--- a/pkg/engine/engine_schema.json
+++ b/pkg/engine/engine_schema.json
@@ -118,7 +118,12 @@
           "description": "Disk-flush policy for the durable journal."
         },
         "retain_days":    {"type": "integer", "minimum": 0},
-        "rotate_size_mb": {"type": "integer", "minimum": 0}
+        "rotate_size_mb": {"type": "integer", "minimum": 0},
+        "exclude_events": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Event types the journal must not record. Bus still dispatches them to subscribers; only durable logging is suppressed. Defaults to [\"core.tick\"]. Set to [] to disable exclusion entirely."
+        }
       }
     }
   }

--- a/tests/integration/journal_basic_test.go
+++ b/tests/integration/journal_basic_test.go
@@ -98,6 +98,15 @@ func TestJournalBasic_AllEventsRecorded(t *testing.T) {
 		t.Error("expected at least one vetoed=true envelope (before:llm.request) but found none")
 	}
 
+	// core.tick is filtered from the journal by default
+	// (JournalConfig.ExcludeEvents). Even though the engine heartbeat
+	// emits ticks on the bus, none should reach the durable log — and
+	// the seq monotonicity check above proves the bus-side seq elision
+	// keeps the on-disk sequence gap-free.
+	if counts["core.tick"] != 0 {
+		t.Errorf("expected 0 core.tick envelopes (excluded by default), got %d", counts["core.tick"])
+	}
+
 	// Header round-trip.
 	if h := r.Header(); h.SchemaVersion != journal.SchemaVersion {
 		t.Errorf("header schema_version=%q want %q", h.SchemaVersion, journal.SchemaVersion)

--- a/tests/integration/journal_exclude_test.go
+++ b/tests/integration/journal_exclude_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/frankbardon/nexus/pkg/engine/journal"
+	"github.com/frankbardon/nexus/pkg/testharness"
+)
+
+// TestJournalExclude_CoreTickSuppressed runs a multi-turn dialogue with the
+// engine heartbeat firing every 100ms. The journal must contain zero
+// core.tick envelopes and the on-disk seq sequence must remain gap-free,
+// proving the bus-side seq elision keeps the writer's reorder buffer happy
+// even when the suppressed event type interleaves heavily with normal
+// dispatch.
+func TestJournalExclude_CoreTickSuppressed(t *testing.T) {
+	h := testharness.New(t, "configs/test-journal-exclude.yaml",
+		testharness.WithTimeout(20*time.Second),
+		testharness.WithKeepSession(),
+	)
+	h.Run()
+
+	sessionDir := h.SessionDir()
+	if sessionDir == "" {
+		t.Fatal("no session dir")
+	}
+	t.Cleanup(func() { os.RemoveAll(sessionDir) })
+	journalDir := filepath.Join(sessionDir, "journal")
+
+	r, err := journal.Open(journalDir)
+	if err != nil {
+		t.Fatalf("open journal at %s: %v", journalDir, err)
+	}
+
+	var envs []journal.Envelope
+	if err := r.Iter(func(e journal.Envelope) bool {
+		envs = append(envs, e)
+		return true
+	}); err != nil {
+		t.Fatalf("iter journal: %v", err)
+	}
+	if len(envs) == 0 {
+		t.Fatal("journal is empty")
+	}
+
+	for i, env := range envs {
+		want := uint64(i + 1)
+		if env.Seq != want {
+			t.Errorf("seq gap at pos %d: got %d want %d (type=%s) — exclusion broke contiguity",
+				i, env.Seq, want, env.Type)
+		}
+	}
+
+	for _, env := range envs {
+		if env.Type == "core.tick" {
+			t.Fatalf("core.tick envelope leaked into journal (seq=%d)", env.Seq)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Filter `core.tick` from the durable journal — every 5s heartbeat no longer bloats `events.jsonl`.
- New `journal.exclude_events` config (default `["core.tick"]`). Excluded events still dispatch to bus subscribers; only the durable log + seq counter + replay ring skip them, so on-disk envelopes stay gap-free without any reorder-buffer change.
- Defense-in-depth: the wildcard journal handler also checks `IsExcluded` so a stray emit can't write a `seq=0` envelope.
- Replay path unchanged — the live tick goroutine regenerates ticks during a replay run.

Closes #101

## Files
- `pkg/engine/bus.go` — `ExcludeController` interface, atomic excluded-types set, seq/ring/dispatch-stack elision in `EmitEvent` and `EmitVetoable`.
- `pkg/engine/engine.go` — `startJournal` installs the exclusion list and guards the wildcard handler.
- `pkg/engine/config.go` + `engine_schema.json` + `config_validation.go` — `JournalConfig.ExcludeEvents` plumbing and schema.
- `pkg/engine/bus_test.go` — unit test that excluded events skip seq + ring while still dispatching.
- `tests/integration/journal_exclude_test.go` + `configs/test-journal-exclude.yaml` — 100 ms-tick session, asserts zero `core.tick` envelopes and gap-free seq.
- `tests/integration/journal_basic_test.go` — added `counts["core.tick"] == 0` assertion.
- `docs/src/configuration/reference.md` + `docs/src/architecture/sessions.md` — new key documented (per CLAUDE.md rule).

## Test plan
- [x] `go test ./pkg/engine/...`
- [x] `go test -tags integration ./tests/integration/ -run Journal` (8/8 pass, including new `TestJournalExclude_CoreTickSuppressed`)
- [x] `go test -tags integration ./tests/integration/` (only failure is pre-existing `TestWebSearch_AnthropicNative` semantic-assertion flake, unrelated)
- [x] `make build`
- [ ] Manual: `bin/nexus -config configs/default.yaml` for ~30 s, `jq '.type' ~/.nexus/sessions/<latest>/journal/events.jsonl | sort -u` shows no `core.tick`

🤖 Generated with [Claude Code](https://claude.com/claude-code)