### PR TITLE
fix(gemini): wrap non-object tool results in functionResponse.response

### DIFF
--- a/plugins/providers/gemini/plugin.go
+++ b/plugins/providers/gemini/plugin.go
@@ -563,11 +563,18 @@ func (p *Plugin) convertMessages(msgs []events.Message) (string, []map[string]an
 				// callers may emit synthetic IDs equal to the tool name.
 				name = msg.ToolCallID
 			}
-			// Gemini expects response.content to be a structured object. Wrap
-			// raw text in {output: ...} for round-trip safety.
+			// Gemini expects functionResponse.response to be a structured object
+			// (a protobuf Struct). Wrap raw text in {output: ...} for round-trip
+			// safety, and likewise wrap any valid-JSON result that is not an
+			// object — a top-level array or scalar (e.g. a tool returning a list
+			// of matches) is otherwise rejected with "Proto field is not
+			// repeating, cannot start list".
 			var responseObj any
 			if err := json.Unmarshal([]byte(msg.Content), &responseObj); err != nil {
 				responseObj = map[string]any{"output": msg.Content}
+			}
+			if _, isObj := responseObj.(map[string]any); !isObj {
+				responseObj = map[string]any{"output": responseObj}
 			}
 			out = append(out, map[string]any{
 				"role": "user",

--- a/plugins/providers/gemini/tool_response_test.go
+++ b/plugins/providers/gemini/tool_response_test.go
@@ -1,0 +1,82 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/frankbardon/nexus/pkg/events"
+)
+
+// findFunctionResponse returns the response payload of the first
+// functionResponse part in the converted contents, or nil.
+func findFunctionResponse(t *testing.T, contents []map[string]any) map[string]any {
+	t.Helper()
+	for _, c := range contents {
+		parts, _ := c["parts"].([]map[string]any)
+		for _, p := range parts {
+			if fr, ok := p["functionResponse"].(map[string]any); ok {
+				resp, ok := fr["response"].(map[string]any)
+				if !ok {
+					t.Fatalf("functionResponse.response is %T, want object (map)", fr["response"])
+				}
+				return resp
+			}
+		}
+	}
+	t.Fatal("no functionResponse part found")
+	return nil
+}
+
+func convertTool(t *testing.T, toolContent string) map[string]any {
+	t.Helper()
+	msgs := []events.Message{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", ToolCalls: []events.ToolCallRequest{{ID: "call1", Name: "pulse_label_resolve", Arguments: "{}"}}},
+		{Role: "tool", ToolCallID: "call1", Content: toolContent},
+	}
+	_, contents, err := (&Plugin{}).convertMessages(msgs)
+	if err != nil {
+		t.Fatalf("convertMessages: %v", err)
+	}
+	return findFunctionResponse(t, contents)
+}
+
+// A tool result that is a top-level JSON array (e.g. pulse_label_resolve
+// returning a list of matches) must be wrapped in an object — Gemini rejects a
+// bare array at functionResponse.response.
+func TestConvertMessages_WrapsArrayToolResult(t *testing.T) {
+	resp := convertTool(t, `[{"name":"Nike","score":1.0},{"name":"Adidas","score":0.8}]`)
+	arr, ok := resp["output"].([]any)
+	if !ok {
+		t.Fatalf("array result not wrapped under output: %#v", resp)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("want 2 matches preserved, got %d", len(arr))
+	}
+}
+
+// A scalar JSON result is likewise wrapped.
+func TestConvertMessages_WrapsScalarToolResult(t *testing.T) {
+	resp := convertTool(t, `42`)
+	if resp["output"] != float64(42) {
+		t.Fatalf("scalar result not wrapped: %#v", resp)
+	}
+}
+
+// An object result passes through unchanged (no double-wrapping).
+func TestConvertMessages_PassesObjectToolResult(t *testing.T) {
+	resp := convertTool(t, `{"matches":["Nike"],"count":1}`)
+	if _, wrapped := resp["output"]; wrapped {
+		t.Fatalf("object result should not be wrapped under output: %#v", resp)
+	}
+	if resp["count"] != float64(1) {
+		t.Fatalf("object fields not preserved: %#v", resp)
+	}
+}
+
+// Non-JSON text is wrapped under output (existing behaviour, guarded).
+func TestConvertMessages_WrapsPlainTextToolResult(t *testing.T) {
+	resp := convertTool(t, `not json at all`)
+	if resp["output"] != "not json at all" {
+		t.Fatalf("plain text not wrapped: %#v", resp)
+	}
+}


### PR DESCRIPTION
## Summary
- `convertMessages` only wrapped *unparseable* tool output in `{output: ...}`. A tool returning valid JSON that is a **top-level array or scalar** (e.g. `pulse_label_resolve` returning a list of matches) was passed straight into `functionResponse.response`, which Gemini rejects — that field is a protobuf `Struct` and must be an object.
- Symptom (HTTP 400): `Invalid JSON payload received. Unknown name "response" at contents[N].parts[0].function_response: Proto field is not repeating, cannot start list.`
- Fix: after unmarshalling, wrap any non-object result under `{output: ...}`. Object results pass through unchanged.

## Test plan
- [x] `go test ./plugins/providers/gemini/` — new regression tests cover array / scalar / object / plain-text tool results
- [x] `go vet ./plugins/providers/gemini/`
- [x] Full gemini package suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)