### PR TITLE
feat(icm): blog-pipeline example workspace + workflow UI feedback + correctness fixes

### DIFF
--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -1524,6 +1524,40 @@ Source: `plugins/planners/static/plugin.go`. Approval auto-defaults to `never`
 
 ## Workflows
 
+### Generic workflow surface
+
+Workflow plugins (currently `nexus.workflows.icm`; planned to extend to other
+multi-stage runners) emit a workflow-agnostic event class so IO plugins can
+render a dedicated progress surface (a sticky panel in the TUI right rail; a
+status indicator chip in the browser) without subscribing to plugin-specific
+event taxonomies.
+
+**Event**: `workflow.progress` — payload `events.WorkflowProgress`
+(`pkg/events/workflow.go`).
+
+| Field            | Type            | Description |
+|------------------|-----------------|-------------|
+| `workflow_id`    | string          | Producer plugin instance ID (`nexus.workflows.icm`, `nexus.workflows.icm/script`, …). |
+| `workflow_name`  | string          | Human-readable workflow label (workspace name for ICM). |
+| `run_id`         | string          | Identifier for this particular run. |
+| `stage` / `stage_label` | string   | Machine ID + display label for the current stage. Empty at run start / end. |
+| `stage_index` / `stage_total` | int | 1-based position in the stage sequence. |
+| `iteration` / `max_iterations` | int | Loop iteration counters. `0` when the stage is not looping. |
+| `turn` / `max_turns` | int         | Inner-turn counters. `0` when not tracked. |
+| `items_done` / `items_total` | int | Fan-out progress. `0` when not a fan-out stage. |
+| `current_item`   | string          | Most recently completed item ID for fan-out. |
+| `status`         | string          | One of `started`, `running`, `iterating`, `item_done`, `completed`, `failed`, `halted`. |
+| `detail`         | string          | Short free-form one-liner suitable for display. |
+| `failures`       | list of strings | Names of predicates whose failure prevented this iteration / turn from converging. |
+
+ICM emits `workflow.progress` *alongside* its detailed `icm.*` events: the
+`icm.*` family feeds scrollback audit rows; `workflow.progress` feeds the
+dedicated status surface. Future workflow plugins can emit only the generic
+event and inherit the same UI treatment without per-plugin subscriptions.
+
+The TUI (`nexus.io.tui`) and browser (`nexus.io.browser`) subscribe to
+`workflow.progress` automatically when active.
+
 ### `nexus.workflows.icm`
 
 Source: `plugins/workflows/icm/plugin.go`. File-driven multi-stage workflow
@@ -1553,6 +1587,25 @@ Requires the `posture.registry` capability (provided by
 | `auto_include_skill_reference_tool`  | bool   | `true`        | When true, ICM automatically appends the `read_skill_reference[_<suffix>]` tool to each derived stage posture whose contract declares `inputs.skills`. Set false to require explicit listing in `agent.tools`. |
 | `predicate_command_timeout_seconds`  | int    | `30`          | Default timeout for `type: command` predicates when neither the predicate nor the stage budget specifies one. |
 | `emit_progress_thinking_steps`       | bool   | `true`        | When true, ICM emits `thinking.step` events with `Phase="icm.<stage_id>"` so UIs that render thinking surfaces show inline stage transitions. |
+
+#### Events
+
+Subscribes:
+
+- `io.input` — entry point. Each input begins a new workflow run.
+- `hitl.responded` — resumes a run paused at a human gate or `type: human` predicate.
+
+Emits (workflow lifecycle):
+
+- `icm.run.started` / `icm.run.completed` / `icm.run.halted` — overall run boundaries.
+- `icm.stage.started` / `icm.stage.completed` / `icm.stage.failed` — per-stage transitions.
+- `icm.stage.iteration` — fires once per loop iteration with the prior iteration's `exit_failures`.
+- `icm.turn` — fires once per inner turn with the turn's validator failures.
+- `icm.fanout.item` — per-item lifecycle in a fan-out stage (`active`, `completed`, `failed`).
+- `icm.predicate.failed` — fires for every predicate evaluation whose verdict is `fail`.
+- `plan.created` / `plan.progress` — generic plan surface mirrored for any UI that already renders ReAct plans.
+- `workflow.progress` — engine-generic structured progress (see [Generic workflow surface](#generic-workflow-surface) below).
+- `hitl.requested` — human gates and `type: human` predicates dispatch through HITL.
 
 ### `nexus.skills`
 

--- a/docs/src/plugins/workflows-icm.md
+++ b/docs/src/plugins/workflows-icm.md
@@ -721,11 +721,32 @@ following typed events surface richer detail. All payloads carry a
 | `icm.turn` | After each turn within an invocation. | Richer-UI feed only; basic UIs already see stage transitions via `plan.progress`. |
 | `icm.fanout.item` | Item lifecycle boundary in a fan-out stage. | `Status` is `active` / `completed` / `failed`. |
 | `icm.predicate.failed` | Any predicate evaluation returns `Verdict=false`. | Single source of truth for failure visibility — pass paths are not emitted. |
+| `workflow.progress` | Run start, stage start, every iteration, every fan-out item completion, stage / run completion, halt / failure. | Engine-generic structured payload (`events.WorkflowProgress`). Powers the dedicated workflow status panel in `nexus.io.tui` and the indicator chip in `nexus.io.browser`. Emitted *alongside* the `icm.*` family, not in place of it. |
 
 In addition, with `emit_progress_thinking_steps: true` (default) ICM emits
 `thinking.step` events tagged `Phase="icm.<stage_id>"` so UIs that render
 thinking surfaces show inline stage transitions without subscribing to the
 typed event family.
+
+### UI feedback surfaces
+
+Both bundled IO plugins (`nexus.io.tui`, `nexus.io.browser`) wire ICM
+progress directly so users see real-time feedback during long runs
+without enabling extra observers:
+
+- **Scrollback (thinking-step stream)** — every `icm.*` event is formatted
+  into a one-line audit row via the helpers in
+  `plugins/workflows/icm/icmtypes/format.go` and rendered alongside other
+  thinking steps. Long runs leave a complete trail of stage transitions,
+  iteration retries, predicate failures, and fan-out item ticks.
+- **Dedicated workflow panel** — the generic `workflow.progress` event
+  drives a sticky surface (TUI right-rail panel, browser chip indicator)
+  that updates in place: workflow name, stage X/Y, iter N/M, turn N/M,
+  fan-out items done/total, status badge, and the names of any predicate
+  failures from the last iteration.
+
+The two surfaces complement each other: scrollback for "what happened",
+dedicated panel for "where are we now".
 
 ## Session layout + artifacts
 

--- a/examples/icm-workspaces/blog-pipeline.yaml
+++ b/examples/icm-workspaces/blog-pipeline.yaml
@@ -1,0 +1,118 @@
+# Blog Pipeline — runnable Nexus config.
+#
+# Boots the example ICM workspace at examples/icm-workspaces/blog-pipeline/
+# against the Anthropic provider, with the six blog_* postures from
+# examples/postures/.
+#
+# Prerequisites:
+#   - ANTHROPIC_API_KEY in env or .env
+#   - Run from the repo root so the relative paths below resolve:
+#       bin/nexus -config examples/icm-workspaces/blog-pipeline.yaml
+#
+# What happens:
+#   1. nexus.agent.postures scans examples/postures/ and registers all
+#      six blog_* postures.
+#   2. nexus.workflows.icm loads the workspace and registers one derived
+#      posture per stage + verifier.
+#   3. nexus.io.tui collects user input on stdin. Drop a paragraph
+#      describing the topic; the workflow expands it into a full post.
+#   4. Stage 02_outline pauses at human_gate: start; review the outline
+#      via the HITL prompt before drafting begins.
+#   5. Stage 04_assemble loops up to 4 times until all exit predicates
+#      pass; a human check fires each iteration.
+#   6. Stage 05_publish pauses at human_gate: end; approve before the
+#      final post.md is finalized.
+#
+# Tip: to use the oneshot IO instead of the TUI (e.g. for scripted runs),
+# swap nexus.io.tui for nexus.io.oneshot and pass input_file:
+#     nexus.io.oneshot:
+#       input_file: ./examples/icm-workspaces/blog-pipeline/inputs/example_brief.md
+
+core:
+  log_level: info
+  tick_interval: 5s
+  max_concurrent_events: 200
+
+  # Model roles referenced by postures via model.model_role. The roles
+  # below are the union of every model_role declared in blog_*.yaml.
+  # Tune per-role as you see fit; the postures will pick up the change
+  # without edits.
+  models:
+    default: writer
+
+    writer:
+      provider: nexus.llm.anthropic
+      model: claude-sonnet-4-6
+      max_tokens: 8192
+
+    editor:
+      provider: nexus.llm.anthropic
+      model: claude-sonnet-4-6
+      max_tokens: 8192
+
+    researcher:
+      provider: nexus.llm.anthropic
+      model: claude-sonnet-4-6
+      max_tokens: 8192
+
+    planner:
+      provider: nexus.llm.anthropic
+      model: claude-sonnet-4-6
+      max_tokens: 6144
+
+    judge:
+      provider: nexus.llm.anthropic
+      model: claude-haiku-4-5-20251001
+      max_tokens: 2048
+
+  sessions:
+    root: ~/.nexus/sessions
+    retention: 30d
+    id_format: datetime_short
+
+plugins:
+  active:
+    - nexus.io.tui              # interactive input + transcript display
+    - nexus.llm.anthropic       # provider for every model role
+    - nexus.agent.postures      # scans examples/postures/ for blog_*.yaml
+    - nexus.agent.delegate      # sub-agent runtime ICM dispatches each stage through
+    - nexus.control.hitl        # human_gate + type: human predicates
+    - nexus.workflows.icm       # the workflow engine itself
+
+  nexus.io.tui:
+    # Defaults are fine for a single-user interactive demo.
+
+  nexus.llm.anthropic:
+    api_key_env: ANTHROPIC_API_KEY
+
+  nexus.agent.postures:
+    # Scan the bundled posture set. The plugin watches this directory
+    # with fsnotify, so edits to any blog_*.yaml hot-reload without a
+    # restart.
+    scan_dirs:
+      - ./examples/postures
+    debounce_ms: 250
+
+  nexus.workflows.icm:
+    workspace: ./examples/icm-workspaces/blog-pipeline
+    default_workflow_posture: blog_workflow_default
+    default_judge_posture: blog_small_judge
+
+    # 32 KB inline limit is the plugin default; bumped a little here so
+    # the assembled draft fits inline for downstream stages without a
+    # round-trip through read_file.
+    inline_artifact_limit_bytes: 49152
+
+    # Cap on loop-exhaustion restarts at the stage level. The example
+    # workspace has loop.max_iterations: 4 in 04_assemble; this caps the
+    # restart cycle on top of that.
+    loop_max_restarts: 2
+
+    # io.input content is interpreted as a file path when the path
+    # exists; otherwise it is written into 00_input/ as the raw brief.
+    treat_input_as_path_if_exists: true
+    input_filename: brief.md
+
+    # Emit thinking.step events scoped to each stage so any thinking-
+    # surface UI shows stage transitions inline.
+    emit_progress_thinking_steps: true

--- a/examples/icm-workspaces/blog-pipeline/README.md
+++ b/examples/icm-workspaces/blog-pipeline/README.md
@@ -1,0 +1,131 @@
+# Blog Pipeline — example ICM workspace
+
+This workspace is the reference demo for `nexus.workflows.icm`. It exists to be **run**, not just read — every major capability the plugin ships is wired into at least one stage so you can watch them fire end-to-end on a single launch.
+
+It turns a one-paragraph topic brief into a publication-ready Markdown blog post via five sequential stages plus a verifier.
+
+## What it demonstrates
+
+| Capability | Stage(s) | How to spot it |
+|---|---|---|
+| `output.format: json` + JSON Schema | `01_research`, `02_outline` | Each stage emits a structured JSON artifact validated against `schemas/*.json` |
+| `schema` predicate | `01_research`, `02_outline` | `output.validators[type: schema]` rejects malformed JSON |
+| `native:json_path_exists` | `01_research` | Requires `.key_concepts` to be non-empty |
+| `native:word_count_under` | `03_draft_sections` | Hard-caps each fan-out section at 400 words |
+| `native:word_count_over` | `04_assemble` | Total draft must exceed 800 words |
+| `native:contains_required_ids` | `04_assemble` | `introduction` + `conclusion` headings must be present |
+| `regex` predicate | `03_draft_sections`, `04_assemble`, `05_publish`, verifier | First-line anchors enforce H1 / H2 / verdict prefixes |
+| `command` predicate (inside `loop.until`) | `04_assemble` | `scripts/link_audit.sh` rejects placeholder / malformed Markdown links each iteration |
+| `llm` predicate (judge posture, as a turn validator) | `04_assemble` | `validators/cohesion_quality.md` rubric against `blog_small_judge`; feedback re-enters the same sub-agent via `<previous_attempt>` |
+| Stage loop (`loop.until` + mechanical predicates) | `04_assemble` | Iterates up to 3 times; `on_exhausted: human_gate` |
+| Fan-out over JSON array | `03_draft_sections` | One sub-agent per `02_outline/outline.json` `.sections[]` entry; per-item folders use `.slug` |
+| `turns.policy` — all three values | `01`/`02`/`03`/`04` use `until_valid`, `05` uses `until_human_approves` (`fixed` is the workspace default for any unset stage) | |
+| `human_gate: start` | `02_outline` | HITL prompt before drafting begins |
+| `human_gate: end` | `04_assemble`, `05_publish` | HITL prompt after the assembly loop converges, and again before final post.md is finalized |
+| `output.persist: both` | `05_publish` | Final post.md both inlined for context and written as a file_ref |
+| Stage-local skill (`SKILL.md` + `references/`) | `stages/03_draft_sections/skills/section-writer` | Drafter pulls examples via `read_skill_reference` |
+| Workspace-shared skill | `shared/skills/brand-voice` (used by `05_publish`) | Polisher consults brand voice + vocabulary references |
+| Shared grounding | `shared/grounding/house_rules.md` | Every stage gets it |
+| Per-stage grounding | `stages/02_outline/grounding/outline_principles.md` | Only the outline stage sees it |
+| Verifier stage | `verifiers/audit_titles/` | Runs after `04_assemble`; checks every outline title survived |
+| `agent.prompt_overlay` | every stage | Per-stage operator-prompt refinement |
+| `agent.budget` overrides | most stages | Per-stage token / tool-call ceilings on top of posture defaults |
+| `00_input/` reserved stage | `01_research`, `02_outline` | Both read `00_input/brief.md` |
+
+## Workflow shape
+
+```
+00_input/brief.md            (user supplies a paragraph)
+        │
+        ▼
+01_research → research.json     # JSON + schema + json_path_exists
+        │
+        ▼
+02_outline → outline.json       # JSON + schema, gated by human_gate: start
+        │   sections[] becomes fan-out source ──┐
+        ▼                                       ▼
+03_draft_sections → section.md   # FAN-OUT one item per section
+        │   aggregated for downstream ──┐
+        ▼                               ▼
+04_assemble → draft.md           # LOOPS until 5 exit predicates pass
+        │   (word_count_over + contains_required_ids + command +
+        │    llm rubric + per-iteration human)
+        │
+        ├──► verifier: audit_titles (every outline title present?)
+        │
+        ▼
+05_publish → post.md             # HITL approve before final output
+```
+
+## Files
+
+```
+blog-pipeline/
+├── README.md                          this file
+├── workspace.md                       Layer 1 workflow description
+├── icm.yaml                           workspace defaults (postures, agent baseline)
+├── inputs/example_brief.md            sample brief you can paste
+├── schemas/                           JSON Schemas for json artifacts
+│   ├── research.json
+│   └── outline.json
+├── scripts/link_audit.sh              command-predicate script (executable)
+├── validators/cohesion_quality.md     LLM rubric for the type:llm predicate
+├── shared/
+│   ├── grounding/house_rules.md       workspace-wide grounding
+│   └── skills/brand-voice/            workspace-shared skill + references
+├── stages/
+│   ├── 01_research/contract.md
+│   ├── 02_outline/
+│   │   ├── contract.md
+│   │   └── grounding/outline_principles.md
+│   ├── 03_draft_sections/
+│   │   ├── contract.md
+│   │   └── skills/section-writer/     stage-local skill + references
+│   ├── 04_assemble/contract.md
+│   └── 05_publish/contract.md
+└── verifiers/audit_titles/contract.md
+```
+
+## How to run it
+
+From the repo root:
+
+```sh
+make build
+ANTHROPIC_API_KEY=... bin/nexus -config examples/icm-workspaces/blog-pipeline.yaml
+```
+
+That config:
+1. Loads the six `blog_*` postures from `examples/postures/` (no manual posture authoring required).
+2. Points `nexus.workflows.icm` at this workspace.
+3. Wires the Anthropic provider for every model role used by the postures (`writer`, `editor`, `researcher`, `planner`, `judge`).
+4. Activates `nexus.control.hitl` so `human_gate` and `type: human` predicates can pause for input.
+
+When the TUI prompts, paste a paragraph like the one in `inputs/example_brief.md`. Each stage's artifacts land under `~/.nexus/sessions/<id>/<runID>/<stage_id>/`.
+
+### Scripted variant
+
+Swap `nexus.io.tui` for `nexus.io.oneshot` in the config to launch with a pre-filled brief:
+
+```yaml
+plugins:
+  active:
+    - nexus.io.oneshot      # replaces nexus.io.tui
+    # ... rest unchanged
+  nexus.io.oneshot:
+    input_file: ./examples/icm-workspaces/blog-pipeline/inputs/example_brief.md
+```
+
+You will still need to answer the HITL prompts at `02_outline`, the per-iteration writer signoff in `04_assemble`, and the `05_publish` approval — they go through `nexus.control.hitl`, not `io.input`.
+
+## Validating after edits
+
+After any change to `contract.md`, `icm.yaml`, schemas, scripts, validators, or skills, ask the running agent to call the `icm_validate` tool with `{"workspace": "<abs path>"}`. The loader aggregates every error in one pass so iteration is fast. Alternatively, write a tiny Go program that calls `workspace.LoadWorkspace` directly — that is what the plugin does at boot.
+
+## Editing tips
+
+- **Adding a stage**: drop a new `stages/NN_<slug>/` folder. The numeric prefix must be unique and sequential. The folder name regex is `^\d+_[a-z0-9_]+$` — no dashes, no uppercase.
+- **Changing word caps**: edit the `args.max_words` / `args.min_words` in the relevant `native` predicate. Update the matching language in `shared/grounding/house_rules.md` so the agent sees the new contract.
+- **Adding required headings**: add the new ID to `04_assemble`'s `contains_required_ids` predicate, and add a sentence to `04_assemble`'s body telling the editor to insert it.
+- **Switching providers**: edit only `core.models` in `blog-pipeline.yaml`. The postures and contracts reference model **roles**, not models, so a one-line provider swap is enough.
+- **Tightening the judge rubric**: edit `validators/cohesion_quality.md`. Hand-feed it a known-bad draft to confirm it catches the failure before re-running the full pipeline.

--- a/examples/icm-workspaces/blog-pipeline/icm.yaml
+++ b/examples/icm-workspaces/blog-pipeline/icm.yaml
@@ -1,0 +1,28 @@
+# Blog Pipeline — workspace defaults.
+#
+# Postures referenced here must exist in the posture registry that
+# nexus.agent.postures loads at boot. The four names below are the
+# minimum set; per-stage contracts override agent.posture / model_role
+# where they need something different.
+
+defaults:
+  turn_policy: fixed
+  human_gate: none
+  on_error: halt
+
+  # Posture name (NOT a raw model identifier) for every type:llm
+  # predicate that omits its own model: field. A small, cheap posture
+  # is the right default — pass/fail judgment doesn't need a frontier
+  # model.
+  judge_posture: blog_small_judge
+
+  # Workspace-wide agent baseline. Per-stage agent blocks override
+  # per-field; absent fields here fall through to the workspace-level
+  # default_workflow_posture in plugin config.
+  agent:
+    posture: blog_workflow_default
+    model_role: writer
+    budget:
+      timeout_seconds: 180
+      max_tokens: 12000
+      max_tool_calls: 30

--- a/examples/icm-workspaces/blog-pipeline/inputs/example_brief.md
+++ b/examples/icm-workspaces/blog-pipeline/inputs/example_brief.md
@@ -1,0 +1,7 @@
+# Example input brief
+
+Drop a file like this one into the session input slot (`00_input/brief.md`) to launch a run. Keep the brief tight — the pipeline expands it. A paragraph is plenty; two paragraphs is the upper bound.
+
+---
+
+How prompt caching changes the unit economics of agent applications. The audience is engineering leads at startups who are picking between OpenAI, Anthropic, and Gemini and trying to forecast their AI cost line. The post should explain the cost model concretely, name the two main failure modes (TTL expiry and prefix mutation), and end with a pragmatic recommendation: treat the cache as ephemeral and measure the hit rate as an observable, not a guarantee. Tone is direct and quantitative — no buzzwords, no "exciting new feature" framing.

--- a/examples/icm-workspaces/blog-pipeline/schemas/outline.json
+++ b/examples/icm-workspaces/blog-pipeline/schemas/outline.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Section outline",
+  "description": "Ordered array of section briefs that fan-out drafting will iterate over.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["title", "summary", "sections"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 90,
+      "description": "Working title for the post. Used for the H1 in final assembly."
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 40,
+      "description": "One-paragraph TL;DR of the whole post."
+    },
+    "sections": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Each section becomes one fan-out invocation in 03_draft_sections.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["slug", "title", "focus", "target_words"],
+        "properties": {
+          "slug": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$",
+            "description": "Per-section folder name during fan-out. Must be filesystem-safe."
+          },
+          "title": {
+            "type": "string",
+            "minLength": 4,
+            "maxLength": 80,
+            "description": "Verbatim H2 heading. Must appear in the final assembled draft."
+          },
+          "focus": {
+            "type": "string",
+            "minLength": 30,
+            "description": "What this section must explain. Concrete, not 'discuss X'."
+          },
+          "target_words": {
+            "type": "integer",
+            "minimum": 80,
+            "maximum": 380,
+            "description": "Soft target. Strict ceiling is enforced by word_count_under."
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/icm-workspaces/blog-pipeline/schemas/research.json
+++ b/examples/icm-workspaces/blog-pipeline/schemas/research.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Research output",
+  "description": "Structured research notes produced by 01_research from the input brief.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["topic", "audience", "key_concepts", "claims", "sources"],
+  "properties": {
+    "topic": {
+      "type": "string",
+      "minLength": 4,
+      "description": "Restatement of the topic in the researcher's own words."
+    },
+    "audience": {
+      "type": "string",
+      "minLength": 4,
+      "description": "Who the post is for. Specific roles + seniority, not 'developers'."
+    },
+    "key_concepts": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "definition"],
+        "properties": {
+          "name": { "type": "string", "minLength": 2 },
+          "definition": { "type": "string", "minLength": 20 }
+        }
+      }
+    },
+    "claims": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["statement", "support"],
+        "properties": {
+          "statement": { "type": "string", "minLength": 10 },
+          "support": { "type": "string", "minLength": 10 }
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "url"],
+        "properties": {
+          "title": { "type": "string", "minLength": 2 },
+          "url": { "type": "string", "format": "uri" }
+        }
+      }
+    }
+  }
+}

--- a/examples/icm-workspaces/blog-pipeline/scripts/link_audit.sh
+++ b/examples/icm-workspaces/blog-pipeline/scripts/link_audit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Link audit: reject obviously broken Markdown links in the assembled draft.
+#
+# Usage by the ICM plugin: invoked with the candidate artifact's path as
+# argv[1]. Exit 0 = pass; non-zero exit + stdout message = fail with the
+# stdout used as feedback for the next iteration.
+#
+# This is a deliberately cheap mechanical check. Anything semantic
+# belongs in the LLM rubric.
+
+set -u
+
+artifact="${1:-}"
+if [[ -z "${artifact}" || ! -f "${artifact}" ]]; then
+  echo "link_audit: artifact path missing or not a file: ${artifact:-<empty>}"
+  exit 2
+fi
+
+problems=0
+issues=""
+
+# Markdown links of the form [text](url). Capture url group with grep -oE.
+# We accept http(s) and relative/anchor links; everything else is suspect.
+while IFS= read -r line; do
+  url="$line"
+  # Strip the brackets and the trailing paren.
+  url="${url#*\](}"
+  url="${url%)*}"
+
+  case "${url}" in
+    http://*|https://*)
+      # ok shape; we don't fetch — that would be a side effect this
+      # predicate has no business making.
+      ;;
+    \#*|./*|/*)
+      # ok shape; relative or anchor.
+      ;;
+    "")
+      issues+=$'\n  empty url in link\n'
+      problems=$((problems+1))
+      ;;
+    TODO|FIXME|tk|TK)
+      issues+=$'\n  placeholder url ('"${url}"$') still present\n'
+      problems=$((problems+1))
+      ;;
+    *)
+      # Reject anything that is not a recognized URL shape — typically
+      # "javascript:" or a missing scheme.
+      issues+=$'\n  suspicious url shape: '"${url}"$'\n'
+      problems=$((problems+1))
+      ;;
+  esac
+done < <(grep -oE '\][^]]*\([^)]+\)' "${artifact}" || true)
+
+if (( problems > 0 )); then
+  echo "link_audit: ${problems} suspicious link(s) found:${issues}"
+  exit 1
+fi
+
+exit 0

--- a/examples/icm-workspaces/blog-pipeline/shared/grounding/house_rules.md
+++ b/examples/icm-workspaces/blog-pipeline/shared/grounding/house_rules.md
@@ -1,0 +1,31 @@
+# House rules
+
+Workspace-wide constraints. Every stage gets these. Do not override locally.
+
+## Output discipline
+
+- Stages that declare `output.format: json` must emit ONLY a JSON document — no preamble, no commentary, no Markdown fence.
+- Stages that emit Markdown must emit clean Markdown — no backtick fence around the whole document, no `> NOTE:` admonitions.
+- One artifact per stage. Never bundle multiple files into one output.
+
+## Citation discipline
+
+- Every factual claim that didn't originate in the input brief must be either grounded in `01_research/research.json` claims or marked as the writer's inference.
+- Inline phrasing only ("the research notes that..."). No footnote syntax, no `[1]` markers.
+
+## Length discipline
+
+- Per-section hard cap: 400 words (enforced by `word_count_under` in `03_draft_sections`).
+- Total floor: 800 words (enforced by `word_count_over` in `04_assemble`).
+- Reach the floor by writing more sections, not by padding existing ones.
+
+## Identifier hygiene
+
+- The H1 title is set in `04_assemble` and SHOULD NOT change in `05_publish` without explicit human direction.
+- Section H2 headings come from `02_outline.sections[].title` and MUST appear verbatim in the final post.
+
+## What stages must NOT do
+
+- No stage may invent new sections after `02_outline`. The outline is the structural contract.
+- No stage may rewrite a research `claim`. Claims are append-only after `01_research`.
+- No stage may invoke external HTTP except via tools explicitly granted in its `agent.tools` list.

--- a/examples/icm-workspaces/blog-pipeline/shared/skills/brand-voice/SKILL.md
+++ b/examples/icm-workspaces/blog-pipeline/shared/skills/brand-voice/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: brand-voice
+description: Authoritative voice, vocabulary, and grammar conventions for the publication. Consult before any final polish; the post WILL get rejected if it ships in a generic LLM tone.
+---
+
+# Brand voice
+
+We publish technical posts for senior practitioners. The voice is direct, declarative, and uses concrete examples instead of generalizations.
+
+## Always
+
+- Active voice. "The cache invalidates after 5 minutes" — not "the cache is invalidated".
+- Specific quantities. "Reduces input tokens by ~75%" — not "significantly fewer tokens".
+- One idea per sentence. Two sentences with one idea each beats one sentence with two.
+- Code, identifiers, and shell commands in backticks. CamelCase API names in backticks even mid-sentence.
+- En-dashes for ranges, em-dashes for parenthetical interruptions.
+
+## Never
+
+- "In this post we'll explore..." — and any other meta-narration.
+- "Easily", "simply", "just" before any verb. They are lies.
+- "Best practices", "leverage", "robust solution", "go-to choice".
+- "It's worth noting that..." — if it's worth noting, just note it.
+- Rhetorical questions in the body. Allowed once in the introduction.
+
+## Headings
+
+- H1 in title case.
+- H2 in title case for major sections, sentence case for "Introduction" / "Conclusion".
+- No emoji in headings.
+
+## References
+
+For more detail, the agent should call `read_skill_reference` for these reference files:
+
+- `tone_examples.md` — paired bad/good rewrites.
+- `vocabulary.md` — preferred terms and their disallowed alternatives.

--- a/examples/icm-workspaces/blog-pipeline/shared/skills/brand-voice/references/tone_examples.md
+++ b/examples/icm-workspaces/blog-pipeline/shared/skills/brand-voice/references/tone_examples.md
@@ -1,0 +1,16 @@
+# Tone examples
+
+Paired rewrites. The "after" column is the published voice.
+
+| Bad | Good |
+|---|---|
+| In this post, we'll explore how prompt caching changes economics. | Prompt caching changes agent economics in three specific ways. |
+| It's worth noting that the cache TTL is 5 minutes. | The cache TTL is 5 minutes. |
+| You can easily integrate this by simply calling the SDK. | The SDK exposes a single `cache_control` parameter; set it per message. |
+| There are many best practices for this. | Three practices recover most of the cost: A, B, C. |
+| This is a robust, go-to solution for production workloads. | This survives 50k QPS in our prod cluster. |
+| Doesn't it make sense to cache the system prompt? | The system prompt is the longest reusable chunk; cache it first. |
+
+## What changed
+
+In every "good" version: a hedge or generalization was replaced with a number, a system name, or a measured outcome. If a sentence can be sharpened by replacing "many" / "easily" / "best" with a specific value or system, sharpen it.

--- a/examples/icm-workspaces/blog-pipeline/shared/skills/brand-voice/references/vocabulary.md
+++ b/examples/icm-workspaces/blog-pipeline/shared/skills/brand-voice/references/vocabulary.md
@@ -1,0 +1,27 @@
+# Vocabulary
+
+Preferred terms (left). Disallowed alternatives (right) — substitute on sight.
+
+| Use | Do not use |
+|---|---|
+| latency | speed, fastness |
+| throughput | bandwidth (when referring to req/s) |
+| input tokens / output tokens | tokens (alone, when count matters) |
+| cache hit / cache miss | cached / not cached |
+| context window | context length, max tokens |
+| sub-agent | child agent, sub-process |
+| posture | persona, role config |
+| stage | phase, step (in ICM-related posts) |
+| artifact | output, file (when referring to ICM stage products) |
+| dispatch | invoke, call (when referring to LLM requests) |
+
+## Anthropic naming
+
+- Claude — not "Claude AI" or "claude.ai".
+- Opus 4.7, Sonnet 4.6, Haiku 4.5 — model family + decimal version. Not "Claude 4.7" or "the latest Opus".
+- Anthropic API — not "Anthropic's API" (no possessive).
+
+## Open-source projects
+
+- Nexus, ICM, MCP — capitalized as proper nouns.
+- HTTP, JSON, YAML, SQL, CSS — all caps as initialisms.

--- a/examples/icm-workspaces/blog-pipeline/stages/01_research/contract.md
+++ b/examples/icm-workspaces/blog-pipeline/stages/01_research/contract.md
@@ -1,0 +1,52 @@
+---
+id: 01_research
+display: Research the topic
+turns:
+  policy: until_valid
+  max: 3
+human_gate: none
+on_error: halt
+output:
+  format: json
+  schema: schemas/research.json
+  persist: file_ref
+  filename: research.json
+  validators:
+    - type: schema
+      name: research_well_formed
+      schema: schemas/research.json
+    - type: native
+      name: has_key_concepts
+      handler: json_path_exists
+      args:
+        path: .key_concepts
+        must_be_non_empty: true
+inputs:
+  artifacts:
+    - 00_input/brief.md
+  shared_grounding:
+    - house_rules.md
+agent:
+  posture: blog_researcher
+  model_role: researcher
+  prompt_overlay: |
+    Bias toward primary evidence. Where you make a claim, attach a
+    source. Where you cannot, mark the claim "unsourced" in the
+    support field so a later stage can flag it.
+  budget:
+    max_tokens: 8000
+---
+
+# Process
+
+Read the brief at `00_input/brief.md`. Produce a structured JSON research note that downstream stages will consume.
+
+**Steps**
+
+1. Restate the topic in your own words (`topic`). If the brief is ambiguous, pick the most useful framing.
+2. Name the audience concretely (`audience`). Roles + seniority + what they will do with this knowledge.
+3. List 3–8 `key_concepts`. Each gets a name and a 1-sentence definition. If a concept is jargon, define it from first principles, not by reference.
+4. Capture 2+ `claims` the post will make. Each claim has a `statement` (what you assert) and `support` (the evidence). Mark unsupported claims with `support: "unsourced"`.
+5. Cite sources where available. Empty list is acceptable; fabricated sources are not.
+
+The schema enforces shape; you enforce substance. Output ONLY the JSON document — no preamble, no Markdown fence.

--- a/examples/icm-workspaces/blog-pipeline/stages/02_outline/contract.md
+++ b/examples/icm-workspaces/blog-pipeline/stages/02_outline/contract.md
@@ -1,0 +1,53 @@
+---
+id: 02_outline
+display: Outline the sections
+turns:
+  policy: until_valid
+  max: 2
+human_gate: start
+on_error: halt
+output:
+  format: json
+  schema: schemas/outline.json
+  persist: file_ref
+  filename: outline.json
+  validators:
+    - type: schema
+      name: outline_well_formed
+      schema: schemas/outline.json
+inputs:
+  artifacts:
+    - 00_input/brief.md
+    - 01_research/research.json
+  grounding:
+    - outline_principles.md
+  shared_grounding:
+    - house_rules.md
+agent:
+  posture: blog_planner
+  model_role: planner
+  prompt_overlay: |
+    The number of sections you choose IS a design decision. 3 sections
+    for a tight argument, 5 for a survey, 6 for a deep technical post.
+    Default to 4 unless the brief obviously calls for something else.
+  budget:
+    max_tokens: 6000
+---
+
+# Process
+
+You have the research note and the original brief. Produce an outline that downstream fan-out drafting will iterate over — one item per section.
+
+**Steps**
+
+1. Choose a working `title`. Use the `<title>: <subtitle>` pattern when it sharpens the framing; do not use clickbait constructions.
+2. Write a one-paragraph `summary` (40+ chars). This becomes the TL;DR.
+3. Decide on 3–6 sections. Each section MUST have:
+   - `slug` — filesystem-safe (lowercase, hyphens). This is the per-item folder name during fan-out. Examples: `intro`, `the-cost-model`, `where-it-breaks`.
+   - `title` — the verbatim H2 the assembled draft will use. A later stage validates that this exact string appears in the final post.
+   - `focus` — what the section must explain. Be specific.
+   - `target_words` — soft target between 80 and 380. The drafter will be hard-capped at 400.
+
+Output ONLY the JSON document — no preamble, no Markdown fence.
+
+A human reviews this outline before drafting begins; do not assume a second chance to reshape after fan-out has started.

--- a/examples/icm-workspaces/blog-pipeline/stages/02_outline/grounding/outline_principles.md
+++ b/examples/icm-workspaces/blog-pipeline/stages/02_outline/grounding/outline_principles.md
@@ -1,0 +1,35 @@
+# Outline principles
+
+Stage-local grounding for `02_outline`. Conventions for building an outline that the fan-out drafter can use without further clarification.
+
+## Section count
+
+| Brief shape | Sections |
+|---|---|
+| Single sharp argument | 3 |
+| Argument + counter-argument + synthesis | 4 (default) |
+| Survey of N related approaches | N + 1 (intro/synthesis) |
+| Deep technical post with prereqs | 5 |
+| Multi-system comparison or retrospective | 6 (max) |
+
+If you find yourself wanting 7+ sections, the post is two posts.
+
+## Section title rules
+
+- Title case. No questions. No clickbait constructions ("The One Weird Trick...").
+- Each title describes the *answer*, not the question. "The Cost Model" beats "What Does It Cost?"
+- The first section is typically scene-setting; the last is typically synthesis. The body sections are the actual argument.
+
+## Section focus rules
+
+The `focus` field is the contract with the drafter. Good focuses are specific enough that two different writers would produce structurally similar drafts. Bad focuses leave the drafter to guess.
+
+| Bad focus | Good focus |
+|---|---|
+| Talk about caching. | Explain the 25% / 1.25x cost multipliers, give the break-even at reads = 2, and name the system-prompt-only caching pattern. |
+| Discuss when it fails. | Identify the two failure modes — silent TTL expiry and prefix mutation — and give the prod-log evidence for each. |
+| Conclude the post. | Restate the central claim that the cache is best treated as ephemeral infrastructure, not a deterministic optimization. |
+
+## Target words
+
+`target_words` is a hint, not a contract. The drafter is hard-capped at 400 by `word_count_under` in `03_draft_sections`. Aim for sections sized to fit comfortably inside that cap.

--- a/examples/icm-workspaces/blog-pipeline/stages/03_draft_sections/contract.md
+++ b/examples/icm-workspaces/blog-pipeline/stages/03_draft_sections/contract.md
@@ -1,0 +1,63 @@
+---
+id: 03_draft_sections
+display: Draft each section (fan-out)
+turns:
+  policy: until_valid
+  max: 2
+human_gate: none
+on_error: halt
+fan_out:
+  source: 02_outline/outline.json
+  jsonpath: .sections
+  item_var: section
+  item_id: .slug
+  max_parallel: 1
+  on_item_failure: continue
+output:
+  format: text
+  persist: file_ref
+  filename: section.md
+  validators:
+    - type: regex
+      name: starts_with_h2
+      pattern: '^## .+'
+      anchor: first_line
+      message: Each section must begin with the H2 heading from the outline.
+    - type: native
+      name: section_under_cap
+      handler: word_count_under
+      args:
+        max_words: 400
+inputs:
+  artifacts:
+    - 01_research/research.json
+    - 02_outline/outline.json
+  shared_grounding:
+    - house_rules.md
+  skills:
+    - section-writer
+agent:
+  posture: blog_writer
+  model_role: writer
+  prompt_overlay: |
+    You are writing ONE section in isolation. Do not introduce the
+    post, do not conclude the post, do not refer to "the previous
+    section". Other instances are drafting in parallel.
+  budget:
+    max_tokens: 6000
+    max_tool_calls: 6
+---
+
+# Process
+
+Each invocation receives one `<fan_out_item key="section">` containing `{slug, title, focus, target_words}`. Your job: produce a single self-contained section.
+
+**Rules**
+
+1. The first line MUST be `## <title>` — copy the title verbatim from the item.
+2. Stay under 400 words. The orchestrator hard-caps you; aim for `target_words` ± 20%.
+3. Stick to the `focus`. Do not drift into other sections' territory — they are being drafted in parallel by other instances.
+4. Cite a research `claim` or `key_concept` when it grounds an assertion. Use inline phrasing like "as noted in the research...", not footnote syntax.
+5. Consult the `section-writer` skill for tone and structural conventions. Use `read_skill_reference` if you need the examples.
+
+Output ONLY the section Markdown — no preamble, no commentary.

--- a/examples/icm-workspaces/blog-pipeline/stages/03_draft_sections/skills/section-writer/SKILL.md
+++ b/examples/icm-workspaces/blog-pipeline/stages/03_draft_sections/skills/section-writer/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: section-writer
+description: Conventions for drafting ONE section of a blog post in isolation, without knowing what the adjacent sections will say. Consult when drafting any fan-out section.
+---
+
+# Section writer
+
+You are drafting exactly one section. Other instances are drafting the others in parallel. Hold this constraint tightly.
+
+## Structural rules
+
+1. **First line is the H2.** Copy `section.title` verbatim. The orchestrator validates this; do not creatively reformat it.
+2. **No cross-section navigation.** Do not write "in the previous section" or "as we'll see later". You do not know what those sections will say. The assembly stage adds the bridges.
+3. **No intro to the post and no conclusion.** This section is body text. The introduction and conclusion are separate work.
+4. **Word budget is real.** The orchestrator hard-caps at 400 words. Sentences past that point disappear; write the most important content first.
+
+## Substance rules
+
+1. **The `focus` field is the contract.** Answer the question the focus implies and nothing else. If the focus is "explain the cost model of prompt caching", do NOT also cover invalidation, race conditions, or rollout strategy — those are other sections' jobs.
+2. **Use the research note.** Cite a `key_concept` definition or a `claim` when it grounds an assertion. Inline phrasing only ("the research notes that...") — no footnotes.
+3. **Concrete > abstract.** Replace any sentence describing "what could happen" with one describing "what does happen". Use specific tools, specific numbers, specific cases.
+
+## Opening pattern
+
+The first sentence after the H2 should pose the section's question in concrete terms. Examples:
+
+- "Caching saves money only when the cached prefix is reused; here is when it is and is not."
+- "The 5-minute TTL is a hard physical fact; the cost it imposes depends on traffic pattern."
+
+Do not open with "Let's discuss" or any meta-narration.
+
+## Closing pattern
+
+End on the strongest single sentence you can write. Do not summarize within the section — the assembly stage handles summarization. A blunt last sentence with momentum is preferable to a tidy one with none.
+
+## References
+
+For more detail, the agent should call `read_skill_reference` for:
+
+- `section_examples.md` — three full example sections at the target length.

--- a/examples/icm-workspaces/blog-pipeline/stages/03_draft_sections/skills/section-writer/references/section_examples.md
+++ b/examples/icm-workspaces/blog-pipeline/stages/03_draft_sections/skills/section-writer/references/section_examples.md
@@ -1,0 +1,27 @@
+# Section examples
+
+Three example sections at the target length. Use as shape reference, not content reference.
+
+---
+
+## The Cost Model
+
+Prompt caching charges 25% of the input-token rate on cache reads and 1.25x on cache writes. The break-even hits at the second read of the same prefix; everything past that compounds. For an agent with a 4000-token system prompt invoked 100 times in a 5-minute window, the cache write costs 5000 tokens-equivalent, and the reads save 396,000. That ratio holds across model sizes — the multipliers are fixed.
+
+The corollary: do not cache one-shot prompts. The 1.25x write penalty is unrecoverable when the prefix is never reused. Reserve the cache for the largest stable chunk that every request actually shares — usually the system prompt, sometimes a fixed tool list.
+
+---
+
+## Where It Breaks
+
+Cache invalidation is silent. The 5-minute TTL resets on every read, so a sustained traffic pattern keeps the cache warm indefinitely; an irregular pattern hits the boundary repeatedly. Production logs from December show a 12% cache-miss rate concentrated in the first request of each new conversation — the moments when latency matters most.
+
+The second failure mode is prefix mutation. The cache key is computed over the literal prefix bytes; a single whitespace change invalidates. Teams that template-render their system prompts must pin the renderer's behavior, or the cache hit rate collapses without warning.
+
+---
+
+## What Survives the Audit
+
+Two patterns hold up under the constraints above. First, cache the system prompt and the tool list together as one block — they change in lockstep at deploy time, so a single cache write per deploy covers every subsequent request. Second, treat the cache as ephemeral infrastructure: assume a miss, measure the hit rate as an observable, and budget the cost at the no-cache rate.
+
+The pattern that does NOT survive: caching individual user turns. The hit rate is structurally bounded by user repetition, which empirically tops out near zero.

--- a/examples/icm-workspaces/blog-pipeline/stages/04_assemble/contract.md
+++ b/examples/icm-workspaces/blog-pipeline/stages/04_assemble/contract.md
@@ -1,0 +1,83 @@
+---
+id: 04_assemble
+display: Assemble and iterate the full draft
+turns:
+  policy: until_valid
+  max: 2
+human_gate: end
+on_error: halt
+loop:
+  # Loop exits when every predicate below passes. Keep these strictly
+  # mechanical so convergence is decidable; quality checks live in
+  # output.validators below, where the agent gets feedback per turn
+  # within an iteration.
+  max_iterations: 3
+  until:
+    - type: native
+      name: above_total_floor
+      handler: word_count_over
+      args:
+        min_words: 800
+    - type: native
+      name: all_section_titles_present
+      handler: contains_required_ids
+      args:
+        ids: [introduction, conclusion]
+        case_insensitive: true
+    - type: command
+      name: link_audit
+      run: scripts/link_audit.sh
+      timeout_seconds: 20
+  on_exhausted: human_gate
+output:
+  format: text
+  persist: file_ref
+  filename: draft.md
+  validators:
+    - type: regex
+      name: starts_with_h1
+      pattern: '^# .+'
+      anchor: first_line
+      message: Draft must open with a single H1.
+    - type: llm
+      name: cohesion_quality
+      rubric: validators/cohesion_quality.md
+inputs:
+  artifacts:
+    - 02_outline/outline.json
+    - 03_draft_sections/section.md
+  shared_grounding:
+    - house_rules.md
+agent:
+  posture: blog_editor
+  model_role: editor
+  prompt_overlay: |
+    You are weaving N independently-drafted sections into one piece.
+    Add an `# H1` title and a 2-3 sentence "Introduction" before the
+    first section. Add a "Conclusion" before signing off. Smooth the
+    seams between sections — repeated definitions, jarring tonal
+    shifts, dangling references. Do not rewrite section bodies whole.
+  budget:
+    max_tokens: 16000
+    max_tool_calls: 8
+verifiers:
+  - audit_titles
+---
+
+# Process
+
+You have the outline (`02_outline/outline.json`) and the fan-out aggregate (`03_draft_sections/section.md`). The aggregate is a mechanical concatenation; your job is to make it read as one cohesive post.
+
+**Steps**
+
+1. Open with `# <outline.title>`.
+2. Write an `## Introduction` section (2-3 sentences) that sets up what follows. Use the outline `summary` as raw material; do not paste it.
+3. Insert each drafted section in outline order. Keep the H2 headings verbatim — a verifier checks every outline `title` survives the assembly.
+4. Smooth transitions. When two adjacent sections both define the same concept, keep the stronger definition and excise the duplicate.
+5. Close with `## Conclusion` (2-3 sentences). Restate the central claim from the research note.
+
+**Iteration**
+
+If any loop predicate fails, you will be re-dispatched with a `<previous_iteration>` block describing what failed. Address each named failure explicitly; do not silently rewrite unrelated parts.
+
+Output ONLY the assembled Markdown.

--- a/examples/icm-workspaces/blog-pipeline/stages/05_publish/contract.md
+++ b/examples/icm-workspaces/blog-pipeline/stages/05_publish/contract.md
@@ -1,0 +1,58 @@
+---
+id: 05_publish
+display: Final polish + human approval
+turns:
+  policy: until_human_approves
+  max: 3
+human_gate: end
+on_error: human_gate
+output:
+  format: text
+  persist: both
+  filename: post.md
+  validators:
+    - type: regex
+      name: has_h1
+      pattern: '^# .+'
+      anchor: first_line
+inputs:
+  artifacts:
+    - 04_assemble/draft.md
+  shared_grounding:
+    - house_rules.md
+  skills:
+    - brand-voice
+agent:
+  posture: blog_editor
+  model_role: editor
+  prompt_overlay: |
+    You are NOT rewriting. You are tuning. Voice + grammar + the small
+    things that mark this post as "ours". A human will approve before
+    publish — do not surprise them.
+  budget:
+    max_tokens: 16000
+    max_tool_calls: 4
+---
+
+# Process
+
+The draft from `04_assemble/draft.md` is structurally complete. Your job: tune voice to match the `brand-voice` skill, fix mechanical issues, polish without rewriting.
+
+**Allowed**
+
+- Sentence-level edits for clarity and pacing.
+- Vocabulary swaps to match brand voice (consult the skill; use `read_skill_reference` for the tone examples).
+- Punctuation, grammar, and formatting fixes.
+- Adding or tightening section transitions (one or two sentences max).
+- Removing redundancy.
+
+**Not allowed**
+
+- Re-ordering sections.
+- Adding or removing sections.
+- Changing the H1 title without an explicit human request.
+- Rewriting claims or evidence.
+
+A human reviews the result before publish. Treat their feedback in the `<previous_iteration>` block as authoritative; address each note before producing the next version.
+
+Output ONLY the final post Markdown.

--- a/examples/icm-workspaces/blog-pipeline/validators/cohesion_quality.md
+++ b/examples/icm-workspaces/blog-pipeline/validators/cohesion_quality.md
@@ -1,0 +1,34 @@
+# Cohesion quality rubric
+
+You are judging whether the assembled draft reads as one cohesive blog post or as five glued-together sections.
+
+Respond with the standard ICM judge schema: `{"verdict": "pass" | "fail", "feedback": "...", "score": 0.0..1.0}`.
+
+**Output format — strict**
+
+Emit ONLY the raw JSON document. No Markdown code fence (no triple backticks). No preamble ("Here is my verdict..."). No commentary after. The parser reads bytes 0..N as JSON; anything else is rejected as malformed.
+
+## Pass when ALL of the following hold
+
+1. **Single voice.** Tone, vocabulary, and sentence rhythm are consistent across sections. No section reads like a different author wrote it.
+2. **No internal duplication.** No concept is defined more than once. No phrase is repeated near-verbatim across sections.
+3. **No dangling references.** Phrases like "as we'll see", "as discussed above", "the previous section" only appear when the referent actually exists in the correct direction.
+4. **Smooth seams.** Adjacent sections connect via at least one transitional sentence. A blunt section break with no bridge is a fail.
+5. **Intro and conclusion frame the body.** The introduction names the central claim and previews how the body supports it. The conclusion returns to that claim with the body's evidence behind it.
+6. **No structural drift.** No section has expanded into another's territory. Each H2 still answers exactly the question its title implies.
+
+## Auto-fail conditions
+
+- Two or more sections define the same key concept independently.
+- An introduction or conclusion is missing or is a copy-paste of the outline summary.
+- A section ends with a question and the next section ignores it.
+- A claim contradicts itself across sections.
+- Markdown is malformed (broken headings, unclosed code fences, list items without parent).
+
+## Feedback discipline
+
+In the `feedback` field, name the specific issue and the specific location. Quote ~10 words of the offending text so the writer can find it. Do not summarize ("improve cohesion"); enumerate ("Section 2 redefines 'prompt caching' which Section 1 already defined as ...").
+
+## Score (optional)
+
+0.0 = unusable, 0.5 = recoverable in one more pass, 0.8 = ship-with-polish, 1.0 = ship as is.

--- a/examples/icm-workspaces/blog-pipeline/verifiers/audit_titles/contract.md
+++ b/examples/icm-workspaces/blog-pipeline/verifiers/audit_titles/contract.md
@@ -1,0 +1,52 @@
+---
+id: audit_titles
+display: Verify every outline title survived assembly
+turns:
+  policy: fixed
+  max: 1
+human_gate: none
+on_error: human_gate
+output:
+  format: text
+  persist: file_ref
+  filename: audit.md
+  validators:
+    - type: regex
+      name: explicit_verdict
+      pattern: '^(PASS|FAIL):'
+      anchor: first_line
+inputs:
+  artifacts:
+    - 02_outline/outline.json
+    - 04_assemble/draft.md
+agent:
+  posture: blog_editor
+  model_role: editor
+  prompt_overlay: |
+    You are a deterministic auditor. Be terse. No commentary.
+  budget:
+    max_tokens: 2000
+    max_tool_calls: 0
+---
+
+# Process
+
+You have the outline JSON and the assembled draft. Confirm that every section title from `02_outline/outline.json` appears verbatim as an `## H2` line in `04_assemble/draft.md`.
+
+**Output format**
+
+First line, exact shape: `PASS:` or `FAIL: <reason>`. After the first line, list any missing titles, one per line, prefixed with `- missing: `.
+
+Examples:
+
+```
+PASS:
+```
+
+```
+FAIL: 2 titles missing
+- missing: The Cost Model
+- missing: Where It Breaks
+```
+
+No other output.

--- a/examples/icm-workspaces/blog-pipeline/workspace.md
+++ b/examples/icm-workspaces/blog-pipeline/workspace.md
@@ -1,0 +1,46 @@
+# Blog Post Pipeline
+
+A five-stage ICM workspace that turns a one-line topic brief into a publication-ready Markdown blog post. Built as the reference demo for `nexus.workflows.icm`, it deliberately exercises every major feature of the plugin:
+
+| Feature | Where |
+|---|---|
+| JSON output + JSON Schema validation | `01_research`, `02_outline` |
+| `native:json_path_exists` predicate | `01_research` |
+| `native:word_count_under` predicate | `03_draft_sections` |
+| `native:word_count_over` predicate | `04_assemble` |
+| `native:contains_required_ids` predicate | `04_assemble` |
+| `schema` predicate | `01_research`, `02_outline` |
+| `regex` predicate | `04_assemble` |
+| `command` predicate (shell script, in loop) | `04_assemble` (link audit each iteration) |
+| `llm` predicate with judge posture | `04_assemble` (per-turn cohesion rubric) |
+| Stage loop (`loop.until` over mechanical predicates) | `04_assemble` |
+| Per-turn validator retry (`turns.policy: until_valid`) | `04_assemble` (cohesion rubric retries within an iteration) |
+| Fan-out over a JSON array artifact | `03_draft_sections` |
+| Stage-local skill | `stages/03_draft_sections/skills/section-writer` |
+| Workspace-shared skill | `shared/skills/brand-voice` |
+| HITL human gate | `04_assemble` and `05_publish` (`human_gate: end`) |
+| Verifier stage | `verifiers/audit_titles` (runs after `04_assemble`) |
+| Shared grounding | `shared/grounding/house_rules.md` |
+| Per-stage grounding | `stages/02_outline/grounding/outline_principles.md` |
+
+## Input
+
+The run starts with a single file dropped into the session input slot under the logical name `00_input/brief.md` — a short freeform topic brief (e.g. "How prompt caching changes the unit economics of agents"). The orchestrator binds it as the `00_input` artifact and Stage 01 reads it as its first input.
+
+## Output
+
+The final artifact is `05_publish/post.md` — a complete Markdown blog post ready to paste into a static site generator.
+
+## Cadence
+
+One-shot. Each run produces one post. There is no recurring scheduler here; the human decides when to launch.
+
+## Conventions
+
+- All postures referenced in this workspace use the **role/posture** form, never raw model identifiers. Six postures ship with this example under `examples/postures/`: `blog_workflow_default`, `blog_small_judge`, `blog_writer`, `blog_editor`, `blog_researcher`, `blog_planner`. Point `nexus.agent.postures.scan_dirs` at that directory before booting.
+- Word counts: per-section ceiling 400, total floor 800.
+- Required structural anchors: every section title from `02_outline/outline.json` must appear verbatim as an `## H2` in the final assembled draft.
+
+## Editing this workspace
+
+After any change, run the plugin's `icm_validate` tool with `{"workspace": "<abs path>"}`. The loader will accumulate every error in one pass; fix them, repeat.

--- a/examples/postures/blog_editor.yaml
+++ b/examples/postures/blog_editor.yaml
@@ -1,0 +1,39 @@
+name: blog_editor
+description: >-
+  Assembler / polisher used by 04_assemble, 05_publish, and the
+  audit_titles verifier. Weaves drafted sections together, smooths seams,
+  and tunes voice without rewriting bodies.
+
+system_prompt: |
+  You are an editor. Depending on the stage:
+
+  - 04_assemble: weave independently-drafted sections into one
+    cohesive post. Add an H1 title, an Introduction (2-3 sentences),
+    and a Conclusion (2-3 sentences). Keep all section H2 headings
+    verbatim — a verifier checks this.
+  - 05_publish: polish ONLY. Voice + grammar + the small things. Do
+    not reorder sections, do not add or remove sections, do not
+    rewrite claims.
+  - verifiers/audit_titles: terse auditor. PASS / FAIL on the first
+    line, then enumerate missing items.
+
+  The stage contract tells you which mode you are in. Read it carefully.
+
+allowed_tools: [read_file, read_skill_reference]
+
+model:
+  model_role: editor
+
+default_budget:
+  timeout: 240s
+  max_tokens: 16000
+  max_tool_calls: 8
+
+# 0 = disabled; rely on the delegate runtime's global MaxDepth (3) cap.
+# An ICM stage dispatch arrives at delegate depth=2 (the orchestrator
+# bumps ParentDepth once, then the runtime bumps it again). Setting
+# this to 1 would reject every stage invocation; setting to 2+ would
+# allow exactly one extra sub-delegate level if this posture ever
+# called another. Leaving it disabled is the safe default for leaf
+# editors that don't delegate further.
+max_recursion_depth: 0

--- a/examples/postures/blog_planner.yaml
+++ b/examples/postures/blog_planner.yaml
@@ -1,0 +1,33 @@
+name: blog_planner
+description: >-
+  Outline designer for 02_outline. Reads the brief + research note and
+  produces a structured outline (title, summary, sections[]) validated
+  against schemas/outline.json. The sections array becomes the fan-out
+  source for 03_draft_sections.
+
+system_prompt: |
+  You are an outline designer. You receive the input brief and the
+  research note. You produce an outline that the downstream fan-out
+  drafter can iterate over without further clarification.
+
+  Rules:
+  - Output ONLY the JSON document — no preamble, no Markdown fence.
+  - 3 to 6 sections. Default to 4 unless the brief clearly demands
+    something else. 7+ sections means the post is two posts.
+  - Each section needs slug (filesystem-safe, lowercase + hyphens),
+    title (verbatim H2 in the final post), focus (concrete contract
+    with the drafter), target_words (80-380).
+  - A human reviews this outline before drafting begins. Do not
+    assume a second chance to reshape after fan-out has started.
+
+allowed_tools: [read_file]
+
+model:
+  model_role: planner
+
+default_budget:
+  timeout: 120s
+  max_tokens: 6000
+  max_tool_calls: 4
+
+max_recursion_depth: 0

--- a/examples/postures/blog_researcher.yaml
+++ b/examples/postures/blog_researcher.yaml
@@ -1,0 +1,32 @@
+name: blog_researcher
+description: >-
+  Topic researcher for 01_research. Reads the input brief and produces a
+  structured JSON research note (topic, audience, key_concepts, claims,
+  sources) validated against schemas/research.json.
+
+system_prompt: |
+  You are a topic researcher. You receive a one-paragraph brief and
+  produce a structured JSON research note that downstream stages
+  consume.
+
+  Rules:
+  - Output ONLY the JSON document — no preamble, no commentary, no
+    Markdown fence.
+  - Bias toward primary evidence. Where you make a claim, attach a
+    source. Where you cannot, set support to "unsourced" so a later
+    stage can flag it.
+  - 3 to 8 key concepts, each with a 1-sentence definition. Define
+    jargon from first principles, not by reference.
+  - 2 or more claims with explicit support fields.
+
+allowed_tools: [read_file]
+
+model:
+  model_role: researcher
+
+default_budget:
+  timeout: 180s
+  max_tokens: 8000
+  max_tool_calls: 4
+
+max_recursion_depth: 0

--- a/examples/postures/blog_small_judge.yaml
+++ b/examples/postures/blog_small_judge.yaml
@@ -1,0 +1,28 @@
+name: blog_small_judge
+description: >-
+  Cheap pass/fail judge for `type: llm` validators and loop-exit conditions
+  in the blog-pipeline workspace. Pass/fail against a rubric does not need
+  a frontier model — keep this on the Haiku tier or equivalent.
+
+system_prompt: |
+  You are an ICM judge. You receive:
+  - A rubric (markdown) describing what "good" means.
+  - A candidate artifact.
+  - Optional prior-iteration context.
+
+  Return ONLY the judge schema, no extra prose:
+    {"verdict": "pass" | "fail", "feedback": "<one paragraph>", "score": 0.0..1.0}
+
+  Be terse. Be specific. Name the failing rubric criterion when you fail.
+
+allowed_tools: []
+
+model:
+  model_role: judge
+
+default_budget:
+  timeout: 60s
+  max_tokens: 1500
+  max_tool_calls: 0
+
+max_recursion_depth: 0

--- a/examples/postures/blog_workflow_default.yaml
+++ b/examples/postures/blog_workflow_default.yaml
@@ -1,0 +1,32 @@
+name: blog_workflow_default
+description: >-
+  Baseline posture for every stage in the blog-pipeline ICM workspace. Stage
+  contracts override per-field; this provides defaults for system prompt,
+  tools, and budget.
+
+system_prompt: |
+  You are a sub-agent inside the blog-pipeline ICM workflow. You see one
+  stage at a time. Each invocation arrives as an <icm_turn> XML envelope
+  carrying grounding, prior artifacts, and the current stage instructions.
+
+  Rules that apply across every stage:
+  - Output ONLY what the stage contract asks for. No commentary. No "I'll
+    now produce..." preambles.
+  - Respect the artifact format declared in <output>. If the stage emits
+    JSON, emit ONLY the JSON document — no Markdown fence, no prose.
+  - Treat the house_rules.md grounding as binding. Other layers override
+    it only when they say so explicitly.
+
+allowed_tools: [read_file]
+
+model:
+  model_role: writer
+
+default_budget:
+  timeout: 180s
+  max_tokens: 12000
+  max_tool_calls: 30
+
+# 0 = disabled. The delegate runtime's MaxDepth (3) covers the cap.
+# See blog_editor.yaml for the depth-math explanation.
+max_recursion_depth: 0

--- a/examples/postures/blog_writer.yaml
+++ b/examples/postures/blog_writer.yaml
@@ -1,0 +1,30 @@
+name: blog_writer
+description: >-
+  Section drafter used by 03_draft_sections. Writes ONE section of a blog
+  post in isolation, holding the focus + word cap given in the fan-out item.
+
+system_prompt: |
+  You are a section drafter. Each invocation produces exactly one body
+  section of a blog post. You do not introduce the post, you do not
+  conclude it, and you do not refer to adjacent sections — they are
+  being drafted by other instances in parallel.
+
+  The first line of your output is the verbatim H2 from the fan-out
+  item's `title` field. Stay under the word cap declared by the stage's
+  word_count_under validator. Aim for the section's target_words ± 20%.
+
+  Consult the section-writer skill before drafting. Use
+  read_skill_reference to pull the section_examples when you need a
+  shape reference.
+
+allowed_tools: [read_file, read_skill_reference]
+
+model:
+  model_role: writer
+
+default_budget:
+  timeout: 180s
+  max_tokens: 6000
+  max_tool_calls: 6
+
+max_recursion_depth: 0

--- a/pkg/events/version_test.go
+++ b/pkg/events/version_test.go
@@ -138,6 +138,8 @@ func versionedPayloads() []versionedPayload {
 		{"PlanRequest", func() any { return PlanRequest{SchemaVersion: PlanRequestVersion} }, PlanRequestVersion},
 		{"PlanResult", func() any { return PlanResult{SchemaVersion: PlanResultVersion} }, PlanResultVersion},
 		{"PlanProgress", func() any { return PlanProgress{SchemaVersion: PlanProgressVersion} }, PlanProgressVersion},
+		// workflow.go
+		{"WorkflowProgress", func() any { return WorkflowProgress{SchemaVersion: WorkflowProgressVersion} }, WorkflowProgressVersion},
 		// provider.go
 		{"ProviderFallback", func() any { return ProviderFallback{SchemaVersion: ProviderFallbackVersion} }, ProviderFallbackVersion},
 		{"ProviderFanoutStart", func() any { return ProviderFanoutStart{SchemaVersion: ProviderFanoutStartVersion} }, ProviderFanoutStartVersion},

--- a/pkg/events/workflow.go
+++ b/pkg/events/workflow.go
@@ -1,0 +1,85 @@
+package events
+
+// Schema-version constants for workflow.* payloads. See doc.go.
+const (
+	WorkflowProgressVersion = 1
+)
+
+// Workflow* status constants are the closed set Status field values for
+// WorkflowProgress. Workflow plugins (e.g. nexus.workflows.icm,
+// nexus.agent.planexec) emit one event per state transition.
+const (
+	WorkflowStatusStarted   = "started"
+	WorkflowStatusRunning   = "running"
+	WorkflowStatusIterating = "iterating"
+	WorkflowStatusItemDone  = "item_done"
+	WorkflowStatusCompleted = "completed"
+	WorkflowStatusFailed    = "failed"
+	WorkflowStatusHalted    = "halted"
+)
+
+// WorkflowProgress is a workflow-agnostic progress payload that any
+// multi-stage workflow plugin can emit. Subscribers — typically IO
+// plugins — render a dedicated workflow status surface (a sticky panel
+// in the TUI right rail, an indicator chip in the browser) from a
+// single canonical event class, regardless of which plugin produced
+// the event.
+//
+// ICM emits WorkflowProgress *alongside* its detailed icm.* events:
+// the icm.* stream feeds the scrollback audit trail, WorkflowProgress
+// feeds the dedicated panel. Future workflow plugins (planexec,
+// orchestrator) can emit just this event and inherit the same UI
+// treatment without a per-plugin event subscription.
+type WorkflowProgress struct {
+	SchemaVersion int `json:"_schema_version"`
+
+	// WorkflowID identifies the producer (plugin instance ID, e.g.
+	// "nexus.workflows.icm" or "nexus.workflows.icm/script").
+	WorkflowID string `json:"workflow_id"`
+	// WorkflowName is a human-readable label for the workflow as a
+	// whole (the workspace name for ICM, the plan summary for planexec).
+	WorkflowName string `json:"workflow_name,omitempty"`
+	// RunID identifies this particular run within the workflow.
+	RunID string `json:"run_id"`
+
+	// Stage is the machine ID of the current stage (e.g. "04_assemble").
+	// Empty when Status is Started before any stage dispatches, or
+	// Completed/Halted at run end.
+	Stage string `json:"stage,omitempty"`
+	// StageLabel is the human-readable display string for the stage.
+	StageLabel string `json:"stage_label,omitempty"`
+	// StageIndex is the 1-based position of the current stage.
+	StageIndex int `json:"stage_index,omitempty"`
+	// StageTotal is the total number of stages in this workflow.
+	StageTotal int `json:"stage_total,omitempty"`
+
+	// Iteration is the current loop iteration within Stage. 0 when the
+	// stage is not iterating.
+	Iteration int `json:"iteration,omitempty"`
+	// MaxIterations is the loop cap for the current stage. 0 when
+	// non-looping.
+	MaxIterations int `json:"max_iterations,omitempty"`
+
+	// Turn is the current inner turn within the current stage
+	// invocation. 0 when not tracked.
+	Turn int `json:"turn,omitempty"`
+	// MaxTurns is the inner-turn cap. 0 when non-bounded.
+	MaxTurns int `json:"max_turns,omitempty"`
+
+	// ItemsDone / ItemsTotal report fan-out progress; both 0 when the
+	// stage is not a fan-out.
+	ItemsDone  int `json:"items_done,omitempty"`
+	ItemsTotal int `json:"items_total,omitempty"`
+	// CurrentItem is the ID of the most recently completed item, when
+	// fan-out applies.
+	CurrentItem string `json:"current_item,omitempty"`
+
+	// Status is the lifecycle marker. One of WorkflowStatus* constants
+	// above. Required.
+	Status string `json:"status"`
+	// Detail is a short free-form one-liner suitable for display.
+	Detail string `json:"detail,omitempty"`
+	// Failures lists predicate names that caused the most recent
+	// non-converging iteration or turn. Empty when not applicable.
+	Failures []string `json:"failures,omitempty"`
+}

--- a/pkg/ui/messages.go
+++ b/pkg/ui/messages.go
@@ -165,6 +165,33 @@ type WorkerStatusMessage struct {
 	ParentTurnID string `json:"parent_turn_id,omitempty"`
 }
 
+// WorkflowStatusMessage powers a dedicated workflow status surface in the
+// UI — a sticky panel in the TUI right rail; a header indicator in the
+// browser. One message per workflow.progress bus event.
+//
+// IO plugins translate events.WorkflowProgress into this shape so the
+// UI rendering code is provider-agnostic: ICM, planexec, and any future
+// workflow plugin look the same in the panel.
+type WorkflowStatusMessage struct {
+	WorkflowID    string   `json:"workflow_id"`
+	WorkflowName  string   `json:"workflow_name,omitempty"`
+	RunID         string   `json:"run_id"`
+	Stage         string   `json:"stage,omitempty"`
+	StageLabel    string   `json:"stage_label,omitempty"`
+	StageIndex    int      `json:"stage_index,omitempty"`
+	StageTotal    int      `json:"stage_total,omitempty"`
+	Iteration     int      `json:"iteration,omitempty"`
+	MaxIterations int      `json:"max_iterations,omitempty"`
+	Turn          int      `json:"turn,omitempty"`
+	MaxTurns      int      `json:"max_turns,omitempty"`
+	ItemsDone     int      `json:"items_done,omitempty"`
+	ItemsTotal    int      `json:"items_total,omitempty"`
+	CurrentItem   string   `json:"current_item,omitempty"`
+	Status        string   `json:"status"`
+	Detail        string   `json:"detail,omitempty"`
+	Failures      []string `json:"failures,omitempty"`
+}
+
 // SessionInfo describes a connected UI session.
 type SessionInfo struct {
 	ID           string    `json:"id"`

--- a/pkg/ui/protocol.go
+++ b/pkg/ui/protocol.go
@@ -27,4 +27,5 @@ const (
 	TypeHITLRequest     = "hitl_request"
 	TypeCodeExecStdout  = "code_exec_stdout"
 	TypeWorkerStatus    = "worker_status"
+	TypeWorkflowStatus  = "workflow_status"
 )

--- a/plugins/io/browser/adapter.go
+++ b/plugins/io/browser/adapter.go
@@ -83,6 +83,14 @@ func (a *Adapter) SendPlanUpdate(msg ui.PlanDisplayMessage) error {
 	return a.broadcast("plan", msg)
 }
 
+// SendWorkflowStatus emits a structured workflow progress update to all
+// clients. One envelope per workflow.progress bus event; the frontend
+// renders the latest payload in a sticky workflow indicator at the top
+// of the chat surface.
+func (a *Adapter) SendWorkflowStatus(msg ui.WorkflowStatusMessage) error {
+	return a.broadcast(ui.TypeWorkflowStatus, msg)
+}
+
 // SendWorkerStatus emits a subagent lifecycle event to all clients. One
 // envelope per bus event in the subagent.started/iteration/complete
 // sequence; the frontend correlates by SpawnID.

--- a/plugins/io/browser/plugin.go
+++ b/plugins/io/browser/plugin.go
@@ -66,6 +66,21 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "session.file.updated", Priority: 50},
 		{EventType: "io.history.replay", Priority: 50},
 		{EventType: "cancel.complete", Priority: 50},
+		// ICM workflow progress — render each as a thinking-step row so
+		// long runs leave a readable audit trail in the chat scroll.
+		{EventType: "icm.run.started", Priority: 50},
+		{EventType: "icm.run.completed", Priority: 50},
+		{EventType: "icm.run.halted", Priority: 50},
+		{EventType: "icm.stage.started", Priority: 50},
+		{EventType: "icm.stage.completed", Priority: 50},
+		{EventType: "icm.stage.failed", Priority: 50},
+		{EventType: "icm.stage.iteration", Priority: 50},
+		{EventType: "icm.turn", Priority: 50},
+		{EventType: "icm.fanout.item", Priority: 50},
+		{EventType: "icm.predicate.failed", Priority: 50},
+		// Generic, workflow-agnostic progress surface. Powers the
+		// workflow status indicator at the top of the chat panel.
+		{EventType: "workflow.progress", Priority: 50},
 	}
 }
 
@@ -173,6 +188,17 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.bus.Subscribe("session.file.updated", p.handleFileChanged, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.history.replay", p.handleHistoryReplay, engine.WithSource(pluginID)),
 		p.bus.Subscribe("cancel.complete", p.handleCancelComplete, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.run.started", p.handleICMRunStarted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.run.completed", p.handleICMRunCompleted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.run.halted", p.handleICMRunHalted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.stage.started", p.handleICMStageStarted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.stage.completed", p.handleICMStageCompleted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.stage.failed", p.handleICMStageFailed, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.stage.iteration", p.handleICMStageIteration, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.turn", p.handleICMTurn, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.fanout.item", p.handleICMFanoutItem, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.predicate.failed", p.handleICMPredicateFailed, engine.WithSource(pluginID)),
+		p.bus.Subscribe("workflow.progress", p.handleWorkflowProgress, engine.WithSource(pluginID)),
 	)
 
 	p.logger.Info("browser IO plugin initialized")

--- a/plugins/io/browser/plugin_icm.go
+++ b/plugins/io/browser/plugin_icm.go
@@ -1,0 +1,129 @@
+package browser
+
+import (
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/pkg/ui"
+	"github.com/frankbardon/nexus/plugins/workflows/icm/icmtypes"
+)
+
+// sendICMThinking funnels every ICM-progress row through the existing
+// thinking-step adapter so the browser frontend reuses the same envelope
+// type ("thinking") that it already renders.
+func (p *Plugin) sendICMThinking(phase, content string) {
+	_ = p.adapter.SendThinking(ui.ThinkingMessage{
+		Content: content,
+		Phase:   phase,
+		Source:  "nexus.workflows.icm",
+	})
+}
+
+func (p *Plugin) handleICMRunStarted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMRunStarted)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatRunStarted(ev))
+}
+
+func (p *Plugin) handleICMRunCompleted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMRunCompleted)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatRunCompleted(ev))
+}
+
+func (p *Plugin) handleICMRunHalted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMRunHalted)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatRunHalted(ev))
+}
+
+func (p *Plugin) handleICMStageStarted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMStageStarted)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatStageStarted(ev))
+}
+
+func (p *Plugin) handleICMStageCompleted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMStageCompleted)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatStageCompleted(ev))
+}
+
+func (p *Plugin) handleICMStageFailed(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMStageFailed)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatStageFailed(ev))
+}
+
+func (p *Plugin) handleICMStageIteration(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMStageIteration)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatStageIteration(ev))
+}
+
+func (p *Plugin) handleICMTurn(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMTurn)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatTurn(ev))
+}
+
+func (p *Plugin) handleICMFanoutItem(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMFanoutItem)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatFanoutItem(ev))
+}
+
+func (p *Plugin) handleICMPredicateFailed(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMPredicateFailed)
+	if !ok {
+		return
+	}
+	p.sendICMThinking(icmtypes.FormatPredicateFailed(ev))
+}
+
+// handleWorkflowProgress projects the engine-generic events.WorkflowProgress
+// payload onto ui.WorkflowStatusMessage and broadcasts it. The browser
+// frontend renders the latest payload in a sticky indicator above the
+// chat panel.
+func (p *Plugin) handleWorkflowProgress(e engine.Event[any]) {
+	ev, ok := e.Payload.(events.WorkflowProgress)
+	if !ok {
+		return
+	}
+	_ = p.adapter.SendWorkflowStatus(ui.WorkflowStatusMessage{
+		WorkflowID:    ev.WorkflowID,
+		WorkflowName:  ev.WorkflowName,
+		RunID:         ev.RunID,
+		Stage:         ev.Stage,
+		StageLabel:    ev.StageLabel,
+		StageIndex:    ev.StageIndex,
+		StageTotal:    ev.StageTotal,
+		Iteration:     ev.Iteration,
+		MaxIterations: ev.MaxIterations,
+		Turn:          ev.Turn,
+		MaxTurns:      ev.MaxTurns,
+		ItemsDone:     ev.ItemsDone,
+		ItemsTotal:    ev.ItemsTotal,
+		CurrentItem:   ev.CurrentItem,
+		Status:        ev.Status,
+		Detail:        ev.Detail,
+		Failures:      ev.Failures,
+	})
+}

--- a/plugins/io/browser/static/app.js
+++ b/plugins/io/browser/static/app.js
@@ -34,6 +34,11 @@ document.addEventListener('alpine:init', () => {
     // Plan (right rail)
     currentPlan: null,
 
+    // Workflow status — latest workflow.progress payload. Rendered as a
+    // sticky panel above the chat. Updated in place per envelope (no
+    // history); set to null on session reset.
+    workflowStatus: null,
+
     // Files
     files: [],
     viewingFile: null,  // { name, path, content, loading }
@@ -164,6 +169,31 @@ document.addEventListener('alpine:init', () => {
           });
           break;
 
+        case 'workflow_status':
+          // Replace prior snapshot — workflow status is "now", not history.
+          // Detail string already arrives human-friendly; this view just
+          // composes a line.
+          this.workflowStatus = {
+            workflowId: payload.workflow_id,
+            workflowName: payload.workflow_name || '',
+            runId: payload.run_id || '',
+            stage: payload.stage || '',
+            stageLabel: payload.stage_label || '',
+            stageIndex: payload.stage_index || 0,
+            stageTotal: payload.stage_total || 0,
+            iteration: payload.iteration || 0,
+            maxIterations: payload.max_iterations || 0,
+            turn: payload.turn || 0,
+            maxTurns: payload.max_turns || 0,
+            itemsDone: payload.items_done || 0,
+            itemsTotal: payload.items_total || 0,
+            currentItem: payload.current_item || '',
+            status: payload.status || '',
+            detail: payload.detail || '',
+            failures: payload.failures || [],
+          };
+          break;
+
         case 'code_exec_stdout':
           this._handleCodeExecStdout(payload, env);
           break;
@@ -204,6 +234,7 @@ document.addEventListener('alpine:init', () => {
         case 'session_reset':
           this.messages = [];
           this.currentPlan = null;
+          this.workflowStatus = null;
           this.status = { state: 'idle', detail: '' };
           break;
 

--- a/plugins/io/browser/static/index.html
+++ b/plugins/io/browser/static/index.html
@@ -130,6 +130,60 @@
       <template x-if="$store.app.activeView === 'chat'">
         <div class="flex flex-col h-full">
 
+          <!-- Workflow status indicator — sticky panel above the chat
+               that updates in place on every workflow.progress envelope.
+               Hidden when no workflow is active. -->
+          <div x-show="$store.app.workflowStatus"
+               class="workflow-status px-4 py-2 border-b border-base-300 bg-base-200/40 text-xs flex items-center gap-3 flex-wrap">
+            <span class="font-semibold opacity-70">Workflow</span>
+            <template x-if="$store.app.workflowStatus">
+              <span class="flex items-center gap-3 flex-wrap">
+                <span class="badge badge-sm"
+                      :class="{
+                        'badge-success': $store.app.workflowStatus.status === 'completed',
+                        'badge-error':   $store.app.workflowStatus.status === 'halted' || $store.app.workflowStatus.status === 'failed',
+                        'badge-info':    $store.app.workflowStatus.status === 'started' || $store.app.workflowStatus.status === 'running',
+                        'badge-warning': $store.app.workflowStatus.status === 'iterating',
+                        'badge-ghost':   $store.app.workflowStatus.status === 'item_done'
+                      }"
+                      x-text="$store.app.workflowStatus.status"></span>
+                <span x-show="$store.app.workflowStatus.workflowName"
+                      class="opacity-70"
+                      x-text="$store.app.workflowStatus.workflowName"></span>
+                <span x-show="$store.app.workflowStatus.stage" class="flex items-center gap-1">
+                  <span class="opacity-50">stage</span>
+                  <span class="font-mono"
+                        x-text="$store.app.workflowStatus.stageLabel || $store.app.workflowStatus.stage"></span>
+                  <span x-show="$store.app.workflowStatus.stageTotal > 0"
+                        class="opacity-50"
+                        x-text="$store.app.workflowStatus.stageIndex + '/' + $store.app.workflowStatus.stageTotal"></span>
+                </span>
+                <span x-show="$store.app.workflowStatus.maxIterations > 0" class="opacity-70">
+                  iter <span class="font-mono"
+                              x-text="$store.app.workflowStatus.iteration + '/' + $store.app.workflowStatus.maxIterations"></span>
+                </span>
+                <span x-show="$store.app.workflowStatus.maxTurns > 0" class="opacity-70">
+                  turn <span class="font-mono"
+                              x-text="$store.app.workflowStatus.turn + '/' + $store.app.workflowStatus.maxTurns"></span>
+                </span>
+                <span x-show="$store.app.workflowStatus.itemsTotal > 0" class="opacity-70">
+                  items <span class="font-mono"
+                               x-text="$store.app.workflowStatus.itemsDone + '/' + $store.app.workflowStatus.itemsTotal"></span>
+                  <span x-show="$store.app.workflowStatus.currentItem" class="opacity-50"
+                        x-text="' (' + $store.app.workflowStatus.currentItem + ')'"></span>
+                </span>
+                <span x-show="$store.app.workflowStatus.detail"
+                      class="opacity-50 italic"
+                      x-text="$store.app.workflowStatus.detail"></span>
+                <span x-show="$store.app.workflowStatus.failures && $store.app.workflowStatus.failures.length > 0"
+                      class="opacity-60">
+                  last fail: <span class="font-mono"
+                                    x-text="(($store.app.workflowStatus.failures || []).join(', '))"></span>
+                </span>
+              </span>
+            </template>
+          </div>
+
           <!-- Messages -->
           <div x-ref="chatScroll" class="flex-1 overflow-y-auto chat-scroll px-4 py-4 space-y-1"
                x-effect="$nextTick(() => { if ($refs.chatScroll) $refs.chatScroll.scrollTop = $refs.chatScroll.scrollHeight })">

--- a/plugins/io/tui/adapter.go
+++ b/plugins/io/tui/adapter.go
@@ -112,6 +112,16 @@ func (a *Adapter) SendThinking(msg ui.ThinkingMessage) error {
 	return nil
 }
 
+// SendWorkflowStatus sends a structured workflow progress update to the TUI.
+// The TUI renders the message as a dedicated workflow status panel in the
+// right rail and as a one-line status indicator in the chat header.
+func (a *Adapter) SendWorkflowStatus(msg ui.WorkflowStatusMessage) error {
+	if a.program != nil {
+		a.program.Send(workflowStatusMsg{msg})
+	}
+	return nil
+}
+
 // SendCodeExecStdout streams a chunk of run_code script stdout to the TUI.
 func (a *Adapter) SendCodeExecStdout(msg ui.CodeExecStdoutMessage) error {
 	if a.program != nil {

--- a/plugins/io/tui/messages.go
+++ b/plugins/io/tui/messages.go
@@ -13,6 +13,7 @@ type codeExecStdoutMsg struct{ ui.CodeExecStdoutMessage }
 type planDisplayMsg struct{ ui.PlanDisplayMessage }
 type approvalRequestMsg struct{ ui.ApprovalRequestMessage }
 type askUserMsg struct{ ui.HITLRequestMessage }
+type workflowStatusMsg struct{ ui.WorkflowStatusMessage }
 
 // planUpdateMsg carries step status updates from the agent during execution.
 type planUpdateMsg struct {

--- a/plugins/io/tui/model.go
+++ b/plugins/io/tui/model.go
@@ -275,6 +275,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case codeExecStdoutMsg:
 		m.chat.AppendCodeExecStdout(msg.CallID, msg.TurnID, msg.Chunk, msg.Final, msg.Truncated)
 
+	case workflowStatusMsg:
+		m.rightRail.SetWorkflowStatus(msg)
+		m.chat.SetStatus(statusMsg{ui.StatusMessage{
+			State:  "workflow." + msg.Status,
+			Detail: workflowStatusLine(msg.WorkflowStatusMessage),
+		}})
+		m.agentBusy = msg.Status != "completed" && msg.Status != "halted" && msg.Status != "failed"
+		m.recalcLayout()
+
 	case planDisplayMsg:
 		m.rightRail.SetPlan(msg)
 		m.recalcLayout()

--- a/plugins/io/tui/plugin.go
+++ b/plugins/io/tui/plugin.go
@@ -52,6 +52,22 @@ func (p *Plugin) Subscriptions() []engine.EventSubscription {
 		{EventType: "session.file.updated", Priority: 50},
 		{EventType: "io.history.replay", Priority: 50},
 		{EventType: "cancel.complete", Priority: 50},
+		// ICM workflow progress — render each as a thinking-step row so
+		// long runs leave a readable audit trail in the scrollback.
+		{EventType: "icm.run.started", Priority: 50},
+		{EventType: "icm.run.completed", Priority: 50},
+		{EventType: "icm.run.halted", Priority: 50},
+		{EventType: "icm.stage.started", Priority: 50},
+		{EventType: "icm.stage.completed", Priority: 50},
+		{EventType: "icm.stage.failed", Priority: 50},
+		{EventType: "icm.stage.iteration", Priority: 50},
+		{EventType: "icm.turn", Priority: 50},
+		{EventType: "icm.fanout.item", Priority: 50},
+		{EventType: "icm.predicate.failed", Priority: 50},
+		// Generic, workflow-agnostic progress surface. Powers the
+		// right-rail workflow status panel; rendered identically
+		// regardless of which workflow plugin emits the event.
+		{EventType: "workflow.progress", Priority: 50},
 	}
 }
 
@@ -126,6 +142,17 @@ func (p *Plugin) Init(ctx engine.PluginContext) error {
 		p.bus.Subscribe("session.file.updated", p.handleFileChanged, engine.WithSource(pluginID)),
 		p.bus.Subscribe("io.history.replay", p.handleHistoryReplay, engine.WithSource(pluginID)),
 		p.bus.Subscribe("cancel.complete", p.handleCancelComplete, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.run.started", p.handleICMRunStarted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.run.completed", p.handleICMRunCompleted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.run.halted", p.handleICMRunHalted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.stage.started", p.handleICMStageStarted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.stage.completed", p.handleICMStageCompleted, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.stage.failed", p.handleICMStageFailed, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.stage.iteration", p.handleICMStageIteration, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.turn", p.handleICMTurn, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.fanout.item", p.handleICMFanoutItem, engine.WithSource(pluginID)),
+		p.bus.Subscribe("icm.predicate.failed", p.handleICMPredicateFailed, engine.WithSource(pluginID)),
+		p.bus.Subscribe("workflow.progress", p.handleWorkflowProgress, engine.WithSource(pluginID)),
 	)
 
 	p.logger.Info("terminal IO plugin initialized")

--- a/plugins/io/tui/plugin_icm.go
+++ b/plugins/io/tui/plugin_icm.go
@@ -1,0 +1,128 @@
+package tui
+
+import (
+	"github.com/frankbardon/nexus/pkg/engine"
+	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/pkg/ui"
+	"github.com/frankbardon/nexus/plugins/workflows/icm/icmtypes"
+)
+
+// sendThinking is the shared funnel for every ICM-progress row. It maps a
+// formatter output to the TUI's thinking-step surface so ICM events reuse
+// the existing scrollback rendering rather than carving a new lane.
+func (p *Plugin) sendThinking(phase, content string) {
+	_ = p.adapter.SendThinking(ui.ThinkingMessage{
+		Content: content,
+		Phase:   phase,
+		Source:  "nexus.workflows.icm",
+	})
+}
+
+func (p *Plugin) handleICMRunStarted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMRunStarted)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatRunStarted(ev))
+}
+
+func (p *Plugin) handleICMRunCompleted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMRunCompleted)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatRunCompleted(ev))
+}
+
+func (p *Plugin) handleICMRunHalted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMRunHalted)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatRunHalted(ev))
+}
+
+func (p *Plugin) handleICMStageStarted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMStageStarted)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatStageStarted(ev))
+}
+
+func (p *Plugin) handleICMStageCompleted(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMStageCompleted)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatStageCompleted(ev))
+}
+
+func (p *Plugin) handleICMStageFailed(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMStageFailed)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatStageFailed(ev))
+}
+
+func (p *Plugin) handleICMStageIteration(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMStageIteration)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatStageIteration(ev))
+}
+
+func (p *Plugin) handleICMTurn(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMTurn)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatTurn(ev))
+}
+
+func (p *Plugin) handleICMFanoutItem(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMFanoutItem)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatFanoutItem(ev))
+}
+
+func (p *Plugin) handleICMPredicateFailed(e engine.Event[any]) {
+	ev, ok := e.Payload.(icmtypes.ICMPredicateFailed)
+	if !ok {
+		return
+	}
+	p.sendThinking(icmtypes.FormatPredicateFailed(ev))
+}
+
+// handleWorkflowProgress projects the engine-generic events.WorkflowProgress
+// payload onto ui.WorkflowStatusMessage and forwards it to the TUI. The
+// fields map 1:1 — this handler is workflow-plugin-agnostic.
+func (p *Plugin) handleWorkflowProgress(e engine.Event[any]) {
+	ev, ok := e.Payload.(events.WorkflowProgress)
+	if !ok {
+		return
+	}
+	_ = p.adapter.SendWorkflowStatus(ui.WorkflowStatusMessage{
+		WorkflowID:    ev.WorkflowID,
+		WorkflowName:  ev.WorkflowName,
+		RunID:         ev.RunID,
+		Stage:         ev.Stage,
+		StageLabel:    ev.StageLabel,
+		StageIndex:    ev.StageIndex,
+		StageTotal:    ev.StageTotal,
+		Iteration:     ev.Iteration,
+		MaxIterations: ev.MaxIterations,
+		Turn:          ev.Turn,
+		MaxTurns:      ev.MaxTurns,
+		ItemsDone:     ev.ItemsDone,
+		ItemsTotal:    ev.ItemsTotal,
+		CurrentItem:   ev.CurrentItem,
+		Status:        ev.Status,
+		Detail:        ev.Detail,
+		Failures:      ev.Failures,
+	})
+}

--- a/plugins/io/tui/rightrail.go
+++ b/plugins/io/tui/rightrail.go
@@ -7,6 +7,8 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/frankbardon/nexus/pkg/ui"
 )
 
 type rightRail struct {
@@ -18,12 +20,37 @@ type rightRail struct {
 	// Thinking
 	thinkingSteps []thinkingStep
 
+	// Workflow status
+	workflow *workflowState
+
 	planViewport     viewport.Model
 	thinkingViewport viewport.Model
 
 	width, height int
 	focused       bool
 	features      map[string]bool
+}
+
+// workflowState captures the latest workflow.progress payload for the
+// dedicated workflow panel. Updated in place: each new event replaces
+// the prior snapshot rather than scrolling, so the panel always shows
+// "where are we right now".
+type workflowState struct {
+	Name          string
+	Stage         string
+	StageLabel    string
+	StageIndex    int
+	StageTotal    int
+	Iteration     int
+	MaxIterations int
+	Turn          int
+	MaxTurns      int
+	ItemsDone     int
+	ItemsTotal    int
+	CurrentItem   string
+	Status        string
+	Detail        string
+	Failures      []string
 }
 
 type planState struct {
@@ -55,7 +82,57 @@ func newRightRail(styles *Styles) rightRail {
 }
 
 func (r *rightRail) Visible() bool {
-	return r.plan != nil
+	return r.plan != nil || r.workflow != nil
+}
+
+// SetWorkflowStatus stores the latest workflow progress snapshot. The
+// panel updates in place (no scrollback) so users see the current state
+// at a glance.
+func (r *rightRail) SetWorkflowStatus(msg workflowStatusMsg) {
+	r.workflow = &workflowState{
+		Name:          msg.WorkflowName,
+		Stage:         msg.Stage,
+		StageLabel:    msg.StageLabel,
+		StageIndex:    msg.StageIndex,
+		StageTotal:    msg.StageTotal,
+		Iteration:     msg.Iteration,
+		MaxIterations: msg.MaxIterations,
+		Turn:          msg.Turn,
+		MaxTurns:      msg.MaxTurns,
+		ItemsDone:     msg.ItemsDone,
+		ItemsTotal:    msg.ItemsTotal,
+		CurrentItem:   msg.CurrentItem,
+		Status:        msg.Status,
+		Detail:        msg.Detail,
+		Failures:      msg.Failures,
+	}
+}
+
+// workflowStatusLine builds a one-line summary suitable for the chat
+// header / status bar. Used by the model when it sets the chat status
+// alongside the right-rail update.
+func workflowStatusLine(msg ui.WorkflowStatusMessage) string {
+	var parts []string
+	if msg.WorkflowName != "" {
+		parts = append(parts, msg.WorkflowName)
+	}
+	if msg.Stage != "" {
+		stage := msg.Stage
+		if msg.StageIndex > 0 && msg.StageTotal > 0 {
+			stage = fmt.Sprintf("%s (%d/%d)", stage, msg.StageIndex, msg.StageTotal)
+		}
+		parts = append(parts, stage)
+	}
+	switch {
+	case msg.Iteration > 0 && msg.MaxIterations > 0:
+		parts = append(parts, fmt.Sprintf("iter %d/%d", msg.Iteration, msg.MaxIterations))
+	case msg.ItemsTotal > 0:
+		parts = append(parts, fmt.Sprintf("items %d/%d", msg.ItemsDone, msg.ItemsTotal))
+	}
+	if msg.Detail != "" {
+		parts = append(parts, msg.Detail)
+	}
+	return strings.Join(parts, " · ")
 }
 
 func (r *rightRail) SetSize(w, h int) {
@@ -238,6 +315,18 @@ func (r *rightRail) stepStyle(status string) (string, lipgloss.Style) {
 func (r *rightRail) View() string {
 	var sections []string
 
+	// Workflow status section — sticky panel at the top showing the
+	// current workflow state at a glance. Updated in place on each
+	// workflow.progress event; no scrollback.
+	if r.workflow != nil {
+		header := r.styles.Bold.Render(" Workflow")
+		if r.workflow.Status != "" {
+			header += " " + r.styles.Dim.Render("("+r.workflow.Status+")")
+		}
+		sections = append(sections, header)
+		sections = append(sections, r.renderWorkflowContent())
+	}
+
 	// Plan section
 	if r.plan != nil {
 		header := r.styles.Bold.Render(" Plan")
@@ -257,4 +346,45 @@ func (r *rightRail) View() string {
 
 	body := lipgloss.JoinVertical(lipgloss.Left, sections...)
 	return r.styles.RightRail.Height(r.height).Render(body)
+}
+
+func (r *rightRail) renderWorkflowContent() string {
+	if r.workflow == nil {
+		return ""
+	}
+	var b strings.Builder
+	w := r.workflow
+	if w.Name != "" {
+		b.WriteString(r.styles.Dim.Render(" "+w.Name) + "\n")
+	}
+	if w.Stage != "" {
+		stage := w.Stage
+		if w.StageLabel != "" && w.StageLabel != w.Stage {
+			stage = w.StageLabel
+		}
+		if w.StageIndex > 0 && w.StageTotal > 0 {
+			stage = fmt.Sprintf("%s  %d/%d", stage, w.StageIndex, w.StageTotal)
+		}
+		b.WriteString(" " + stage + "\n")
+	}
+	if w.MaxIterations > 0 {
+		b.WriteString(r.styles.Dim.Render(fmt.Sprintf("  iter %d/%d", w.Iteration, w.MaxIterations)) + "\n")
+	}
+	if w.MaxTurns > 0 {
+		b.WriteString(r.styles.Dim.Render(fmt.Sprintf("  turn %d/%d", w.Turn, w.MaxTurns)) + "\n")
+	}
+	if w.ItemsTotal > 0 {
+		line := fmt.Sprintf("  items %d/%d", w.ItemsDone, w.ItemsTotal)
+		if w.CurrentItem != "" {
+			line += "  " + w.CurrentItem
+		}
+		b.WriteString(r.styles.Dim.Render(line) + "\n")
+	}
+	if w.Detail != "" {
+		b.WriteString(" " + wordWrap(w.Detail, r.width-3) + "\n")
+	}
+	if len(w.Failures) > 0 {
+		b.WriteString(r.styles.Dim.Render(" last fail: "+strings.Join(w.Failures, ", ")) + "\n")
+	}
+	return b.String()
 }

--- a/plugins/workflows/icm/icmtypes/format.go
+++ b/plugins/workflows/icm/icmtypes/format.go
@@ -1,0 +1,147 @@
+package icmtypes
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatStageStarted renders an ICMStageStarted event as a one-line
+// progress string suitable for the thinking-step stream. Phase ("icm.stage")
+// is returned alongside so subscribers can label the row consistently.
+func FormatStageStarted(ev ICMStageStarted) (phase, content string) {
+	return "icm.stage", fmt.Sprintf("▶ stage %d: %s (posture: %s)", ev.Order, ev.StageID, ev.PostureName)
+}
+
+// FormatStageCompleted renders an ICMStageCompleted event. Includes
+// iteration count and convergence flag when relevant.
+func FormatStageCompleted(ev ICMStageCompleted) (phase, content string) {
+	var parts []string
+	parts = append(parts, "✓ "+ev.StageID+" done")
+	if ev.IterationsRun > 0 {
+		parts = append(parts, fmt.Sprintf("%d iter", ev.IterationsRun))
+	}
+	if ev.ConvergenceFailed {
+		parts = append(parts, "convergence failed")
+	}
+	if ev.ArtifactPath != "" {
+		parts = append(parts, "→ "+ev.ArtifactPath)
+	}
+	return "icm.stage", strings.Join(parts, " · ")
+}
+
+// FormatStageFailed renders an ICMStageFailed event.
+func FormatStageFailed(ev ICMStageFailed) (phase, content string) {
+	return "icm.stage", fmt.Sprintf("✗ %s failed: %s", ev.StageID, ev.Reason)
+}
+
+// FormatStageIteration renders an ICMStageIteration event. The first
+// iteration of a stage has no exit failures yet; later iterations list
+// the failing predicate names so the reader sees what didn't converge.
+func FormatStageIteration(ev ICMStageIteration) (phase, content string) {
+	scope := ev.StageID
+	if ev.ItemID != "" {
+		scope = ev.StageID + "[" + ev.ItemID + "]"
+	}
+	base := fmt.Sprintf("↻ %s iter %d/%d", scope, ev.Iteration, ev.MaxIterations)
+	if len(ev.ExitFailures) > 0 {
+		names := failureNames(ev.ExitFailures)
+		base += " — last fail: " + strings.Join(names, ", ")
+	}
+	return "icm.iter", base
+}
+
+// FormatTurn renders an ICMTurn event. Turns are the inner retry layer
+// inside a single stage invocation; the failures here come from
+// output.validators that rejected the artifact.
+func FormatTurn(ev ICMTurn) (phase, content string) {
+	scope := ev.StageID
+	if ev.ItemID != "" {
+		scope = ev.StageID + "[" + ev.ItemID + "]"
+	}
+	if ev.Iteration > 0 {
+		scope = fmt.Sprintf("%s iter %d", scope, ev.Iteration)
+	}
+	base := fmt.Sprintf("⟳ %s turn %d/%d", scope, ev.Turn, ev.MaxTurns)
+	if len(ev.LastFailures) > 0 {
+		names := failureNames(ev.LastFailures)
+		base += " — fail: " + strings.Join(names, ", ")
+	}
+	return "icm.turn", base
+}
+
+// FormatFanoutItem renders an ICMFanoutItem event for any item lifecycle
+// boundary (active, completed, failed).
+func FormatFanoutItem(ev ICMFanoutItem) (phase, content string) {
+	marker := "•"
+	switch ev.Status {
+	case "completed":
+		marker = "✓"
+	case "failed":
+		marker = "✗"
+	case "active":
+		marker = "▸"
+	}
+	base := fmt.Sprintf("%s %s[%s] %d/%d %s", marker, ev.StageID, ev.ItemID, ev.Index, ev.Total, ev.Status)
+	if ev.Error != "" {
+		base += " — " + ev.Error
+	}
+	return "icm.fanout", base
+}
+
+// FormatPredicateFailed renders an ICMPredicateFailed event with the
+// container ("output.validators", "loop.until", or "verifier") and the
+// predicate name. The feedback string can be long — the caller may
+// truncate before sending to a constrained UI.
+func FormatPredicateFailed(ev ICMPredicateFailed) (phase, content string) {
+	scope := ev.StageID
+	if ev.ItemID != "" {
+		scope = ev.StageID + "[" + ev.ItemID + "]"
+	}
+	base := fmt.Sprintf("✗ %s %s/%s (%s)", scope, ev.Container, ev.PredicateName, ev.PredicateType)
+	if ev.Feedback != "" {
+		base += " — " + ev.Feedback
+	}
+	return "icm.predicate", base
+}
+
+// FormatRunStarted renders an ICMRunStarted event.
+func FormatRunStarted(ev ICMRunStarted) (phase, content string) {
+	return "icm.run", fmt.Sprintf("▶ workflow %q (%d stages, run=%s)", ev.WorkspaceName, ev.Stages, ev.RunID)
+}
+
+// FormatRunCompleted renders an ICMRunCompleted event.
+func FormatRunCompleted(ev ICMRunCompleted) (phase, content string) {
+	base := fmt.Sprintf("✓ workflow completed: %d stages, %ds", ev.StagesRun, ev.ElapsedSeconds)
+	if ev.AggregatePath != "" {
+		base += " → " + ev.AggregatePath
+	}
+	return "icm.run", base
+}
+
+// FormatRunHalted renders an ICMRunHalted event.
+func FormatRunHalted(ev ICMRunHalted) (phase, content string) {
+	scope := "workflow"
+	if ev.HaltedAtStage != "" {
+		scope = "stage " + ev.HaltedAtStage
+	}
+	verb := "halted"
+	if ev.Cancelled {
+		verb = "cancelled"
+	}
+	return "icm.run", fmt.Sprintf("✗ %s %s: %s (%ds)", scope, verb, ev.Reason, ev.ElapsedSeconds)
+}
+
+func failureNames(conds []ConditionResult) []string {
+	out := make([]string, 0, len(conds))
+	for _, c := range conds {
+		if c.Verdict == "pass" {
+			continue
+		}
+		name := c.Name
+		if name == "" {
+			name = c.Type
+		}
+		out = append(out, name)
+	}
+	return out
+}

--- a/plugins/workflows/icm/icmtypes/format_test.go
+++ b/plugins/workflows/icm/icmtypes/format_test.go
@@ -1,0 +1,92 @@
+package icmtypes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatStageStarted(t *testing.T) {
+	phase, content := FormatStageStarted(ICMStageStarted{
+		StageID:     "04_assemble",
+		PostureName: "blog_editor",
+		Order:       4,
+	})
+	if phase != "icm.stage" {
+		t.Errorf("phase = %q, want icm.stage", phase)
+	}
+	for _, want := range []string{"4", "04_assemble", "blog_editor"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("content %q missing %q", content, want)
+		}
+	}
+}
+
+func TestFormatStageIteration_WithFailures(t *testing.T) {
+	_, content := FormatStageIteration(ICMStageIteration{
+		StageID:       "04_assemble",
+		Iteration:     2,
+		MaxIterations: 3,
+		ExitFailures: []ConditionResult{
+			{Type: "native", Name: "above_total_floor", Verdict: "fail"},
+			{Type: "command", Name: "link_audit", Verdict: "fail"},
+			// Pass entries must be filtered.
+			{Type: "regex", Name: "starts_with_h1", Verdict: "pass"},
+		},
+	})
+	for _, want := range []string{"2/3", "above_total_floor", "link_audit"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("content %q missing %q", content, want)
+		}
+	}
+	if strings.Contains(content, "starts_with_h1") {
+		t.Errorf("pass entry leaked into failure list: %q", content)
+	}
+}
+
+func TestFormatFanoutItem_StatusMarkers(t *testing.T) {
+	cases := []struct {
+		status string
+		marker string
+	}{
+		{"active", "▸"},
+		{"completed", "✓"},
+		{"failed", "✗"},
+	}
+	for _, tc := range cases {
+		_, content := FormatFanoutItem(ICMFanoutItem{
+			StageID: "03_draft_sections",
+			ItemID:  "intro",
+			Index:   1,
+			Total:   4,
+			Status:  tc.status,
+		})
+		if !strings.HasPrefix(content, tc.marker) {
+			t.Errorf("status %q: content %q missing marker %q", tc.status, content, tc.marker)
+		}
+	}
+}
+
+func TestFormatPredicateFailed_IncludesFeedback(t *testing.T) {
+	_, content := FormatPredicateFailed(ICMPredicateFailed{
+		StageID:       "04_assemble",
+		Container:     "loop.until",
+		PredicateName: "link_audit",
+		PredicateType: "command",
+		Feedback:      "link_audit: 1 suspicious link(s) found",
+	})
+	for _, want := range []string{"loop.until", "link_audit", "command", "suspicious"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("content %q missing %q", content, want)
+		}
+	}
+}
+
+func TestFormatRunHalted_CancelledVerb(t *testing.T) {
+	_, content := FormatRunHalted(ICMRunHalted{
+		Reason:    "context cancelled",
+		Cancelled: true,
+	})
+	if !strings.Contains(content, "cancelled") {
+		t.Errorf("expected 'cancelled' verb, got %q", content)
+	}
+}

--- a/plugins/workflows/icm/icmtypes/names.go
+++ b/plugins/workflows/icm/icmtypes/names.go
@@ -1,0 +1,51 @@
+package icmtypes
+
+import "strings"
+
+// InstanceSuffix returns the portion of a plugin instance ID after the
+// last "/" separator. Multi-instance ICM plugins use the form
+// "nexus.workflows.icm/<suffix>" (e.g. "nexus.workflows.icm/script");
+// the default instance has no suffix.
+//
+// Lives in icmtypes so registration (runtime) and dispatch (predicates)
+// can both call the same helper without forming an import cycle.
+func InstanceSuffix(instanceID string) string {
+	if i := strings.LastIndexByte(instanceID, '/'); i >= 0 && i+1 < len(instanceID) {
+		return instanceID[i+1:]
+	}
+	return ""
+}
+
+// StagePostureName returns the registry name a stage (or verifier)
+// posture is registered under. Default instance: "icm.<stageID>".
+// Suffixed instance: "icm.<suffix>.<stageID>".
+//
+// Both registration in the plugin and lookup in the orchestrator must
+// pass through this helper to stay in sync.
+func StagePostureName(instanceID, stageID string) string {
+	if suffix := InstanceSuffix(instanceID); suffix != "" {
+		return "icm." + suffix + "." + stageID
+	}
+	return "icm." + stageID
+}
+
+// StageOutputSchemaName returns the engine SchemaRegistry key used for
+// a stage's `output` schema (when output.format=json and output.schema
+// is set). The synthesized "output" predicate that backs that schema
+// shares this name with the predicate variant — see PredicateSchemaName.
+func StageOutputSchemaName(instanceID, stageID string) string {
+	return StagePostureName(instanceID, stageID) + ".output"
+}
+
+// PredicateSchemaName returns the canonical schema-registry name for a
+// per-predicate JSON schema (output validator or loop `until` condition
+// using type=schema). Format: "<stage_posture>.<predicate_name>".
+//
+// Predicates author the workspace-relative file path in YAML; the icm
+// plugin reads + registers each schema under the name produced here at
+// Ready(). The predicate dispatcher MUST use this same helper to look
+// up the registered schema — the raw file path is registration-time
+// metadata, not a runtime lookup key.
+func PredicateSchemaName(instanceID, stageID, predicateName string) string {
+	return StagePostureName(instanceID, stageID) + "." + predicateName
+}

--- a/plugins/workflows/icm/judge_unwrap.go
+++ b/plugins/workflows/icm/judge_unwrap.go
@@ -1,0 +1,72 @@
+package icm
+
+import "strings"
+
+// unwrapJudgeJSON normalizes a judge LLM's verdict-JSON response. Small
+// "judge" postures (Haiku-class) frequently wrap their JSON output in a
+// Markdown code fence (```json ... ``` or bare ``` ... ```) or prefix it
+// with a short preamble, even when the rubric asks for raw JSON. Treating
+// that as a fatal parse failure would cause an otherwise-fine loop to
+// never converge, so we strip the wrapping defensively.
+//
+// Stripping order:
+//  1. Trim whitespace.
+//  2. If the body is fenced (```lang? ... ```), strip the fence.
+//  3. Otherwise, if `{` appears later in the string, drop everything
+//     before the first `{` and after the matching closing `}`. This
+//     handles "Here's my verdict: {...}" preambles.
+//  4. Otherwise return as-is and let the JSON parser produce a clean
+//     error.
+//
+// The function never returns an empty string when the input has any
+// non-whitespace content; the caller still gets a chance to report a
+// meaningful parse error.
+func unwrapJudgeJSON(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return s
+	}
+
+	// Fenced block: ```json\n{...}\n``` or ```\n{...}\n```
+	if strings.HasPrefix(s, "```") {
+		// Drop the opening fence + optional language tag, then drop the
+		// trailing fence. Keep everything in between.
+		end := strings.LastIndex(s, "```")
+		if end > 3 {
+			inner := s[3:end]
+			// Strip an optional language hint on the first line.
+			if nl := strings.IndexByte(inner, '\n'); nl >= 0 {
+				firstLine := strings.TrimSpace(inner[:nl])
+				if isLangHint(firstLine) {
+					inner = inner[nl+1:]
+				}
+			}
+			return strings.TrimSpace(inner)
+		}
+	}
+
+	// Preamble + JSON body: trim anything outside the outermost braces.
+	if i := strings.IndexByte(s, '{'); i > 0 {
+		if j := strings.LastIndexByte(s, '}'); j > i {
+			return strings.TrimSpace(s[i : j+1])
+		}
+	}
+
+	return s
+}
+
+// isLangHint reports whether s looks like a code-fence language tag
+// (e.g. "json", "JSON") rather than the first line of JSON content.
+// A language hint is a short, all-letters string. Anything containing
+// braces, colons, or quotes is JSON content.
+func isLangHint(s string) bool {
+	if s == "" || len(s) > 16 {
+		return false
+	}
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')) {
+			return false
+		}
+	}
+	return true
+}

--- a/plugins/workflows/icm/judge_unwrap_test.go
+++ b/plugins/workflows/icm/judge_unwrap_test.go
@@ -1,0 +1,60 @@
+package icm
+
+import "testing"
+
+func TestUnwrapJudgeJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "bare json passes through",
+			in:   `{"verdict":"pass","feedback":"ok"}`,
+			want: `{"verdict":"pass","feedback":"ok"}`,
+		},
+		{
+			name: "json fence with language",
+			in:   "```json\n{\"verdict\":\"fail\",\"feedback\":\"x\"}\n```",
+			want: `{"verdict":"fail","feedback":"x"}`,
+		},
+		{
+			name: "bare fence",
+			in:   "```\n{\"verdict\":\"pass\"}\n```",
+			want: `{"verdict":"pass"}`,
+		},
+		{
+			name: "preamble before json",
+			in:   "Here is my verdict:\n{\"verdict\":\"pass\",\"feedback\":\"good\"}",
+			want: `{"verdict":"pass","feedback":"good"}`,
+		},
+		{
+			name: "preamble + trailing prose",
+			in:   "Verdict:\n{\"verdict\":\"fail\",\"feedback\":\"bad\"}\nLet me know if you need more.",
+			want: `{"verdict":"fail","feedback":"bad"}`,
+		},
+		{
+			name: "whitespace-only input",
+			in:   "   \n\t",
+			want: "",
+		},
+		{
+			name: "no braces returns as-is",
+			in:   "Verdict: pass",
+			want: "Verdict: pass",
+		},
+		{
+			name: "fence with uppercase lang",
+			in:   "```JSON\n{\"verdict\":\"pass\"}\n```",
+			want: `{"verdict":"pass"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := unwrapJudgeJSON(tc.in)
+			if got != tc.want {
+				t.Errorf("unwrapJudgeJSON(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/plugins/workflows/icm/predicates/evaluator.go
+++ b/plugins/workflows/icm/predicates/evaluator.go
@@ -258,12 +258,13 @@ func (e *Evaluator) emitFailure(p *workspace.Predicate, r Result, sc StageEvalCo
 // PredicateSchemaName returns the canonical schema-registry name for a
 // predicate. The icm plugin uses this helper at Ready() to register
 // every output schema; the evaluator uses it at lookup time. Both
-// halves must agree on the format — keep changes in lockstep.
+// halves stay in lockstep by delegating to the icmtypes canonical
+// helper.
 //
-// Format: "icm.<instanceID>.<stageID>.<predName>". When predName is
-// "output" (the synthesized stage-output schema predicate) the result
-// still includes it, so output schemas and named schema predicates
-// share one namespace.
+// Format: "icm.[<instance suffix>.]<stageID>.<predName>". When predName
+// is "output" (the synthesized stage-output schema predicate) the
+// result is the same as StageOutputSchemaName so output schemas and
+// named schema predicates share one namespace.
 func PredicateSchemaName(instanceID, stageID, predName string) string {
-	return "icm." + instanceID + "." + stageID + "." + predName
+	return icmtypes.PredicateSchemaName(instanceID, stageID, predName)
 }

--- a/plugins/workflows/icm/predicates/evaluator_test.go
+++ b/plugins/workflows/icm/predicates/evaluator_test.go
@@ -141,17 +141,18 @@ func TestEvalSchema_UnknownName(t *testing.T) {
 
 func TestEvalSchema_CompileCache(t *testing.T) {
 	e := newEvaluator(t)
-	name := "icm.test.s3.v"
+	sc := StageEvalContext{InstanceID: "nexus.workflows.icm", StageID: "s3"}
+	name := PredicateSchemaName(sc.InstanceID, sc.StageID, "v")
 	e.Schemas.Register(name, map[string]any{"type": "object"}, "test")
 	p := &workspace.Predicate{Type: workspace.PredSchema, Name: "v", SchemaPath: name}
 
-	_ = e.Evaluate(context.Background(), p, []byte(`{}`), StageEvalContext{})
+	_ = e.Evaluate(context.Background(), p, []byte(`{}`), sc)
 	if _, ok := e.schemaCompileCache[name]; !ok {
 		t.Fatalf("schema not cached after first evaluation")
 	}
 	firstPtr := e.schemaCompileCache[name]
 
-	_ = e.Evaluate(context.Background(), p, []byte(`{}`), StageEvalContext{})
+	_ = e.Evaluate(context.Background(), p, []byte(`{}`), sc)
 	secondPtr := e.schemaCompileCache[name]
 	if firstPtr != secondPtr {
 		t.Errorf("expected cached schema to be reused; got distinct compile result")
@@ -635,9 +636,18 @@ func TestEvaluateAll_NilBusSkipsEmission(t *testing.T) {
 // ---------------------------------------------------------------------
 
 func TestPredicateSchemaName(t *testing.T) {
+	// Suffixed instance: only the segment after the last "/" enters the
+	// name. This keeps registration (PostureBuilder) and dispatch
+	// (evaluator) in lockstep with the canonical icmtypes helper.
 	got := PredicateSchemaName("nexus.workflows.icm/research", "02_script", "schema_0")
-	want := "icm.nexus.workflows.icm/research.02_script.schema_0"
+	want := "icm.research.02_script.schema_0"
 	if got != want {
-		t.Errorf("name mismatch: got %q want %q", got, want)
+		t.Errorf("suffixed: got %q want %q", got, want)
+	}
+	// Default instance (no slash): no suffix segment.
+	got = PredicateSchemaName("nexus.workflows.icm", "01_intake", "v")
+	want = "icm.01_intake.v"
+	if got != want {
+		t.Errorf("default: got %q want %q", got, want)
 	}
 }

--- a/plugins/workflows/icm/predicates/schema.go
+++ b/plugins/workflows/icm/predicates/schema.go
@@ -23,12 +23,12 @@ func (e *Evaluator) evalSchema(p *workspace.Predicate, artifact []byte, sc Stage
 		res.Feedback = "schema registry not configured"
 		return res
 	}
-	name := p.SchemaPath
-	if name == "" {
-		// The output-schema synthesizer names its predicate "output";
-		// look that up under the canonical PredicateSchemaName.
-		name = PredicateSchemaName(sc.InstanceID, sc.StageID, p.Name)
-	}
+	// SchemaPath in the workspace YAML is a file path consumed at
+	// registration time. The runtime lookup key is the canonical
+	// synthesized name — using SchemaPath here would miss the registry
+	// every time a contract sets `schema:` on its `type: schema`
+	// predicate.
+	name := PredicateSchemaName(sc.InstanceID, sc.StageID, p.Name)
 	schema, err := e.compileSchema(name)
 	if err != nil {
 		res.Verdict = false

--- a/plugins/workflows/icm/predicates_wiring.go
+++ b/plugins/workflows/icm/predicates_wiring.go
@@ -167,8 +167,15 @@ func (p *Plugin) dispatchJudgePredicate(ctx context.Context, pr *workspace.Predi
 		return false, fmt.Sprintf("judge status %s: %s", out.Status, out.Error), nil, nil
 	}
 
+	// LLM judges (especially small/cheap models) habitually wrap the
+	// verdict JSON in a Markdown code fence even when the rubric asks
+	// for raw JSON. Strip that defensively so a stylistic quirk does
+	// not cause an unrecoverable loop failure. Falls back to extracting
+	// the first `{...}` substring when the response still contains
+	// commentary around the JSON document.
+	raw := unwrapJudgeJSON(out.Result)
 	var parsed judgeResponse
-	if err := json.Unmarshal([]byte(out.Result), &parsed); err != nil {
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
 		return false, fmt.Sprintf("judge output malformed (not JSON): %v", err), nil, nil
 	}
 	if parsed.Verdict != "pass" && parsed.Verdict != "fail" {

--- a/plugins/workflows/icm/runtime/fanout.go
+++ b/plugins/workflows/icm/runtime/fanout.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/frankbardon/nexus/pkg/events"
 	"github.com/frankbardon/nexus/plugins/workflows/icm/icmtypes"
 	"github.com/frankbardon/nexus/plugins/workflows/icm/session"
 	"github.com/frankbardon/nexus/plugins/workflows/icm/workspace"
@@ -137,6 +138,18 @@ func (o *Orchestrator) runFanOut(ctx context.Context, stage *workspace.Stage) (s
 					Total:         len(items),
 					Status:        status,
 					Error:         errMsg,
+				})
+				detail := "item done"
+				if status == "failed" {
+					detail = "item failed"
+				}
+				o.emitWorkflowProgress(events.WorkflowProgress{
+					Stage:       stage.ID,
+					ItemsDone:   i + 1,
+					ItemsTotal:  len(items),
+					CurrentItem: itemID,
+					Status:      events.WorkflowStatusItemDone,
+					Detail:      detail,
 				})
 			}
 

--- a/plugins/workflows/icm/runtime/loop.go
+++ b/plugins/workflows/icm/runtime/loop.go
@@ -58,6 +58,14 @@ func (o *Orchestrator) runLoopInner(ctx context.Context, stage *workspace.Stage,
 				MaxIterations: loop.MaxIterations,
 				ExitFailures:  prevFails,
 			})
+			o.emitWorkflowProgress(events.WorkflowProgress{
+				Stage:         stage.ID,
+				Iteration:     iter,
+				MaxIterations: loop.MaxIterations,
+				Status:        events.WorkflowStatusIterating,
+				Failures:      failureNamesFromConds(prevFails),
+				CurrentItem:   itemID,
+			})
 		}
 
 		// Record iteration state.

--- a/plugins/workflows/icm/runtime/orchestrator.go
+++ b/plugins/workflows/icm/runtime/orchestrator.go
@@ -110,6 +110,10 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}
 
 	o.emitRunStarted()
+	o.emitWorkflowProgress(events.WorkflowProgress{
+		Status: events.WorkflowStatusStarted,
+		Detail: "workflow started",
+	})
 
 	for i := range o.Workflow.Stages {
 		stage := &o.Workflow.Stages[i]
@@ -136,6 +140,10 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			RunID:          o.RunID,
 			StagesRun:      len(o.Workflow.Stages),
 			ElapsedSeconds: elapsed,
+		})
+		o.emitWorkflowProgress(events.WorkflowProgress{
+			Status: events.WorkflowStatusCompleted,
+			Detail: "workflow completed",
 		})
 	}
 	return nil
@@ -215,6 +223,11 @@ func (o *Orchestrator) haltRun(stageID, reason string, cancelled bool, startedAt
 			Cancelled:      cancelled,
 			ElapsedSeconds: int64(time.Since(startedAt).Seconds()),
 		})
+		o.emitWorkflowProgress(events.WorkflowProgress{
+			Stage:  stageID,
+			Status: events.WorkflowStatusHalted,
+			Detail: reason,
+		})
 	}
 	return cause
 }
@@ -262,19 +275,25 @@ func (o *Orchestrator) withState(fn func(*session.RunState)) {
 	fn(o.state)
 }
 
-// stageStateRef returns a mutable pointer into o.state.Stages keyed by ID.
-// Panics on missing — the orchestrator must initialize every stage in
-// initState, so a miss is a programming error. Callers that mutate
-// through the returned pointer in a goroutine must wrap the access in
-// withState; sequential callers (top-level Run, runStage, runLoop) can
-// rely on the in-order semantics of the surrounding code.
+// stageStateRef returns a mutable pointer into o.state.Stages keyed by ID,
+// or nil when the ID is not a primary stage. Verifiers run through the same
+// runInvocation surface as stages but their state lives in o.state.Verifiers
+// rather than o.state.Stages, so a verifier ID is a legitimate miss here.
+// Callers that mutate through the returned pointer in a goroutine must wrap
+// the access in withState; sequential callers (top-level Run, runStage,
+// runLoop) can rely on the in-order semantics of the surrounding code.
+//
+// Stage-only callers (runStage, runLoop, runFanOut, runOutput) expect a
+// non-nil return — those paths never touch verifiers, so a nil here would
+// indicate a programming error and the subsequent nil-deref is the
+// intended fail-fast.
 func (o *Orchestrator) stageStateRef(stageID string) *session.StageState {
 	for i := range o.state.Stages {
 		if o.state.Stages[i].ID == stageID {
 			return &o.state.Stages[i]
 		}
 	}
-	panic(fmt.Sprintf("orchestrator: stage %q not registered in state", stageID))
+	return nil
 }
 
 // cloneState returns a deep-enough copy of the RunState for marshalling.

--- a/plugins/workflows/icm/runtime/posture.go
+++ b/plugins/workflows/icm/runtime/posture.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/frankbardon/nexus/pkg/posture"
+	"github.com/frankbardon/nexus/plugins/workflows/icm/icmtypes"
 	"github.com/frankbardon/nexus/plugins/workflows/icm/workspace"
 )
 
@@ -120,23 +121,20 @@ func (b *PostureBuilder) BuildVerifier(verifier *workspace.Stage) (posture.Agent
 // registered under. Default instance: `icm.<stageID>`. Suffixed instance
 // (`nexus.workflows.icm/<suffix>`): `icm.<suffix>.<stageID>`.
 func (b *PostureBuilder) PostureName(stageID string) string {
-	if suffix := instanceSuffix(b.InstanceID); suffix != "" {
-		return "icm." + suffix + "." + stageID
-	}
-	return "icm." + stageID
+	return icmtypes.StagePostureName(b.InstanceID, stageID)
 }
 
 // SchemaName returns the engine SchemaRegistry key used for a stage's
 // `output` schema. Default instance: `icm.<stageID>.output`. Suffixed:
 // `icm.<suffix>.<stageID>.output`.
 func (b *PostureBuilder) SchemaName(stageID string) string {
-	return b.PostureName(stageID) + ".output"
+	return icmtypes.StageOutputSchemaName(b.InstanceID, stageID)
 }
 
 // PredicateSchemaName returns the schema registry key used for a per-
 // predicate JSON schema (output validator or loop `until` condition).
 func (b *PostureBuilder) PredicateSchemaName(stageID, predicateName string) string {
-	return b.PostureName(stageID) + "." + predicateName
+	return icmtypes.PredicateSchemaName(b.InstanceID, stageID, predicateName)
 }
 
 // build is the shared implementation of Build/BuildVerifier.
@@ -259,23 +257,10 @@ func (b *PostureBuilder) renderOperatorPrompt(stage *workspace.Stage) (string, e
 // `read_skill_reference_<suffix>` so multi-instance ICM configurations
 // don't collide on a shared tool name.
 func SkillToolName(instanceID string) string {
-	if suffix := instanceSuffix(instanceID); suffix != "" {
+	if suffix := icmtypes.InstanceSuffix(instanceID); suffix != "" {
 		return "read_skill_reference_" + suffix
 	}
 	return "read_skill_reference"
-}
-
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
-
-// instanceSuffix returns the portion of an instance ID after the last
-// '/', or empty when the instance is the default (no suffix).
-func instanceSuffix(instanceID string) string {
-	if i := strings.LastIndexByte(instanceID, '/'); i >= 0 && i+1 < len(instanceID) {
-		return instanceID[i+1:]
-	}
-	return ""
 }
 
 // applyAgentOverrides layers stage AgentSpec fields onto the derived

--- a/plugins/workflows/icm/runtime/stage.go
+++ b/plugins/workflows/icm/runtime/stage.go
@@ -26,6 +26,11 @@ func (o *Orchestrator) runStage(ctx context.Context, stage *workspace.Stage, ord
 		if o.Bus != nil {
 			_ = o.Bus.Emit("icm.stage.started", makeStageStarted(o.RunID, stage.ID, o.PostureBuilder.PostureName(stage.ID), order))
 			o.emitPlanProgress(stage.ID, "active", "")
+			o.emitWorkflowProgress(events.WorkflowProgress{
+				Stage:  stage.ID,
+				Status: events.WorkflowStatusRunning,
+				Detail: "stage started",
+			})
 		}
 
 		gate := o.humanGateFor(stage)
@@ -89,9 +94,26 @@ func (o *Orchestrator) runStage(ctx context.Context, stage *workspace.Stage, ord
 			}
 			_ = o.Bus.Emit("icm.stage.completed", completed)
 			o.emitPlanProgress(stage.ID, "completed", artifactPath)
+			o.emitWorkflowProgress(events.WorkflowProgress{
+				Stage:         stage.ID,
+				Iteration:     completed.IterationsRun,
+				MaxIterations: loopMaxIterations(stage),
+				Status:        events.WorkflowStatusRunning,
+				Detail:        "stage done",
+			})
 		}
 		return nil
 	}
+}
+
+// loopMaxIterations returns the configured max for a looping stage or 0
+// otherwise. Lives next to runStage because workflow.progress payloads
+// quote it on stage-completed events to give panels the final tally.
+func loopMaxIterations(s *workspace.Stage) int {
+	if s == nil || s.Loop == nil {
+		return 0
+	}
+	return s.Loop.MaxIterations
 }
 
 // emitPlanProgress bridges ICM's stage lifecycle into the engine-generic
@@ -294,6 +316,11 @@ func (o *Orchestrator) failStage(stage *workspace.Stage, cause error) error {
 			Reason:        cause.Error(),
 		})
 		o.emitPlanProgress(stage.ID, "failed", cause.Error())
+		o.emitWorkflowProgress(events.WorkflowProgress{
+			Stage:  stage.ID,
+			Status: events.WorkflowStatusFailed,
+			Detail: cause.Error(),
+		})
 	}
 	return cause
 }

--- a/plugins/workflows/icm/runtime/workflow_progress.go
+++ b/plugins/workflows/icm/runtime/workflow_progress.go
@@ -1,0 +1,78 @@
+package runtime
+
+import (
+	"github.com/frankbardon/nexus/pkg/events"
+	"github.com/frankbardon/nexus/plugins/workflows/icm/icmtypes"
+)
+
+// emitWorkflowProgress publishes the engine-generic events.WorkflowProgress
+// payload that powers IO plugins' dedicated workflow status surface
+// (the TUI right-rail workflow panel; the browser chip indicator).
+//
+// This sits alongside the icm.* event family rather than replacing it:
+//   - icm.* gives detailed audit-trail-style rows in the scrollback.
+//   - workflow.progress gives the one-glance "where are we now" status,
+//     shaped identically across every workflow plugin (icm, planexec, ...).
+//
+// stageID may be empty for run-level transitions (Started before stages,
+// Completed after the last stage, Halted on cancel). The helper looks up
+// stage index/total + display label off the loaded Workflow so call sites
+// pass only what changed.
+func (o *Orchestrator) emitWorkflowProgress(p events.WorkflowProgress) {
+	if o.Bus == nil {
+		return
+	}
+	p.SchemaVersion = events.WorkflowProgressVersion
+	if p.WorkflowID == "" {
+		p.WorkflowID = o.InstanceID
+		if p.WorkflowID == "" {
+			p.WorkflowID = "nexus.workflows.icm"
+		}
+	}
+	if p.RunID == "" {
+		p.RunID = o.RunID
+	}
+	if p.WorkflowName == "" && o.Workflow != nil {
+		p.WorkflowName = lastPathElement(o.Workflow.Root)
+	}
+	if p.StageTotal == 0 && o.Workflow != nil {
+		p.StageTotal = len(o.Workflow.Stages)
+	}
+	if p.Stage != "" && o.Workflow != nil {
+		for i := range o.Workflow.Stages {
+			s := &o.Workflow.Stages[i]
+			if s.ID == p.Stage {
+				if p.StageIndex == 0 {
+					p.StageIndex = i + 1
+				}
+				if p.StageLabel == "" {
+					p.StageLabel = s.Display
+					if p.StageLabel == "" {
+						p.StageLabel = s.ID
+					}
+				}
+				break
+			}
+		}
+	}
+	_ = o.Bus.Emit("workflow.progress", p)
+}
+
+// failureNamesFromConds reduces a ConditionResult slice to the names of
+// the failed conditions only. Workflow status panels render the names
+// (not the full feedback text) so users see at-a-glance what didn't
+// converge without overflowing the panel.
+func failureNamesFromConds(conds []icmtypes.ConditionResult) []string {
+	out := make([]string, 0, len(conds))
+	for _, c := range conds {
+		if c.Verdict == "pass" {
+			continue
+		}
+		name := c.Name
+		if name == "" {
+			name = c.Type
+		}
+		out = append(out, name)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- **Reference ICM workspace** (`examples/icm-workspaces/blog-pipeline/`) — five-stage blog-post pipeline that exercises every major `nexus.workflows.icm` capability (JSON+schema validation, all four shipped native predicates, regex/command/llm/human predicate types, fan-out, stage loop, stage-local + workspace-shared skills, HITL gates, verifier). Ships with six `blog_*` postures under `examples/postures/` and a runnable Anthropic-backed config so the example boots end-to-end with only `ANTHROPIC_API_KEY` in env.
- **UI feedback surfaces** — both `nexus.io.tui` and `nexus.io.browser` now render ICM progress in real time, in two complementary lanes:
  - **Scrollback**: every `icm.*` event formatted via shared `icmtypes/format.go` helpers and pushed through the existing thinking-step adapter (audit trail).
  - **Dedicated panel**: new engine-generic `events.WorkflowProgress` event (`pkg/events/workflow.go`) drives a sticky workflow status surface — right-rail panel in the TUI, header chip in the browser — that updates in place with stage X/Y, iter N/M, items done/total, status badge, and last predicate failures. ICM emits the generic event alongside the existing `icm.*` family; future workflow plugins inherit the same UI for free.
- **Correctness fixes** discovered while running the example:
  - `runtime/orchestrator.go` — `stageStateRef` returns `nil` instead of panicking when the ID is a verifier (verifiers track state in `o.state.Verifiers`, not `o.state.Stages`). Fixes `panic: orchestrator: stage "audit_titles" not registered in state`.
  - `predicates_wiring.go` + new `judge_unwrap.go` — strip Markdown code fences and preamble/postamble around the outermost `{...}` before unmarshalling judge LLM responses. Fixes infinite `type: llm` predicate loops with `judge output malformed (not JSON)`.
  - `icmtypes/names.go` + `predicates/schema.go` + `runtime/posture.go` — unified canonical schema-registry name synthesis. `type: schema` predicates with an explicit `schema:` field no longer fail with `schema "schemas/X.json" is not registered`; registration (PostureBuilder) and dispatch (evaluator) now delegate to a single source of truth.

## Why split into two commits

1. `feat(examples/icm): blog-pipeline reference workspace` — additive, isolated to `examples/`. Reviewable on its own.
2. `feat(workflows/icm,io): workflow UI feedback + correctness fixes` — the engine-side work the example uncovered + the cross-cutting UI improvements that benefit every workflow.

## Test plan

- [x] `make build` — clean
- [x] `go test ./...` — all green (incl. new `icmtypes/format_test.go`, `icmtypes/names_test.go` coverage, `judge_unwrap_test.go`, and corrected `predicates/evaluator_test.go` cases that previously asserted the broken naming format)
- [x] `workspace.LoadWorkspace` against the new example workspace — loads cleanly, 5 stages + 1 verifier
- [x] End-to-end run of `bin/nexus -config examples/icm-workspaces/blog-pipeline.yaml` exercises all wired events; right-rail panel updates per stage / iteration / fan-out item
- [x] Reviewer: skim `examples/icm-workspaces/blog-pipeline/README.md` for the per-capability map of what each stage demonstrates
- [x] Reviewer: confirm `docs/src/configuration/reference.md` "Generic workflow surface" section captures the cross-plugin contract you want for future workflow plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)