### PR TITLE
refactor(shell): remove deprecated top-level sandbox config keys

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -53,7 +53,7 @@ The `configs/` directory holds two kinds of YAML profiles, distinguished by file
 
 | Plugin | ID | Key Config |
 |--------|----|------------|
-| Shell | `nexus.tool.shell` | `allowed_commands` ([]string), `timeout` (default `30s`), `sandbox` (default `false`) |
+| Shell | `nexus.tool.shell` | `timeout` (default `30s`), `sandbox.allowed_commands` ([]string), `sandbox.env_restrict`, `sandbox.path_dirs` |
 | File IO | `nexus.tool.file` | `base_dir`, `allow_external_writes` (default `false`), `tools` map (`read_file`, `write_file`, `check_file_size`, `list_files` — all default `true`) |
 
 ### Memory

--- a/configs/demo-approval-policy.yaml
+++ b/configs/demo-approval-policy.yaml
@@ -87,9 +87,10 @@ plugins:
       vetoed, explain what was blocked and ask the user how to proceed.
 
   nexus.tool.shell:
-    allowed_commands: ["ls", "cat", "grep", "find", "rm", "mkdir", "touch", "echo"]
     timeout: 10s
-    sandbox: true
+    sandbox:
+      allowed_commands: ["ls", "cat", "grep", "find", "rm", "mkdir", "touch", "echo"]
+      env_restrict: true
 
   nexus.tool.file: {}
 

--- a/configs/demo-browser-orchestrator.yaml
+++ b/configs/demo-browser-orchestrator.yaml
@@ -98,9 +98,10 @@ plugins:
     max_iterations: 15
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat, grep, find]
     timeout: 15s
-    sandbox: true
+    sandbox:
+      allowed_commands: [ls, cat, grep, find]
+      env_restrict: true
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/demo-browser-tools.yaml
+++ b/configs/demo-browser-tools.yaml
@@ -82,9 +82,10 @@ plugins:
     max_iterations: 15
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat, grep, find, echo, pwd]
     timeout: 15s
-    sandbox: true
+    sandbox:
+      allowed_commands: [ls, cat, grep, find, echo, pwd]
+      env_restrict: true
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/demo-hitl-synthesizer.yaml
+++ b/configs/demo-hitl-synthesizer.yaml
@@ -91,9 +91,10 @@ plugins:
       vetoed, explain what was blocked and ask the user how to proceed.
 
   nexus.tool.shell:
-    allowed_commands: ["ls", "cat", "grep", "find", "rm", "mkdir", "touch", "echo"]
     timeout: 10s
-    sandbox: true
+    sandbox:
+      allowed_commands: ["ls", "cat", "grep", "find", "rm", "mkdir", "touch", "echo"]
+      env_restrict: true
 
   nexus.tool.file: {}
 

--- a/configs/demo-tool-result-clear.yaml
+++ b/configs/demo-tool-result-clear.yaml
@@ -75,5 +75,6 @@ plugins:
     drop_strategy: replace_with_envelope
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat, pwd, echo, head, wc, find]
     timeout: 10s
+    sandbox:
+      allowed_commands: [ls, cat, pwd, echo, head, wc, find]

--- a/configs/test-all-gates.yaml
+++ b/configs/test-all-gates.yaml
@@ -147,9 +147,10 @@ plugins:
     exclude: []
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat, echo, grep]
     timeout: 15s
-    sandbox: true
+    sandbox:
+      allowed_commands: [ls, cat, echo, grep]
+      env_restrict: true
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/test-code-exec.yaml
+++ b/configs/test-code-exec.yaml
@@ -55,9 +55,10 @@ plugins:
     system_prompt: "You are a test agent. Use tools when asked."
 
   nexus.tool.shell:
-    allowed_commands: ["echo"]
     timeout: 5s
-    sandbox: true
+    sandbox:
+      allowed_commands: ["echo"]
+      env_restrict: true
 
   nexus.tool.code_exec:
     timeout_seconds: 10

--- a/configs/test-kitchen-sink.yaml
+++ b/configs/test-kitchen-sink.yaml
@@ -91,9 +91,10 @@ plugins:
     exclude: []
 
   nexus.tool.shell:
-    allowed_commands: [echo]
     timeout: 10s
-    sandbox: true
+    sandbox:
+      allowed_commands: [echo]
+      env_restrict: true
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/test-static-plan-approval.yaml
+++ b/configs/test-static-plan-approval.yaml
@@ -64,9 +64,10 @@ plugins:
     max_iterations: 5
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat, grep, find]
     timeout: 15s
-    sandbox: true
+    sandbox:
+      allowed_commands: [ls, cat, grep, find]
+      env_restrict: true
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/test-tool-choice-cross-provider-anthropic.yaml
+++ b/configs/test-tool-choice-cross-provider-anthropic.yaml
@@ -66,9 +66,10 @@ plugins:
     max_iterations: 5
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat, grep, find]
     timeout: 15s
-    sandbox: true
+    sandbox:
+      allowed_commands: [ls, cat, grep, find]
+      env_restrict: true
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/test-tool-choice-cross-provider-openai.yaml
+++ b/configs/test-tool-choice-cross-provider-openai.yaml
@@ -66,9 +66,10 @@ plugins:
     max_iterations: 5
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat, grep, find]
     timeout: 15s
-    sandbox: true
+    sandbox:
+      allowed_commands: [ls, cat, grep, find]
+      env_restrict: true
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/test-tool-choice.yaml
+++ b/configs/test-tool-choice.yaml
@@ -67,9 +67,10 @@ plugins:
     max_iterations: 5
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat, grep, find]
     timeout: 15s
-    sandbox: true
+    sandbox:
+      allowed_commands: [ls, cat, grep, find]
+      env_restrict: true
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/test-tool-filter.yaml
+++ b/configs/test-tool-filter.yaml
@@ -60,8 +60,9 @@ plugins:
     include: [read_file, write_file, check_file_size, list_files]
 
   nexus.tool.shell:
-    allowed_commands: [ls, cat]
     timeout: 15s
+    sandbox:
+      allowed_commands: [ls, cat]
 
   nexus.tool.file:
     allow_external_writes: false

--- a/configs/test-tool-result-clear.yaml
+++ b/configs/test-tool-result-clear.yaml
@@ -66,8 +66,9 @@ plugins:
     max_iterations: 4
 
   nexus.tool.shell:
-    allowed_commands: [echo]
     timeout: 5s
+    sandbox:
+      allowed_commands: [echo]
 
   nexus.memory.capped:
     max_messages: 50

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -665,11 +665,6 @@ Source: `plugins/tools/shell/plugin.go`. Routes commands through
 | `sandbox.env_restrict`     | bool | `false`                | Strip sensitive env vars (AWS, Google, Azure, Anthropic API keys) before execution. |
 | `sandbox.timeout`          | duration | `30s`              | Per-command default; `timeout` above wins per-call. |
 
-**Legacy keys** still accepted for backwards compatibility:
-`allowed_commands`, `path_dirs`, `sandbox: <bool>` at the top level are
-auto-shimmed into the equivalent `sandbox: { ... }` block. Documented as
-deprecated; removal targeted for the milestone after gVisor lands.
-
 ### `nexus.tool.file`
 
 Source: `plugins/tools/fileio/plugin.go`. Registers `read_file`, `write_file`,

--- a/docs/src/plugins/tools/shell.md
+++ b/docs/src/plugins/tools/shell.md
@@ -14,9 +14,13 @@ Executes shell commands in a controlled environment with optional command allowl
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `allowed_commands` | string[] | *(none)* | Whitelist of allowed command names. If empty, all commands are allowed. |
-| `timeout` | duration | `30s` | Maximum execution time per command |
-| `sandbox` | bool | `false` | Restrict environment variables when enabled |
+| `working_dir` | string | *(session files dir)* | Working directory for executions. |
+| `timeout` | duration | `30s` | Maximum execution time per command. |
+| `sandbox.backend` | string | `host` | Sandbox tier (`host`; future: `gvisor`, `firecracker`, `landlock`). |
+| `sandbox.allowed_commands` | string[] | *(none — all allowed)* | Whitelist of base command names. |
+| `sandbox.path_dirs` | string[] | *(none)* | Directories prepended to `PATH`. |
+| `sandbox.env_restrict` | bool | `false` | Strip sensitive env vars before execution. |
+| `sandbox.timeout` | duration | `30s` | Per-command default; top-level `timeout` wins per-call. |
 
 ## Tool Parameters
 
@@ -44,18 +48,19 @@ Executes shell commands in a controlled environment with optional command allowl
 
 ### Command Allowlist
 
-When `allowed_commands` is set, only commands whose base name matches the list are permitted:
+When `sandbox.allowed_commands` is set, only commands whose base name matches the list are permitted:
 
 ```yaml
 nexus.tool.shell:
-  allowed_commands: ["ls", "cat", "grep", "find", "git", "make"]
+  sandbox:
+    allowed_commands: ["ls", "cat", "grep", "find", "git", "make"]
 ```
 
 Attempting to run a command not in the list returns an error to the agent.
 
-### Sandbox Mode
+### Sandbox Environment Restriction
 
-When `sandbox: true`, the shell environment is restricted. This provides a basic layer of isolation.
+When `sandbox.env_restrict: true`, sensitive environment variables (AWS, Google, Azure, Anthropic API keys) are stripped before command execution.
 
 ### Command History
 
@@ -72,15 +77,17 @@ nexus.tool.shell:
 ### Coding assistant
 ```yaml
 nexus.tool.shell:
-  allowed_commands: ["go", "git", "ls", "cat", "grep", "find", "mkdir", "rm", "cp", "mv", "make", "docker", "npm", "cargo", "python"]
   timeout: 30s
-  sandbox: true
+  sandbox:
+    allowed_commands: ["go", "git", "ls", "cat", "grep", "find", "mkdir", "rm", "cp", "mv", "make", "docker", "npm", "cargo", "python"]
+    env_restrict: true
 ```
 
 ### Read-only exploration
 ```yaml
 nexus.tool.shell:
-  allowed_commands: ["ls", "cat", "grep", "find", "head", "tail", "wc"]
   timeout: 10s
-  sandbox: true
+  sandbox:
+    allowed_commands: ["ls", "cat", "grep", "find", "head", "tail", "wc"]
+    env_restrict: true
 ```

--- a/plugins/tools/shell/plugin.go
+++ b/plugins/tools/shell/plugin.go
@@ -75,17 +75,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.timeout = d
 	}
 
-	// Backwards-compatible legacy config: when the plugin has no `sandbox:`
-	// block but does have any of `allowed_commands`, `path_dirs`, or
-	// `sandbox: <bool>`, synthesise an equivalent host-backend config and
-	// replace the engine-supplied default sandbox. Documented as deprecated;
-	// removal targeted for the milestone after gVisor lands.
-	if needsLegacyShim(ctx.Config) {
-		shim, err := buildLegacyShim(ctx.Config)
-		if err != nil {
-			return err
-		}
-		p.sandbox = shim
+	if err := rejectLegacyKeys(ctx.Config); err != nil {
+		return err
 	}
 
 	p.unsubs = append(p.unsubs,
@@ -96,58 +87,23 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	return nil
 }
 
-// needsLegacyShim reports whether the plugin config carries pre-Sandbox keys
-// (`allowed_commands`, `path_dirs`, top-level `sandbox: <bool>`). A new
-// `sandbox:` map block opts back into the structured path even if the legacy
-// keys are also present, since callers that bothered to write the new block
-// are unambiguously asking for it.
-func needsLegacyShim(cfg map[string]any) bool {
+// rejectLegacyKeys fails fast on configs that still use the pre-Sandbox
+// top-level keys. The previous shim auto-translated them; it was removed in
+// favour of a single nested `sandbox:` shape.
+func rejectLegacyKeys(cfg map[string]any) error {
 	if cfg == nil {
-		return false
-	}
-	if _, ok := cfg["sandbox"].(map[string]any); ok {
-		return false
+		return nil
 	}
 	if _, ok := cfg["allowed_commands"]; ok {
-		return true
+		return fmt.Errorf("shell: top-level `allowed_commands` is no longer supported — move it under `sandbox.allowed_commands`")
 	}
 	if _, ok := cfg["path_dirs"]; ok {
-		return true
+		return fmt.Errorf("shell: top-level `path_dirs` is no longer supported — move it under `sandbox.path_dirs`")
 	}
 	if _, ok := cfg["sandbox"].(bool); ok {
-		return true
+		return fmt.Errorf("shell: `sandbox: <bool>` shorthand is no longer supported — use `sandbox: { env_restrict: <bool> }`")
 	}
-	return false
-}
-
-// buildLegacyShim translates the deprecated top-level keys into a host
-// backend so existing configs keep working without the new sandbox block.
-func buildLegacyShim(cfg map[string]any) (sandbox.Sandbox, error) {
-	block := map[string]any{}
-	if v, ok := cfg["allowed_commands"]; ok {
-		block["allowed_commands"] = v
-	}
-	if v, ok := cfg["path_dirs"]; ok {
-		// path_dirs in the legacy shape are pre-expansion strings — pass
-		// through; the host backend doesn't expand, the caller does.
-		raw, ok := v.([]any)
-		if ok {
-			expanded := make([]any, 0, len(raw))
-			for _, entry := range raw {
-				if s, ok := entry.(string); ok {
-					expanded = append(expanded, engine.ExpandPath(s))
-				}
-			}
-			block["path_dirs"] = expanded
-		}
-	}
-	if v, ok := cfg["sandbox"].(bool); ok {
-		block["env_restrict"] = v
-	}
-	if ts, ok := cfg["timeout"].(string); ok {
-		block["timeout"] = ts
-	}
-	return sandbox.New(sandbox.BackendHost, block)
+	return nil
 }
 
 func (p *Plugin) Ready() error {

--- a/plugins/tools/shell/schema.json
+++ b/plugins/tools/shell/schema.json
@@ -8,33 +8,16 @@
     "working_dir": {"type": "string", "description": "Working directory for executions."},
     "timeout":     {"type": "string", "description": "Per-command timeout (Go duration)."},
     "sandbox": {
-      "description": "Sandbox configuration block. Boolean form is a deprecated env-restrict shorthand.",
-      "oneOf": [
-        {"type": "boolean"},
-        {
-          "type": "object",
-          "additionalProperties": true,
-          "properties": {
-            "backend":          {"type": "string"},
-            "allowed_commands": {"type": "array", "items": {"type": "string"}},
-            "path_dirs":        {"type": "array", "items": {"type": "string"}},
-            "env_restrict":     {"type": "boolean"},
-            "timeout":          {"type": "string"}
-          }
-        }
-      ]
-    },
-    "allowed_commands": {
-      "type": "array",
-      "items": {"type": "string"},
-      "deprecated": true,
-      "description": "Deprecated: use sandbox.allowed_commands instead."
-    },
-    "path_dirs": {
-      "type": "array",
-      "items": {"type": "string"},
-      "deprecated": true,
-      "description": "Deprecated: use sandbox.path_dirs instead."
+      "type": "object",
+      "description": "Sandbox configuration block.",
+      "additionalProperties": true,
+      "properties": {
+        "backend":          {"type": "string"},
+        "allowed_commands": {"type": "array", "items": {"type": "string"}},
+        "path_dirs":        {"type": "array", "items": {"type": "string"}},
+        "env_restrict":     {"type": "boolean"},
+        "timeout":          {"type": "string"}
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Removes the legacy shim in `plugins/tools/shell/plugin.go` that auto-translated top-level `allowed_commands`, `path_dirs`, and boolean `sandbox` into the structured `sandbox: { ... }` block.
- Replaces it with a fail-fast `rejectLegacyKeys` check so old configs get a clear migration error at Init rather than being silently shimmed.
- Trims the schema (`plugins/tools/shell/schema.json`) to a single nested sandbox object — drops the deprecated top-level entries and the boolean form.
- Migrates all 14 bundled configs and `configs/README.md` to the nested `sandbox.allowed_commands` shape (and `sandbox.env_restrict: true` where the old `sandbox: true` shorthand was used).
- Updates `docs/src/plugins/tools/shell.md` examples to the new shape and removes the "Legacy keys" paragraph from the canonical `docs/src/configuration/reference.md`.

Closes #104.

## Test plan

- [x] `make fmt`
- [x] `make vet`
- [x] `make test` (all packages green; `plugins/tools/shell` ran fresh, not cached)
- [x] `make build`
- [x] Smoke a config that still uses the old top-level keys and confirm the error message points at the right replacement key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)