### PR TITLE
refactor(config): use model_role everywhere; drop raw model-name keys

### DIFF
--- a/cmd/demo/config-drafter.yaml
+++ b/cmd/demo/config-drafter.yaml
@@ -200,7 +200,7 @@ plugins:
       enabled: true
 
   nexus.control.hitl_synthesizer:
-    model: balanced
+    model_role: balanced
     cache_enabled: true
 
   # tool_timeout: file_write should be near-instant; surface anything

--- a/cmd/demo/config-engineer.yaml
+++ b/cmd/demo/config-engineer.yaml
@@ -270,7 +270,7 @@ plugins:
       enabled: true
 
   nexus.control.hitl_synthesizer:
-    model: balanced
+    model_role: balanced
     cache_enabled: true
 
   # ─── Gates ───────────────────────────────────────────────────────────

--- a/cmd/demo/config-librarian.yaml
+++ b/cmd/demo/config-librarian.yaml
@@ -206,7 +206,7 @@ plugins:
   # role. Cache the result so an identical action signature within a
   # session doesn't pay the LLM cost twice.
   nexus.control.hitl_synthesizer:
-    model: balanced
+    model_role: balanced
     cache_enabled: true
 
   # tool_timeout: any tool call exceeding this default is aborted. The

--- a/cmd/demo/config-multimodal.yaml
+++ b/cmd/demo/config-multimodal.yaml
@@ -230,7 +230,7 @@ plugins:
     registry:
       enabled: true
   nexus.control.hitl_synthesizer:
-    model: balanced
+    model_role: balanced
     cache_enabled: true
 
   # ─── Gates ───────────────────────────────────────────────────────────

--- a/cmd/demo/config-orchestrator.yaml
+++ b/cmd/demo/config-orchestrator.yaml
@@ -306,7 +306,7 @@ plugins:
     registry:
       enabled: true
   nexus.control.hitl_synthesizer:
-    model: balanced
+    model_role: balanced
     cache_enabled: true
 
   # ─── Gates ───────────────────────────────────────────────────────────

--- a/cmd/demo/config-researcher.yaml
+++ b/cmd/demo/config-researcher.yaml
@@ -34,6 +34,10 @@ core:
   # provider.fallback event.
   models:
     default: balanced
+    quick:
+      provider: nexus.llm.anthropic
+      model: claude-haiku-4-5-20251001
+      max_tokens: 4096
     balanced:
       - provider: nexus.llm.anthropic
         model: claude-sonnet-4-6
@@ -41,6 +45,10 @@ core:
       - provider: nexus.llm.openai
         model: gpt-4o
         max_tokens: 8192
+    reasoning:
+      provider: nexus.llm.anthropic
+      model: claude-opus-4-7
+      max_tokens: 8192
 
   sessions:
     root: ~/.nexus/demo/sessions
@@ -279,7 +287,6 @@ plugins:
     rrf_k: 60
     retrieve_k: 50
     fuse_to: 20
-    embedding_model: text-embedding-3-small
     reranker:
       enabled: true
 
@@ -334,12 +341,12 @@ plugins:
   # That's the right outcome — these are different demos exercised
   # independently.
   nexus.router.classifier:
-    classifier_model: claude-haiku-4-5-20251001
-    candidates:
-      - claude-haiku-4-5-20251001
-      - claude-sonnet-4-6
-      - claude-opus-4-7
-    fallback: claude-sonnet-4-6
+    classifier_role: quick
+    candidate_roles:
+      - quick
+      - balanced
+      - reasoning
+    fallback_role: balanced
     prefix_chars: 256
     latency_budget_ms: 800
     cache_classification: true
@@ -366,7 +373,7 @@ plugins:
   # is itself a fallback chain — see core.models above). The synthesizer's
   # questions are short enough that the chain rarely hits its fallback.
   nexus.control.hitl_synthesizer:
-    model: balanced
+    model_role: balanced
     cache_enabled: true
 
   # tool_timeout: web_fetch can be very slow on heavy pages, so it gets a

--- a/cmd/demo/recipe-browser-ui.yaml
+++ b/cmd/demo/recipe-browser-ui.yaml
@@ -94,7 +94,6 @@ plugins:
     fusion: rrf
     retrieve_k: 40
     fuse_to: 15
-    embedding_model: text-embedding-3-small
     reranker:
       enabled: true
 

--- a/cmd/demo/recipe-tui.yaml
+++ b/cmd/demo/recipe-tui.yaml
@@ -100,7 +100,6 @@ plugins:
     rrf_k: 60
     retrieve_k: 40
     fuse_to: 15
-    embedding_model: text-embedding-3-small
     reranker:
       enabled: true
 

--- a/configs/demo-hitl-synthesizer.yaml
+++ b/configs/demo-hitl-synthesizer.yaml
@@ -78,7 +78,7 @@ plugins:
       enabled: false
 
   nexus.control.hitl_synthesizer:
-    model: haiku                       # cheap; resolved via core.models
+    model_role: quick                  # cheap; resolved via core.models
     max_action_ref_chars: 1500
     cache_enabled: true
     fallback_prompt: "Approve action: {{.action_kind}}"

--- a/configs/demo-router-and-cost.yaml
+++ b/configs/demo-router-and-cost.yaml
@@ -133,12 +133,12 @@ plugins:
     default_model: claude-sonnet-4-6
 
   nexus.router.classifier:
-    classifier_model: claude-haiku-4-5-20251001
-    candidates:
-      - claude-haiku-4-5-20251001
-      - claude-sonnet-4-6
-      - claude-opus-4-7
-    fallback: claude-sonnet-4-6
+    classifier_role: quick
+    candidate_roles:
+      - quick
+      - balanced
+      - reasoning
+    fallback_role: balanced
     cache_classification: true
     cache_max_entries: 1024
     latency_budget_ms: 800

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -731,9 +731,12 @@ Source: `plugins/tools/knowledge_search/plugin.go`. Requires
 | `tool_name`          | string | `knowledge_search` | Name of the registered tool. |
 | `top_k`              | int    | `5`                | Default chunks to return (LLM may override; capped at 50). |
 | `include_metadata`   | bool   | `true`             | Include vector metadata alongside chunks. |
-| `embedding_model`    | string | *(none)*           | Override the default embedding model. |
 | `namespaces`         | list   | *(required)*       | Allowed vector store namespaces. |
 | `default_namespaces` | list   | *(required)*       | Namespaces searched when the LLM doesn't specify. |
+
+The active `embeddings.provider` plugin owns the model choice — there is
+no consumer-side override. Configure the model once on the provider
+plugin (e.g. `nexus.embeddings.openai.model`).
 
 ### `nexus.tool.pdf`
 
@@ -820,8 +823,7 @@ Synthesised prompts are cached on disk under
 
 | Key                    | Type   | Default                              | Description |
 |------------------------|--------|--------------------------------------|-------------|
-| `model`                | string | `haiku`                              | Model role (resolved via `core.models`) used for synthesis. |
-| `model_id`             | string | *(none)*                             | Explicit model ID; bypasses role lookup when set. |
+| `model_role`           | string | `quick`                              | Model role (resolved via `core.models`) used for synthesis. |
 | `max_action_ref_chars` | int    | `1500`                               | ActionRef truncation budget (in JSON characters) before sending to the model. |
 | `cache_enabled`        | bool   | `true`                               | Toggle the on-disk cache. Disable for debugging or strict-determinism runs. |
 | `fallback_prompt`      | string | `Approve action: {{.action_kind}}`   | Go `text/template` over `{action_kind, action_ref, requester_plugin, request_id}` used when synthesis fails. |
@@ -960,7 +962,6 @@ Source: `plugins/memory/vector/plugin.go`. Provides `memory.vector`. Requires
 | `namespace`             | string | `memory-{instanceID}`  | Vector store namespace. |
 | `top_k`                 | int    | `5`                    | Recalled matches per query. |
 | `min_similarity`        | float  | `0.0`                  | Minimum cosine similarity (0 disables filtering). |
-| `embedding_model`       | string | *(none)*               | Override the embedding model. |
 | `auto_store_compaction` | bool   | `true`                 | Store summaries when `memory.compacted` fires. |
 | `auto_store_user_input` | bool   | `false`                | Store user messages on every input (opt-in). |
 | `section_priority`      | int    | `45`                   | Priority of the recalled-memory section in the system prompt. |
@@ -1136,7 +1137,6 @@ results via Reciprocal Rank Fusion or weighted score combination.
 | `weights.lexical`  | float  | `0.3`   | Per-backend bias for `weighted` fusion. |
 | `retrieve_k`       | int    | `50`    | Per-backend candidate count gathered before fusion. |
 | `fuse_to`          | int    | `20`    | Default post-fusion top-N when the caller does not specify K. |
-| `embedding_model`  | string | *(provider default)* | Embedding model used when callers fire `hybrid.query` without a pre-embedded vector. |
 | `reranker.enabled` | bool   | `false` | Apply a post-fusion reranker pass via the `search.reranker` capability. Off by default — enable when a reranker provider is active and the latency budget allows. |
 
 Requires `embeddings.provider`, `vector.store`, and `search.lexical`. Per-query
@@ -1230,8 +1230,7 @@ and the `rag.ingest` event handler.
 | `watch[].glob`        | string | *(empty — match all)*    | Glob pattern for files to ingest. |
 | `watch[].namespace`   | string | *(required)*             | Vector store namespace. |
 | `contextual_retrieval.enabled`              | bool   | `false`                    | Per-chunk LLM-generated situating prefix (Anthropic contextual retrieval). Adds one LLM call per uncached chunk during ingest; ~49% reported recall improvement. Stored content stays the raw chunk; only the embed/lexical text is prefixed. |
-| `contextual_retrieval.model`                | string | *(role default)*           | Model role to use for prefix generation (e.g. `cheap`, `balanced`). Combined with `model_id` to override `core.models` at the call site. |
-| `contextual_retrieval.model_id`             | string | *(role default)*           | Concrete model identifier override. |
+| `contextual_retrieval.model_role`           | string | *(role default)*           | Model role used for prefix generation (resolved via `core.models`). |
 | `contextual_retrieval.max_chars_doc_window` | int    | `2000`                     | Max characters of surrounding document context handed to the LLM. |
 | `contextual_retrieval.max_chars_prefix`     | int    | `400`                      | Truncate generated prefix to this many characters before concatenation. |
 | `contextual_retrieval.timeout_ms`           | int    | `30000`                    | Per-call timeout. On timeout the prefix is dropped and the raw chunk is used. |
@@ -1563,22 +1562,22 @@ Each entry under `rules`:
 ### `nexus.router.classifier`
 
 Source: `plugins/router/classifier/plugin.go`. Small LLM judges the
-difficulty of the user's most recent prompt and picks one of `candidates`.
-The decision is cached by prompt-prefix hash (LRU). Cache hits route
-synchronously; misses route to `fallback` immediately and warm the cache
-asynchronously via a probe `llm.request` tagged `_source: nexus.router.classifier`.
+difficulty of the user's most recent prompt and picks one of
+`candidate_roles`. The decision is cached by prompt-prefix hash (LRU).
+Cache hits rewrite `LLMRequest.Role` synchronously; misses route to
+`fallback_role` immediately and warm the cache asynchronously via a
+probe `llm.request` tagged `_source: nexus.router.classifier`.
 
-| Key                    | Type   | Default     | Description |
-|------------------------|--------|-------------|-------------|
-| `classifier_model`     | string | *(one of)*  | Model id used for the classification probe. |
-| `classifier_role`      | string | *(one of)*  | Alternative to `classifier_model`. |
-| `candidates`           | list   | *(required)* | Cheapest-first list of model ids the classifier picks among. |
-| `fallback`             | string | *(none)*    | Model id used on cache miss while the cache warms. |
-| `prompt`               | string | *(default)* | Classifier prompt template (`%s` for candidates list and prompt). |
-| `prefix_chars`         | int    | `256`       | Number of leading prompt characters folded into the cache key. |
-| `cache_classification` | bool   | `true`      | Whether to cache decisions at all. |
-| `cache_max_entries`    | int    | `1024`      | LRU capacity. |
-| `latency_budget_ms`    | int    | `800`       | Drop the warm if the probe doesn't return within this window. |
+| Key                    | Type   | Default      | Description |
+|------------------------|--------|--------------|-------------|
+| `classifier_role`      | string | *(required)* | Model role (resolved via `core.models`) used for the classification probe. |
+| `candidate_roles`      | list   | *(required)* | Cheapest-first list of model roles the classifier picks among. |
+| `fallback_role`        | string | *(none)*     | Model role used on cache miss while the cache warms. |
+| `prompt`               | string | *(default)*  | Classifier prompt template (`%s` for the candidate-role list and prompt). |
+| `prefix_chars`         | int    | `256`        | Number of leading prompt characters folded into the cache key. |
+| `cache_classification` | bool   | `true`       | Whether to cache decisions at all. |
+| `cache_max_entries`    | int    | `1024`       | LRU capacity. |
+| `latency_budget_ms`    | int    | `800`        | Drop the warm if the probe doesn't return within this window. |
 
 ---
 

--- a/docs/src/guides/rag.md
+++ b/docs/src/guides/rag.md
@@ -256,7 +256,6 @@ nexus.tool.knowledge_search:
   default_namespaces: [kb]            # used when LLM omits the arg
   top_k: 5                            # default; LLM may override per-call up to maxTopK=50
   include_metadata: true              # whether to return raw metadata map
-  embedding_model: ""                 # optional pin; empty = provider default
 ```
 
 The system-prompt example in `configs/rag.yaml` nudges the LLM toward calling `knowledge_search` first on factual questions — adjust this prompt for your domain so the tool gets used at the right times. Without a hint, the LLM may try to answer from training data on questions you wanted grounded in the KB.
@@ -276,7 +275,6 @@ nexus.memory.vector:
   min_similarity: 0.3                       # filter out weak hits from the prompt
   auto_store_compaction: true               # auto-write summaries on memory.compacted
   auto_store_user_input: false              # off by default — you usually don't want this
-  embedding_model: ""                       # optional pin
   section_priority: 45                      # prompt ordering vs. other sections
 ```
 

--- a/docs/src/plugins/control/hitl_synthesizer.md
+++ b/docs/src/plugins/control/hitl_synthesizer.md
@@ -59,7 +59,7 @@ plugins:
     - nexus.control.hitl_synthesizer
 
 nexus.control.hitl_synthesizer:
-  model: haiku                       # resolved via core.models
+  model_role: quick                  # resolved via core.models
   max_action_ref_chars: 1500
   cache_enabled: true
   fallback_prompt: "Approve action: {{.action_kind}}"
@@ -67,8 +67,7 @@ nexus.control.hitl_synthesizer:
 
 | Key                    | Type   | Default                              | Description |
 |------------------------|--------|--------------------------------------|-------------|
-| `model`                | string | `haiku`                              | Model role used for synthesis (resolved via `core.models`). |
-| `model_id`             | string | *(none)*                             | Explicit model ID; bypasses role lookup when set. |
+| `model_role`           | string | `quick`                              | Model role used for synthesis (resolved via `core.models`). |
 | `max_action_ref_chars` | int    | `1500`                               | ActionRef truncation budget (in JSON characters). |
 | `cache_enabled`        | bool   | `true`                               | Persist successful synthesis results to `cache.jsonl`. |
 | `fallback_prompt`      | string | `Approve action: {{.action_kind}}`   | `text/template` used when synthesis fails. |

--- a/docs/src/plugins/memory/summary_buffer.md
+++ b/docs/src/plugins/memory/summary_buffer.md
@@ -33,7 +33,6 @@ summarised view is what the ReAct agent sees on the next request.
 | `chars_per_token` | float64 | `4.0` | Rough per-token char ratio for token estimation |
 | `max_recent` | int | `8` | Number of recent messages kept verbatim after summarisation |
 | `model_role` | string | `"quick"` | Role used to dispatch the summarisation LLM request |
-| `model` | string | `""` | Explicit model override; otherwise inferred from the role |
 | `prompt` | string | _built-in_ | Inline override of the summarisation system prompt. The default prompt is reasoning-preservation aware: it instructs the summariser to wrap segments in `<summary topic="…" compressed-from-turns="…">…</summary>` and end with a `## Preserved Kinds:` trailer. Overriding loses both behaviours. |
 | `prompt_file` | string | _unset_ | Path to a file containing the summarisation prompt (takes precedence over `prompt`) |
 | `quality_retry` | bool | `false` | Re-run the summariser once with a stricter prompt when the trailer omits any required preserved kind. Off by default for backwards compatibility. |

--- a/docs/src/plugins/memory/vector.md
+++ b/docs/src/plugins/memory/vector.md
@@ -30,7 +30,6 @@ nexus.memory.vector:
   # namespace: memory-default               # default: "memory-{InstanceID}"
   top_k: 5
   min_similarity: 0.3
-  embedding_model: ""                       # optional pin
   auto_store_compaction: true               # auto-write summaries on memory.compacted
   auto_store_user_input: false              # off by default; turning on makes every turn a memory
   section_priority: 45                      # PromptRegistry priority for the recalled-memory block
@@ -41,10 +40,13 @@ nexus.memory.vector:
 | `namespace` | string | `memory-{InstanceID}` | Vector store namespace for this agent. The default sanitizes the InstanceID for filesystem safety (`/` → `-`, `:` → `-`). Multi-agent desktop shells isolate automatically. |
 | `top_k` | int | `5` | Max hits queried per turn. |
 | `min_similarity` | float | `0.0` | Hits below this similarity are dropped from the prompt. `0` disables filtering. |
-| `embedding_model` | string | *(provider default)* | Pin a specific embedding model. Should match the model used to populate the namespace. |
 | `auto_store_compaction` | bool | `true` | Write the compaction summary on `memory.compacted`. |
 | `auto_store_user_input` | bool | `false` | Write every user message. Off by default — usually too noisy. |
 | `section_priority` | int | `45` | `PromptRegistry` priority. Higher numbers append later. |
+
+The active `embeddings.provider` plugin owns the model choice — set the
+embedding model on that plugin. The model used to populate a namespace
+must match the model used to query it.
 
 ## Behavior
 

--- a/docs/src/plugins/tools/knowledge_search.md
+++ b/docs/src/plugins/tools/knowledge_search.md
@@ -24,7 +24,6 @@ nexus.tool.knowledge_search:
   top_k: 5
   include_metadata: true
   # tool_name: knowledge_search       # rename the LLM-visible tool if you want
-  # embedding_model: ""               # pin a specific model; empty = provider default
 ```
 
 | Key | Type | Default | Description |
@@ -34,7 +33,10 @@ nexus.tool.knowledge_search:
 | `top_k` | int | `5` | Default max results. LLM may override per call up to `maxTopK = 50`. |
 | `include_metadata` | bool | `true` | Whether to return the full metadata map alongside structured fields. |
 | `tool_name` | string | `knowledge_search` | LLM-visible tool name. Override if it collides with another tool. |
-| `embedding_model` | string | *(empty)* | Pin a specific model; empty = use provider default. Should match the model used to ingest. |
+
+The active `embeddings.provider` plugin owns the model choice. Configure
+it on that plugin (e.g. `nexus.embeddings.openai.model`); the model used
+to ingest must match the model used to query.
 
 If `namespaces` is empty or unset, **boot fails** — the tool refuses to register without a defined allow-list.
 

--- a/pkg/engine/registry_test.go
+++ b/pkg/engine/registry_test.go
@@ -11,15 +11,15 @@ import (
 // occurs so the methods only need to satisfy the interface.
 type registryStub struct{ id string }
 
-func (r *registryStub) ID() string                          { return r.id }
-func (r *registryStub) Name() string                        { return r.id }
-func (r *registryStub) Version() string                     { return "test" }
-func (r *registryStub) Dependencies() []string              { return nil }
-func (r *registryStub) Requires() []Requirement             { return nil }
-func (r *registryStub) Capabilities() []Capability          { return nil }
-func (r *registryStub) Init(PluginContext) error            { return nil }
-func (r *registryStub) Ready() error                        { return nil }
-func (r *registryStub) Shutdown(context.Context) error      { return nil }
+func (r *registryStub) ID() string                         { return r.id }
+func (r *registryStub) Name() string                       { return r.id }
+func (r *registryStub) Version() string                    { return "test" }
+func (r *registryStub) Dependencies() []string             { return nil }
+func (r *registryStub) Requires() []Requirement            { return nil }
+func (r *registryStub) Capabilities() []Capability         { return nil }
+func (r *registryStub) Init(PluginContext) error           { return nil }
+func (r *registryStub) Ready() error                       { return nil }
+func (r *registryStub) Shutdown(context.Context) error     { return nil }
 func (r *registryStub) Subscriptions() []EventSubscription { return nil }
 func (r *registryStub) Emissions() []string                { return nil }
 

--- a/pkg/testharness/contract/contract_test.go
+++ b/pkg/testharness/contract/contract_test.go
@@ -21,12 +21,12 @@ type stubPlugin struct {
 
 func newStubPlugin() engine.Plugin { return &stubPlugin{echoTag: "ok"} }
 
-func (s *stubPlugin) ID() string                          { return "nexus.test.contract.stub" }
-func (s *stubPlugin) Name() string                        { return "Contract Stub" }
-func (s *stubPlugin) Version() string                     { return "0.1.0" }
-func (s *stubPlugin) Dependencies() []string              { return nil }
-func (s *stubPlugin) Requires() []engine.Requirement      { return nil }
-func (s *stubPlugin) Capabilities() []engine.Capability   { return nil }
+func (s *stubPlugin) ID() string                        { return "nexus.test.contract.stub" }
+func (s *stubPlugin) Name() string                      { return "Contract Stub" }
+func (s *stubPlugin) Version() string                   { return "0.1.0" }
+func (s *stubPlugin) Dependencies() []string            { return nil }
+func (s *stubPlugin) Requires() []engine.Requirement    { return nil }
+func (s *stubPlugin) Capabilities() []engine.Capability { return nil }
 func (s *stubPlugin) Subscriptions() []engine.EventSubscription {
 	return []engine.EventSubscription{{EventType: "stub.input"}}
 }
@@ -41,7 +41,7 @@ func (s *stubPlugin) Init(ctx engine.PluginContext) error {
 	}, engine.WithSource(s.ID())))
 	return nil
 }
-func (s *stubPlugin) Ready() error                  { return nil }
+func (s *stubPlugin) Ready() error { return nil }
 func (s *stubPlugin) Shutdown(_ context.Context) error {
 	for _, u := range s.unsubs {
 		u()
@@ -88,14 +88,16 @@ type leakyStub struct {
 	unsubs []func()
 }
 
-func (l *leakyStub) ID() string                                  { return "nexus.test.leaky" }
-func (l *leakyStub) Name() string                                { return "Leaky" }
-func (l *leakyStub) Version() string                             { return "0.1.0" }
-func (l *leakyStub) Dependencies() []string                      { return nil }
-func (l *leakyStub) Requires() []engine.Requirement              { return nil }
-func (l *leakyStub) Capabilities() []engine.Capability           { return nil }
-func (l *leakyStub) Subscriptions() []engine.EventSubscription   { return []engine.EventSubscription{{EventType: "stub.input"}} }
-func (l *leakyStub) Emissions() []string                         { return []string{"declared.only"} }
+func (l *leakyStub) ID() string                        { return "nexus.test.leaky" }
+func (l *leakyStub) Name() string                      { return "Leaky" }
+func (l *leakyStub) Version() string                   { return "0.1.0" }
+func (l *leakyStub) Dependencies() []string            { return nil }
+func (l *leakyStub) Requires() []engine.Requirement    { return nil }
+func (l *leakyStub) Capabilities() []engine.Capability { return nil }
+func (l *leakyStub) Subscriptions() []engine.EventSubscription {
+	return []engine.EventSubscription{{EventType: "stub.input"}}
+}
+func (l *leakyStub) Emissions() []string { return []string{"declared.only"} }
 func (l *leakyStub) Init(ctx engine.PluginContext) error {
 	l.bus = ctx.Bus
 	l.unsubs = append(l.unsubs, l.bus.Subscribe("stub.input", func(ev engine.Event[any]) {
@@ -103,7 +105,7 @@ func (l *leakyStub) Init(ctx engine.PluginContext) error {
 	}, engine.WithSource(l.ID())))
 	return nil
 }
-func (l *leakyStub) Ready() error                       { return nil }
+func (l *leakyStub) Ready() error { return nil }
 func (l *leakyStub) Shutdown(_ context.Context) error {
 	for _, u := range l.unsubs {
 		u()

--- a/plugins/agents/subagent/plugin.go
+++ b/plugins/agents/subagent/plugin.go
@@ -44,9 +44,10 @@ func New() engine.Plugin {
 	}
 }
 
-func (p *Plugin) ID() string                        { return p.instanceID }
-func (p *Plugin) Name() string                      { return pluginName }
-func (p *Plugin) Version() string                   { return version }
+func (p *Plugin) ID() string      { return p.instanceID }
+func (p *Plugin) Name() string    { return pluginName }
+func (p *Plugin) Version() string { return version }
+
 // Dependencies returns no plugins. Earlier versions of this plugin
 // declared a dependency on nexus.agent.react, but the runSubagent
 // loop manages its own LLM + tool dispatch directly via bus
@@ -60,7 +61,7 @@ func (p *Plugin) Version() string                   { return version }
 // subagent workers can still include nexus.agent.react in their
 // `plugins.active` list explicitly; that's now an opt-in choice,
 // not a side effect of using subagent.
-func (p *Plugin) Dependencies() []string { return nil }
+func (p *Plugin) Dependencies() []string            { return nil }
 func (p *Plugin) Requires() []engine.Requirement    { return nil }
 func (p *Plugin) Capabilities() []engine.Capability { return nil }
 

--- a/plugins/control/hitl_synthesizer/plugin.go
+++ b/plugins/control/hitl_synthesizer/plugin.go
@@ -74,7 +74,6 @@ type Plugin struct {
 	session *engine.SessionWorkspace
 
 	// Configuration.
-	model               string
 	modelRole           string
 	maxActionRefChars   int
 	cacheEnabled        bool
@@ -132,15 +131,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.cacheEnabled = true
 	p.fallbackTemplateRaw = defaultFallbackTemplate
 
-	if v, ok := ctx.Config["model"].(string); ok && v != "" {
-		// "model" can be a model role (resolved via core.models) or a
-		// raw model ID. The provider plugins handle either via
-		// LLMRequest.Role / LLMRequest.Model.
+	if v, ok := ctx.Config["model_role"].(string); ok && v != "" {
 		p.modelRole = v
-	}
-	if v, ok := ctx.Config["model_id"].(string); ok && v != "" {
-		// Optional override: explicit model ID, bypassing role lookup.
-		p.model = v
 	}
 	if v, ok := ctx.Config["max_action_ref_chars"].(int); ok && v > 0 {
 		p.maxActionRefChars = v
@@ -160,8 +152,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	}
 	p.fallbackTemplate = tmpl
 
-	if p.modelRole == "" && p.model == "" {
-		p.modelRole = "haiku"
+	if p.modelRole == "" {
+		p.modelRole = "quick"
 	}
 
 	if err := p.loadCache(); err != nil {
@@ -186,7 +178,6 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 
 	p.logger.Info("hitl prompt synthesizer initialized",
 		"model_role", p.modelRole,
-		"model", p.model,
 		"max_action_ref_chars", p.maxActionRefChars,
 		"cache_enabled", p.cacheEnabled,
 		"cache_entries", len(p.cache),
@@ -309,7 +300,6 @@ func (p *Plugin) synthesize(req *events.HITLRequest) (string, error) {
 	userMsg := buildUserPrompt(req, p.maxActionRefChars)
 
 	emitErr := p.bus.Emit("llm.request", events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: p.modelRole,
-		Model: p.model,
 		Messages: []events.Message{
 			{Role: "system", Content: systemMsg},
 			{Role: "user", Content: userMsg},

--- a/plugins/control/hitl_synthesizer/schema.json
+++ b/plugins/control/hitl_synthesizer/schema.json
@@ -5,8 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "model":                {"type": "string",  "description": "Model role from core.models used for question synthesis."},
-    "model_id":             {"type": "string",  "description": "Direct model ID override (bypasses role lookup)."},
+    "model_role":           {"type": "string",  "description": "Model role from core.models used for question synthesis."},
     "max_action_ref_chars": {"type": "integer", "minimum": 1, "description": "Cap on the action-reference text fed to the synthesizer."},
     "cache_enabled":        {"type": "boolean", "description": "Cache synthesized questions per action signature."},
     "fallback_prompt":      {"type": "string",  "description": "Go template used when the LLM call fails."}

--- a/plugins/io/oneshot/plugin.go
+++ b/plugins/io/oneshot/plugin.go
@@ -42,11 +42,11 @@ type Plugin struct {
 	readStdin  bool   // whether to read stdin when no other input source supplied
 
 	// State captured during the run
-	mu        sync.Mutex
-	startedAt time.Time
-	endedAt   time.Time
-	turnDepth int  // number of in-flight turns (start - end)
-	turnsSeen int  // total agent.turn.start events observed after input was sent
+	mu            sync.Mutex
+	startedAt     time.Time
+	endedAt       time.Time
+	turnDepth     int    // number of in-flight turns (start - end)
+	turnsSeen     int    // total agent.turn.start events observed after input was sent
 	inputSent     bool   // whether we have emitted the initial io.input
 	finalized     bool   // whether we have already flushed output + ended the session
 	pendingPrompt string // resolved prompt staged in Ready(), dispatched on core.ready

--- a/plugins/io/oneshot/plugin_test.go
+++ b/plugins/io/oneshot/plugin_test.go
@@ -35,9 +35,9 @@ func TestOneshot_DefersInputUntilCoreReady(t *testing.T) {
 	}))
 
 	var (
-		mu        sync.Mutex
-		inputs    []events.UserInput
-		gotInput  = make(chan struct{}, 1)
+		mu       sync.Mutex
+		inputs   []events.UserInput
+		gotInput = make(chan struct{}, 1)
 	)
 	h.Bus().Subscribe("io.input", func(ev engine.Event[any]) {
 		ui, ok := ev.Payload.(events.UserInput)

--- a/plugins/mcp/client/config.go
+++ b/plugins/mcp/client/config.go
@@ -63,11 +63,11 @@ type PromptConfig struct {
 
 // Defaults applied to every ServerConfig unless overridden inline.
 type Defaults struct {
-	Lifecycle       string
-	Timeout         time.Duration
-	Resources       ResourceConfig
-	Prompts         PromptConfig
-	CommandPrefix   string // slash prefix; default "mcp"
+	Lifecycle     string
+	Timeout       time.Duration
+	Resources     ResourceConfig
+	Prompts       PromptConfig
+	CommandPrefix string // slash prefix; default "mcp"
 }
 
 // parseConfig converts the raw YAML map into a typed Config. ${ENV_VAR}

--- a/plugins/mcp/client/config_test.go
+++ b/plugins/mcp/client/config_test.go
@@ -8,10 +8,10 @@ import (
 func TestParseConfig_DefaultsApplyToServer(t *testing.T) {
 	cfg, err := parseConfig(map[string]any{
 		"defaults": map[string]any{
-			"timeout":         "10s",
-			"lifecycle":       "session",
-			"command_prefix":  "x",
-			"resources":       map[string]any{"auto_register_max": 7},
+			"timeout":        "10s",
+			"lifecycle":      "session",
+			"command_prefix": "x",
+			"resources":      map[string]any{"auto_register_max": 7},
 		},
 		"servers": []any{
 			map[string]any{

--- a/plugins/mcp/client/prompts.go
+++ b/plugins/mcp/client/prompts.go
@@ -202,4 +202,3 @@ func (p *Plugin) handlePromptsListQuery(e engine.Event[any]) {
 	}
 	q.Prompts = p.listPrompts()
 }
-

--- a/plugins/memory/compaction/plugin.go
+++ b/plugins/memory/compaction/plugin.go
@@ -67,7 +67,6 @@ type Plugin struct {
 	turnThreshold    int     // for turn_count strategy
 	charsPerToken    float64 // rough estimate for token counting
 	modelRole        string
-	model            string
 	compactionPrompt string
 	protectRecent    int  // number of recent messages to keep verbatim
 	persist          bool // persist tracked messages + archives to session workspace
@@ -196,12 +195,9 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.charsPerToken = v
 	}
 
-	// Parse model configuration.
+	// Parse model role.
 	if mr, ok := ctx.Config["model_role"].(string); ok {
 		p.modelRole = mr
-	}
-	if m, ok := ctx.Config["model"].(string); ok {
-		p.model = m
 	}
 
 	// Parse compaction prompt (file takes precedence over inline).
@@ -598,7 +594,6 @@ func (p *Plugin) startCompaction(reason string) {
 	}
 
 	_ = p.bus.Emit("llm.request", events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: p.modelRole,
-		Model:    p.model,
 		Messages: messages,
 		Stream:   false,
 		Metadata: map[string]any{

--- a/plugins/memory/compaction/schema.json
+++ b/plugins/memory/compaction/schema.json
@@ -11,7 +11,6 @@
     "turn_threshold":    {"type": "integer", "minimum": 1},
     "chars_per_token":   {"type": "number", "minimum": 0},
     "model_role":        {"type": "string"},
-    "model":             {"type": "string"},
     "prompt":            {"type": "string"},
     "prompt_file":       {"type": "string"},
     "protect_recent":    {"type": "integer", "minimum": 0},

--- a/plugins/memory/summary_buffer/plugin.go
+++ b/plugins/memory/summary_buffer/plugin.go
@@ -91,7 +91,6 @@ type Plugin struct {
 	charsPerToken    float64
 	maxRecent        int
 	modelRole        string
-	model            string
 	summaryPrompt    string
 	// requirePreservedKinds enumerates Preserved-Kinds tags that must be
 	// reported by the summariser before adoption. When the trailer is
@@ -206,9 +205,6 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	}
 	if mr, ok := ctx.Config["model_role"].(string); ok {
 		p.modelRole = mr
-	}
-	if m, ok := ctx.Config["model"].(string); ok {
-		p.model = m
 	}
 
 	if promptFile, ok := ctx.Config["prompt_file"].(string); ok && promptFile != "" {
@@ -524,7 +520,6 @@ func (p *Plugin) triggerSummarisation(reason string) {
 	}
 
 	_ = p.bus.Emit("llm.request", events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: p.modelRole,
-		Model:    p.model,
 		Messages: messages,
 		Stream:   false,
 		Metadata: map[string]any{
@@ -664,7 +659,6 @@ func (p *Plugin) dispatchSummaryRetry(startTurn, endTurn int) {
 	}
 
 	_ = p.bus.Emit("llm.request", events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: p.modelRole,
-		Model:    p.model,
 		Messages: messages,
 		Stream:   false,
 		Metadata: map[string]any{

--- a/plugins/memory/summary_buffer/schema.json
+++ b/plugins/memory/summary_buffer/schema.json
@@ -12,7 +12,6 @@
     "chars_per_token":   {"type": "number", "minimum": 0},
     "max_recent":        {"type": "integer", "minimum": 0, "description": "Messages kept verbatim; older messages are summarized."},
     "model_role":        {"type": "string"},
-    "model":             {"type": "string"},
     "prompt":            {"type": "string"},
     "prompt_file":       {"type": "string"},
     "quality_retry":     {"type": "boolean", "description": "When true, re-run the summariser once with a stricter prompt if the trailer omits any required preserved kind. Default false (backwards-compatible)."},

--- a/plugins/memory/vector/plugin.go
+++ b/plugins/memory/vector/plugin.go
@@ -52,7 +52,6 @@ type Plugin struct {
 	namespace           string
 	topK                int
 	minSimilarity       float32
-	embeddingModel      string
 	autoStoreCompaction bool
 	autoStoreUserInput  bool // default false — conservative
 	storeImages         bool // default false — opt-in; only useful when a multimodal embeddings.provider is active
@@ -127,9 +126,6 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	}
 	if v, ok := ctx.Config["min_similarity"].(float64); ok {
 		p.minSimilarity = float32(v)
-	}
-	if v, ok := ctx.Config["embedding_model"].(string); ok {
-		p.embeddingModel = v
 	}
 	if v, ok := ctx.Config["auto_store_compaction"].(bool); ok {
 		p.autoStoreCompaction = v
@@ -279,7 +275,6 @@ func (p *Plugin) storeImageAttachments(in events.UserInput) {
 		}
 		req := &events.EmbeddingsRequest{
 			SchemaVersion: events.EmbeddingsRequestVersion,
-			Model:         p.embeddingModel,
 			Inputs: []events.EmbeddingsInput{{
 				Image:    f.Data,
 				MimeType: f.MimeType,
@@ -501,7 +496,7 @@ func (p *Plugin) storeDoc(content, source string, extra map[string]string, vec [
 
 // embedOne embeds a single string via the embeddings.provider capability.
 func (p *Plugin) embedOne(text string) ([]float32, error) {
-	req := &events.EmbeddingsRequest{SchemaVersion: events.EmbeddingsRequestVersion, Texts: []string{text}, Model: p.embeddingModel}
+	req := &events.EmbeddingsRequest{SchemaVersion: events.EmbeddingsRequestVersion, Texts: []string{text}}
 	_ = p.bus.Emit("embeddings.request", req)
 	if req.Error != "" {
 		return nil, fmt.Errorf("embed: %s", req.Error)

--- a/plugins/memory/vector/schema.json
+++ b/plugins/memory/vector/schema.json
@@ -8,7 +8,6 @@
     "namespace":             {"type": "string"},
     "top_k":                 {"type": "integer", "minimum": 1},
     "min_similarity":        {"type": "number", "minimum": 0, "maximum": 1},
-    "embedding_model":       {"type": "string"},
     "auto_store_compaction": {"type": "boolean"},
     "auto_store_user_input": {"type": "boolean"},
     "section_priority":      {"type": "integer"},

--- a/plugins/planners/dynamic/plugin.go
+++ b/plugins/planners/dynamic/plugin.go
@@ -49,8 +49,7 @@ type Plugin struct {
 
 	approval   approvalMode
 	planPrompt string
-	model      string // Explicit model ID override (backward compat)
-	modelRole  string // Model role for role-based selection
+	modelRole  string
 	maxSteps   int
 
 	mu             sync.Mutex
@@ -104,12 +103,8 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.planPrompt = prompt
 	}
 
-	// Parse model role (preferred) or explicit model override (backward compat).
 	if mr, ok := ctx.Config["model_role"].(string); ok {
 		p.modelRole = mr
-	}
-	if m, ok := ctx.Config["model"].(string); ok {
-		p.model = m
 	}
 
 	// Parse max steps.
@@ -129,7 +124,7 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 			engine.WithPriority(50), engine.WithSource(pluginID)),
 	)
 
-	p.logger.Info("dynamic planner initialized", "approval", p.approval, "model_role", p.modelRole, "model", p.model)
+	p.logger.Info("dynamic planner initialized", "approval", p.approval, "model_role", p.modelRole)
 	return nil
 }
 
@@ -233,7 +228,6 @@ func (p *Plugin) handlePlanRequest(req events.PlanRequest) {
 
 	// Emit LLM request tagged for this plugin.
 	llmReq := events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: p.modelRole,
-		Model:    p.model,
 		Messages: messages,
 		Stream:   false,
 		Metadata: map[string]any{

--- a/plugins/planners/dynamic/schema.json
+++ b/plugins/planners/dynamic/schema.json
@@ -9,7 +9,6 @@
     "plan_prompt":      {"type": "string", "description": "Inline plan prompt template."},
     "plan_prompt_file": {"type": "string", "description": "Path to a file containing the plan prompt template."},
     "model_role":       {"type": "string", "description": "Role from core.models for plan synthesis."},
-    "model":            {"type": "string", "description": "Direct model ID override."},
     "max_steps":        {"type": "integer", "minimum": 1, "description": "Maximum plan steps emitted by the LLM."}
   }
 }

--- a/plugins/rag/hybrid/plugin.go
+++ b/plugins/rag/hybrid/plugin.go
@@ -36,13 +36,12 @@ type Plugin struct {
 	bus    engine.EventBus
 	logger *slog.Logger
 
-	fusion         string  // "rrf" | "weighted"
-	rrfK           float64 // RRF smoothing constant
-	weightVector   float64
-	weightLexical  float64
-	retrieveK      int // per-backend candidate count
-	fuseTo         int // post-fusion top-N
-	embeddingModel string
+	fusion        string  // "rrf" | "weighted"
+	rrfK          float64 // RRF smoothing constant
+	weightVector  float64
+	weightLexical float64
+	retrieveK     int // per-backend candidate count
+	fuseTo        int // post-fusion top-N
 	// reranker enables a post-fusion reranker pass via the search.reranker
 	// capability. Off by default so single-mode + hybrid-only deployments
 	// keep their existing latency profile. When on and no provider is
@@ -123,9 +122,6 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	if v, ok := ctx.Config["fuse_to"].(float64); ok && v > 0 {
 		p.fuseTo = int(v)
 	}
-	if v, ok := ctx.Config["embedding_model"].(string); ok {
-		p.embeddingModel = v
-	}
 	if r, ok := ctx.Config["reranker"].(map[string]any); ok {
 		if v, ok := r["enabled"].(bool); ok {
 			p.rerankerEnabled = v
@@ -193,7 +189,7 @@ func (p *Plugin) handleQuery(event engine.Event[any]) {
 	// Embed if the caller did not pre-embed.
 	vec := req.Vector
 	if len(vec) == 0 {
-		embReq := &events.EmbeddingsRequest{SchemaVersion: events.EmbeddingsRequestVersion, Texts: []string{req.Query}, Model: p.embeddingModel}
+		embReq := &events.EmbeddingsRequest{SchemaVersion: events.EmbeddingsRequestVersion, Texts: []string{req.Query}}
 		_ = p.bus.Emit("embeddings.request", embReq)
 		if embReq.Error != "" {
 			req.Error = fmt.Sprintf("embed query: %s", embReq.Error)

--- a/plugins/rag/hybrid/schema.json
+++ b/plugins/rag/hybrid/schema.json
@@ -18,7 +18,6 @@
     },
     "retrieve_k":      {"type": "integer", "minimum": 1, "description": "Pre-fusion candidate count from each retriever."},
     "fuse_to":         {"type": "integer", "minimum": 1, "description": "Final result count after fusion."},
-    "embedding_model": {"type": "string",  "description": "Embedding model used for the vector leg."},
     "reranker": {
       "type": "object",
       "additionalProperties": false,

--- a/plugins/rag/ingest/contextual.go
+++ b/plugins/rag/ingest/contextual.go
@@ -26,7 +26,6 @@ type contextualizer struct {
 	bus            engine.EventBus
 	logger         *slog.Logger
 	enabled        bool
-	model          string
 	modelRole      string
 	maxDocChars    int
 	maxPrefixChars int
@@ -55,11 +54,8 @@ func newContextualizer(bus engine.EventBus, logger *slog.Logger, cfg map[string]
 	if v, ok := cfg["enabled"].(bool); ok {
 		c.enabled = v
 	}
-	if v, ok := cfg["model"].(string); ok && v != "" {
+	if v, ok := cfg["model_role"].(string); ok && v != "" {
 		c.modelRole = v
-	}
-	if v, ok := cfg["model_id"].(string); ok && v != "" {
-		c.model = v
 	}
 	if v, ok := cfg["max_chars_doc_window"].(int); ok && v > 0 {
 		c.maxDocChars = v
@@ -128,7 +124,6 @@ func (c *contextualizer) generate(docContext, chunk string) (string, error) {
 
 	prompt := buildContextPrompt(docContext, chunk, c.maxDocChars)
 	req := events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: c.modelRole,
-		Model: c.model,
 		Messages: []events.Message{
 			{Role: "system", Content: contextSystemPrompt},
 			{Role: "user", Content: prompt},

--- a/plugins/rag/ingest/schema.json
+++ b/plugins/rag/ingest/schema.json
@@ -35,8 +35,7 @@
       "description": "Optional per-chunk LLM-generated situating prefix.",
       "properties": {
         "enabled":              {"type": "boolean"},
-        "model":                {"type": "string"},
-        "model_id":             {"type": "string"},
+        "model_role":           {"type": "string", "description": "Model role from core.models for prefix generation."},
         "max_chars_doc_window": {"type": "integer", "minimum": 1},
         "max_chars_prefix":     {"type": "integer", "minimum": 1},
         "timeout_ms":           {"type": "integer", "minimum": 1}

--- a/plugins/router/classifier/contract_test.go
+++ b/plugins/router/classifier/contract_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestContract(t *testing.T) {
 	h := contract.NewContract(t, New, contract.WithPluginConfig(map[string]any{
-		"classifier_model": "tiny-judge",
-		"candidates":       []any{"haiku", "sonnet", "opus"},
-		"fallback":         "sonnet",
+		"classifier_role": "classifier",
+		"candidate_roles": []any{"quick", "balanced", "reasoning"},
+		"fallback_role":   "balanced",
 	}))
 	h.AssertSubscribesTo("before:llm.request", "llm.response")
 	if got := h.Plugin().Emissions(); len(got) != 1 || got[0] != "llm.request" {

--- a/plugins/router/classifier/plugin.go
+++ b/plugins/router/classifier/plugin.go
@@ -1,13 +1,13 @@
-// Package classifier implements an LLM-judge per-step model router.
+// Package classifier implements an LLM-judge per-step model-role router.
 //
 // The classifier sees the user's most recent message, asks a small fast
-// model to rank the difficulty among the configured candidates, and
-// caches the answer keyed by a prompt-prefix hash so repeat prompts
+// model to rank the difficulty among the configured candidate roles,
+// and caches the answer keyed by a prompt-prefix hash so repeat prompts
 // don't re-pay the classifier latency budget.
 //
 // Routing happens synchronously on before:llm.request:
-//   - Cache hit: rewrite Model immediately. Zero added latency.
-//   - Cache miss: leave Model unchanged (default routing), and spawn a
+//   - Cache hit: rewrite Role immediately. Zero added latency.
+//   - Cache miss: leave Role unchanged (default routing), and spawn a
 //     background goroutine that classifies via the LLM and warms the
 //     cache for the next call. This avoids paying the classifier
 //     round-trip on the very first request — the trade-off documented
@@ -34,11 +34,11 @@ import (
 
 const pluginID = "nexus.router.classifier"
 
-const defaultClassifierPrompt = `You are a routing classifier. Given the user prompt below, decide which model tier should answer.
+const defaultClassifierPrompt = `You are a routing classifier. Given the user prompt below, decide which model role should answer.
 
 Respond with EXACTLY one word from this list and nothing else: %s
 
-The candidates are ordered cheapest first. Pick the cheapest tier that can answer the prompt correctly. Use a stronger tier only when the prompt requires multi-step reasoning, complex tool use, long-context analysis, or nuanced creative output.
+The roles are ordered cheapest first. Pick the cheapest role that can answer the prompt correctly. Use a stronger role only when the prompt requires multi-step reasoning, complex tool use, long-context analysis, or nuanced creative output.
 
 Prompt:
 %s
@@ -62,14 +62,13 @@ type Plugin struct {
 	bus    engine.EventBus
 	logger *slog.Logger
 
-	classifierModel string
-	classifierRole  string
-	candidates      []string
-	fallback        string
-	prefixChars     int
-	latencyMs       int
-	prompt          string
-	cacheEnabled    bool
+	classifierRole string
+	candidateRoles []string
+	fallbackRole   string
+	prefixChars    int
+	latencyMs      int
+	prompt         string
+	cacheEnabled   bool
 
 	cache *cache
 
@@ -90,27 +89,24 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	p.logger = ctx.Logger
 	p.pending = make(map[string]chan events.LLMResponse)
 
-	if v, ok := ctx.Config["classifier_model"].(string); ok {
-		p.classifierModel = v
-	}
 	if v, ok := ctx.Config["classifier_role"].(string); ok {
 		p.classifierRole = v
 	}
-	if v, ok := ctx.Config["fallback"].(string); ok {
-		p.fallback = v
+	if v, ok := ctx.Config["fallback_role"].(string); ok {
+		p.fallbackRole = v
 	}
-	if rawCands, ok := ctx.Config["candidates"].([]any); ok {
+	if rawCands, ok := ctx.Config["candidate_roles"].([]any); ok {
 		for _, c := range rawCands {
 			if s, ok := c.(string); ok && s != "" {
-				p.candidates = append(p.candidates, s)
+				p.candidateRoles = append(p.candidateRoles, s)
 			}
 		}
 	}
-	if len(p.candidates) == 0 {
-		return fmt.Errorf("router.classifier: candidates list is required")
+	if len(p.candidateRoles) == 0 {
+		return fmt.Errorf("router.classifier: candidate_roles list is required")
 	}
-	if p.classifierModel == "" && p.classifierRole == "" {
-		return fmt.Errorf("router.classifier: either classifier_model or classifier_role is required")
+	if p.classifierRole == "" {
+		return fmt.Errorf("router.classifier: classifier_role is required")
 	}
 
 	p.prefixChars = defaultPrefixChars
@@ -147,10 +143,9 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	)
 
 	p.logger.Info("classifier router initialized",
-		"classifier_model", p.classifierModel,
 		"classifier_role", p.classifierRole,
-		"candidates", strings.Join(p.candidates, ","),
-		"fallback", p.fallback,
+		"candidate_roles", strings.Join(p.candidateRoles, ","),
+		"fallback_role", p.fallbackRole,
 		"cache_enabled", p.cacheEnabled,
 		"latency_budget_ms", p.latencyMs)
 	return nil
@@ -212,35 +207,42 @@ func (p *Plugin) handleBeforeLLMRequest(event engine.Event[any]) {
 	key := promptHash(prompt, p.prefixChars)
 
 	if p.cacheEnabled {
-		if model, ok := p.cache.get(key); ok {
-			p.applyDecision(req, model, "cache")
+		if role, ok := p.cache.get(key); ok {
+			p.applyDecision(req, role, "cache")
 			return
 		}
 	}
 
 	// Cache miss: route to fallback now and warm the cache asynchronously.
-	if p.fallback != "" {
-		p.applyDecision(req, p.fallback, "fallback")
+	if p.fallbackRole != "" {
+		p.applyDecision(req, p.fallbackRole, "fallback")
 	}
 	go p.classifyAndCache(prompt, key)
 }
 
-// applyDecision rewrites the request and records the routing trail.
-func (p *Plugin) applyDecision(req *events.LLMRequest, model, why string) {
-	if model == "" || model == req.Model {
+// applyDecision rewrites the request's Role and records the routing trail.
+// Clears Model so the role takes effect (Model takes precedence over Role
+// in provider resolution).
+func (p *Plugin) applyDecision(req *events.LLMRequest, role, why string) {
+	if role == "" || role == req.Role {
 		return
 	}
-	prev := req.Model
-	req.Model = model
+	prevRole := req.Role
+	prevModel := req.Model
+	req.Role = role
+	req.Model = ""
 	if req.Metadata == nil {
 		req.Metadata = make(map[string]any)
 	}
 	req.Metadata["_routed_by"] = pluginID
 	req.Metadata["_routed_reason"] = why
-	if prev != "" {
-		req.Metadata["_routed_from_model"] = prev
+	if prevRole != "" {
+		req.Metadata["_routed_from_role"] = prevRole
 	}
-	p.logger.Debug("classifier routed", "reason", why, "from", prev, "to", model)
+	if prevModel != "" {
+		req.Metadata["_routed_from_model"] = prevModel
+	}
+	p.logger.Debug("classifier routed", "reason", why, "from_role", prevRole, "to_role", role)
 }
 
 // classifyAndCache emits a classification request, awaits the response
@@ -260,9 +262,8 @@ func (p *Plugin) classifyAndCache(prompt, key string) {
 	}()
 
 	probe := events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: p.classifierRole,
-		Model: p.classifierModel,
 		Messages: []events.Message{
-			{Role: "user", Content: fmt.Sprintf(p.prompt, strings.Join(p.candidates, ", "), prompt)},
+			{Role: "user", Content: fmt.Sprintf(p.prompt, strings.Join(p.candidateRoles, ", "), prompt)},
 		},
 		MaxTokens: 32,
 		Metadata: map[string]any{
@@ -283,7 +284,7 @@ func (p *Plugin) classifyAndCache(prompt, key string) {
 		if !ok {
 			return
 		}
-		choice := resolveChoice(resp.Content, p.candidates)
+		choice := resolveChoice(resp.Content, p.candidateRoles)
 		if choice == "" {
 			p.logger.Debug("classifier returned unparseable choice", "content", resp.Content)
 			return
@@ -340,7 +341,7 @@ func promptHash(prompt string, n int) string {
 }
 
 // resolveChoice maps the classifier's free-text answer to one of the
-// candidate model ids. Falls back to substring matching since small models
+// candidate roles. Falls back to substring matching since small models
 // sometimes return verbose answers despite the "EXACTLY one word" prompt.
 func resolveChoice(text string, candidates []string) string {
 	t := strings.TrimSpace(text)

--- a/plugins/router/classifier/plugin_test.go
+++ b/plugins/router/classifier/plugin_test.go
@@ -30,39 +30,39 @@ func newClassifier(t *testing.T, cfg map[string]any) (*Plugin, engine.EventBus) 
 
 func minimalCfg() map[string]any {
 	return map[string]any{
-		"classifier_model":  "tiny-judge",
-		"candidates":        []any{"haiku", "sonnet", "opus"},
-		"fallback":          "sonnet",
+		"classifier_role":   "classifier",
+		"candidate_roles":   []any{"quick", "balanced", "reasoning"},
+		"fallback_role":     "balanced",
 		"latency_budget_ms": 200,
 	}
 }
 
-func TestInit_RequiresCandidates(t *testing.T) {
+func TestInit_RequiresCandidateRoles(t *testing.T) {
 	bus := engine.NewEventBus()
 	p := New().(*Plugin)
 	err := p.Init(engine.PluginContext{Bus: bus, Logger: testLogger, Config: map[string]any{
-		"classifier_model": "x",
+		"classifier_role": "classifier",
 	}})
 	if err == nil {
-		t.Fatal("expected error on missing candidates")
+		t.Fatal("expected error on missing candidate_roles")
 	}
 }
 
-func TestInit_RequiresClassifierModel(t *testing.T) {
+func TestInit_RequiresClassifierRole(t *testing.T) {
 	bus := engine.NewEventBus()
 	p := New().(*Plugin)
 	err := p.Init(engine.PluginContext{Bus: bus, Logger: testLogger, Config: map[string]any{
-		"candidates": []any{"a"},
+		"candidate_roles": []any{"quick"},
 	}})
 	if err == nil {
-		t.Fatal("expected error on missing classifier_model")
+		t.Fatal("expected error on missing classifier_role")
 	}
 }
 
 func TestSkipsInternalSourcedRequests(t *testing.T) {
 	_, bus := newClassifier(t, minimalCfg())
 
-	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Model: "claude-sonnet-4-6-20250514",
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: "balanced",
 		Messages: []events.Message{
 			{Role: "user", Content: "hello"},
 		},
@@ -70,19 +70,18 @@ func TestSkipsInternalSourcedRequests(t *testing.T) {
 	}
 	_, _ = bus.EmitVetoable("before:llm.request", req)
 
-	// _source set means classifier ignored it.
 	if req.Metadata["_routed_by"] != nil {
 		t.Fatalf("internal-sourced requests must not be routed, got _routed_by=%v", req.Metadata["_routed_by"])
 	}
-	if req.Model != "claude-sonnet-4-6-20250514" {
-		t.Fatalf("model unchanged expected, got %s", req.Model)
+	if req.Role != "balanced" {
+		t.Fatalf("role unchanged expected, got %s", req.Role)
 	}
 }
 
 func TestSkipsAlreadyRouted(t *testing.T) {
 	_, bus := newClassifier(t, minimalCfg())
 
-	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Model: "claude-sonnet-4-6-20250514",
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: "balanced",
 		Messages: []events.Message{
 			{Role: "user", Content: "complex question"},
 		},
@@ -97,14 +96,14 @@ func TestSkipsAlreadyRouted(t *testing.T) {
 func TestCacheMissAppliesFallback(t *testing.T) {
 	_, bus := newClassifier(t, minimalCfg())
 
-	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Model: "claude-opus-4-6-20250602",
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: "reasoning",
 		Messages: []events.Message{
 			{Role: "user", Content: "complex question"},
 		},
 	}
 	_, _ = bus.EmitVetoable("before:llm.request", req)
-	if req.Model != "sonnet" {
-		t.Fatalf("expected fallback model, got %s", req.Model)
+	if req.Role != "balanced" {
+		t.Fatalf("expected fallback role, got %s", req.Role)
 	}
 	if req.Metadata["_routed_reason"] != "fallback" {
 		t.Fatalf("expected reason=fallback, got %v", req.Metadata["_routed_reason"])
@@ -114,14 +113,14 @@ func TestCacheMissAppliesFallback(t *testing.T) {
 func TestCacheHitRoutesImmediately(t *testing.T) {
 	p, bus := newClassifier(t, minimalCfg())
 	prompt := "what is the capital of france"
-	p.cache.put(promptHash(prompt, defaultPrefixChars), "haiku")
+	p.cache.put(promptHash(prompt, defaultPrefixChars), "quick")
 
-	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Model: "claude-opus-4-6-20250602",
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: "reasoning",
 		Messages: []events.Message{{Role: "user", Content: prompt}},
 	}
 	_, _ = bus.EmitVetoable("before:llm.request", req)
-	if req.Model != "haiku" {
-		t.Fatalf("expected cache hit to route to haiku, got %s", req.Model)
+	if req.Role != "quick" {
+		t.Fatalf("expected cache hit to route to quick, got %s", req.Role)
 	}
 	if req.Metadata["_routed_reason"] != "cache" {
 		t.Fatalf("expected reason=cache, got %v", req.Metadata["_routed_reason"])
@@ -131,8 +130,6 @@ func TestCacheHitRoutesImmediately(t *testing.T) {
 func TestClassifierWarmsCacheAsync(t *testing.T) {
 	p, bus := newClassifier(t, minimalCfg())
 
-	// Stand in as the LLM provider: any llm.request from the classifier
-	// gets a synthetic response with the chosen tier.
 	var probeWG sync.WaitGroup
 	probeWG.Add(1)
 	bus.Subscribe("llm.request", func(event engine.Event[any]) {
@@ -146,21 +143,20 @@ func TestClassifierWarmsCacheAsync(t *testing.T) {
 		callID, _ := req.Metadata["_call_id"].(string)
 		go func() {
 			defer probeWG.Done()
-			_ = bus.Emit("llm.response", events.LLMResponse{SchemaVersion: events.LLMResponseVersion, Content: "haiku",
+			_ = bus.Emit("llm.response", events.LLMResponse{SchemaVersion: events.LLMResponseVersion, Content: "quick",
 				Metadata: map[string]any{"_call_id": callID},
 			})
 		}()
 	})
 
 	prompt := "trivial weather query"
-	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Model: "claude-opus-4-6-20250602",
+	req := &events.LLMRequest{SchemaVersion: events.LLMRequestVersion, Role: "reasoning",
 		Messages: []events.Message{{Role: "user", Content: prompt}},
 	}
 	_, _ = bus.EmitVetoable("before:llm.request", req)
 
 	probeWG.Wait()
 
-	// Allow goroutine to land the cache write.
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if _, ok := p.cache.get(promptHash(prompt, defaultPrefixChars)); ok {
@@ -172,15 +168,15 @@ func TestClassifierWarmsCacheAsync(t *testing.T) {
 }
 
 func TestResolveChoiceExactMatch(t *testing.T) {
-	got := resolveChoice("haiku", []string{"haiku", "sonnet", "opus"})
-	if got != "haiku" {
+	got := resolveChoice("quick", []string{"quick", "balanced", "reasoning"})
+	if got != "quick" {
 		t.Fatalf("got %s", got)
 	}
 }
 
 func TestResolveChoiceSubstring(t *testing.T) {
-	got := resolveChoice("I'd choose: opus", []string{"haiku", "sonnet", "opus"})
-	if got != "opus" {
+	got := resolveChoice("I'd choose: reasoning", []string{"quick", "balanced", "reasoning"})
+	if got != "reasoning" {
 		t.Fatalf("got %s", got)
 	}
 }

--- a/plugins/router/classifier/schema.json
+++ b/plugins/router/classifier/schema.json
@@ -4,16 +4,15 @@
   "title": "nexus.router.classifier",
   "type": "object",
   "additionalProperties": false,
-  "required": ["candidates"],
+  "required": ["classifier_role", "candidate_roles"],
   "properties": {
-    "classifier_model":     {"type": "string", "description": "Direct model ID for the classifier call."},
-    "classifier_role":      {"type": "string", "description": "Role from core.models for the classifier call."},
-    "fallback":             {"type": "string", "description": "Candidate to use when classification fails."},
-    "candidates": {
+    "classifier_role":      {"type": "string", "description": "Role from core.models used for the classifier probe."},
+    "fallback_role":        {"type": "string", "description": "Candidate role used on cache miss while the cache warms."},
+    "candidate_roles": {
       "type": "array",
       "minItems": 1,
       "items": {"type": "string"},
-      "description": "Candidate model IDs the classifier may pick from."
+      "description": "Cheapest-first list of candidate model roles the classifier may pick from."
     },
     "prefix_chars":         {"type": "integer", "minimum": 1, "description": "Number of input chars passed to the classifier."},
     "latency_budget_ms":    {"type": "integer", "minimum": 1, "description": "Latency budget for classification (ms)."},

--- a/plugins/tools/knowledge_search/plugin.go
+++ b/plugins/tools/knowledge_search/plugin.go
@@ -45,7 +45,6 @@ type Plugin struct {
 	defaultNS       []string // used when the LLM doesn't pick
 	topK            int
 	includeMetadata bool
-	embeddingModel  string // optional pin; otherwise provider default
 	// hasHybrid switches the query path to search.hybrid (RRF / weighted
 	// fusion of vector + lexical) when the orchestrator capability is
 	// active. Falls back to direct vector.query otherwise so single-mode
@@ -91,9 +90,6 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 	}
 	if v, ok := ctx.Config["include_metadata"].(bool); ok {
 		p.includeMetadata = v
-	}
-	if v, ok := ctx.Config["embedding_model"].(string); ok {
-		p.embeddingModel = v
 	}
 	p.allowedNS = configStrings(ctx.Config["namespaces"])
 	p.defaultNS = configStrings(ctx.Config["default_namespaces"])
@@ -234,7 +230,7 @@ func (p *Plugin) handle(tc events.ToolCall) {
 			}
 		}
 	} else {
-		embReq := &events.EmbeddingsRequest{SchemaVersion: events.EmbeddingsRequestVersion, Texts: []string{query}, Model: p.embeddingModel}
+		embReq := &events.EmbeddingsRequest{SchemaVersion: events.EmbeddingsRequestVersion, Texts: []string{query}}
 		_ = p.bus.Emit("embeddings.request", embReq)
 		if embReq.Error != "" {
 			p.emit(tc, "", fmt.Sprintf("embed query: %s", embReq.Error))

--- a/plugins/tools/knowledge_search/schema.json
+++ b/plugins/tools/knowledge_search/schema.json
@@ -8,7 +8,6 @@
     "tool_name":        {"type": "string",  "description": "Override the LLM-facing tool name."},
     "top_k":            {"type": "integer", "minimum": 1, "description": "Number of top results returned per query."},
     "include_metadata": {"type": "boolean", "description": "Include vector store metadata in results."},
-    "embedding_model":  {"type": "string",  "description": "Embedding model used for query embedding."},
     "namespaces": {
       "type": "array",
       "items": {"type": "string"},

--- a/tests/integration/mcp_fake/main.go
+++ b/tests/integration/mcp_fake/main.go
@@ -2,10 +2,10 @@
 // small, deterministic surface so the Nexus mcp.client plugin can be exercised
 // end-to-end over stdio:
 //
-//   tools:     echo (string -> string), add (a+b -> int)
-//   resources: readme (text), tiny-image (binary)
-//   template:  doc://{name}
-//   prompts:   greet (no args), review (one required arg)
+//	tools:     echo (string -> string), add (a+b -> int)
+//	resources: readme (text), tiny-image (binary)
+//	template:  doc://{name}
+//	prompts:   greet (no args), review (one required arg)
 //
 // Not built as part of normal go build — the integration test compiles it on
 // demand via `go build`. Lives outside the main module path so it doesn't


### PR DESCRIPTION
Closes #102.

## Summary

Plugin configs that used to take raw model IDs now take **model roles** (resolved via `core.models`). Removes the long-running confusion between the two layers.

## Breaking changes (no backwards compatibility)

| Plugin | Before | After |
|---|---|---|
| `nexus.memory.compaction` | `model_role` *or* `model` | `model_role` only |
| `nexus.memory.summary_buffer` | `model_role` *or* `model` | `model_role` only |
| `nexus.planner.dynamic` | `model_role` *or* `model` | `model_role` only |
| `nexus.control.hitl_synthesizer` | `model:` (treated as role) + `model_id:` | `model_role:` only |
| `nexus.router.classifier` | `classifier_model` / `candidates` / `fallback` (model IDs) | `classifier_role` / `candidate_roles` / `fallback_role` |
| `nexus.rag.ingest.contextual_retrieval` | `model:` + `model_id:` | `model_role:` only |
| `nexus.memory.vector` | `embedding_model:` | *(removed — provider owns it)* |
| `nexus.tool.knowledge_search` | `embedding_model:` | *(removed — provider owns it)* |
| `nexus.rag.hybrid` | `embedding_model:` | *(removed — provider owns it)* |

The classifier router now rewrites `LLMRequest.Role` (and clears `Model`) instead of `LLMRequest.Model`, so role resolution happens at the provider plugin rather than at the router.

Vendor-gated `model:` keys on provider/adapter plugins (`embeddings/openai`, `rag/reranker/cohere`, `search/anthropic_native`, etc.) are intentionally unchanged — those talk straight to vendor APIs and don't participate in the role system.

## What changed

- Plugin source: `plugins/{memory/compaction,memory/summary_buffer,memory/vector,planners/dynamic,control/hitl_synthesizer,router/classifier,rag/ingest,rag/hybrid,tools/knowledge_search}/plugin.go`
- Plugin schemas (`schema.json`) updated to match
- Tests updated for `nexus.router.classifier` (role-based assertions)
- Example configs in `configs/` and `cmd/demo/` migrated
- Docs: `docs/src/configuration/reference.md`, per-plugin pages, RAG guide

## Test plan
- [x] `make fmt && make vet && make build`
- [x] `make test` (full suite — `TestConfigsSmokeBoot` schema validation passes for every config under `configs/`)
- [x] Manual: boot `bin/nexus -config configs/demo-router-and-cost.yaml` and confirm classifier routes by role through the journal
- [x] Manual: boot `bin/nexus -config configs/demo-hitl-synthesizer.yaml` and confirm the synthesizer renders prompts using the `quick` role

🤖 Generated with [Claude Code](https://claude.com/claude-code)